### PR TITLE
Fix for 429393 - org.eclipse.birt.data.oda.pojo.impl.internal.ClassMethodFieldBuffer is not threadsafe

### DIFF
--- a/data/org.eclipse.birt.data.oda.pojo.tests/src/org/eclipse/birt/data/oda/pojo/impl/ResultSetTest.java
+++ b/data/org.eclipse.birt.data.oda.pojo.tests/src/org/eclipse/birt/data/oda/pojo/impl/ResultSetTest.java
@@ -16,10 +16,10 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
-import org.eclipse.birt.data.oda.pojo.impl.Query;
+import org.eclipse.birt.data.oda.pojo.api.Constants;
 import org.eclipse.birt.data.oda.pojo.impl.ResultSet;
-import org.eclipse.birt.data.oda.pojo.impl.internal.ClassMethodFieldBuffer;
 import org.eclipse.birt.data.oda.pojo.input.pojos.Course;
 import org.eclipse.birt.data.oda.pojo.input.pojos.CustomTeacherDataSet;
 import org.eclipse.birt.data.oda.pojo.input.pojos.Student;
@@ -39,7 +39,6 @@ import org.eclipse.datatools.connectivity.oda.IQuery;
 import org.eclipse.datatools.connectivity.oda.IResultSet;
 import org.eclipse.datatools.connectivity.oda.OdaException;
 
-
 import junit.framework.TestCase;
 
 /**
@@ -58,7 +57,6 @@ public class ResultSetTest extends TestCase
 	protected void setUp( ) throws Exception
 	{
 		super.setUp( );
-		ClassMethodFieldBuffer.createInstance( );
 	}
 
 	/*
@@ -69,7 +67,6 @@ public class ResultSetTest extends TestCase
 	@Override
 	protected void tearDown( ) throws Exception
 	{
-		ClassMethodFieldBuffer.release( );
 		super.tearDown( );
 	}
 
@@ -80,7 +77,9 @@ public class ResultSetTest extends TestCase
 		List<Teacher> ts = PojoInstancesUtil.createTeachers( );
 		Map appContext = new HashMap( );
 		appContext.put( query.getAppContextKey( ), ts );
-		IQuery q = new Query( null );
+		Connection conn = new Connection();	
+		conn.open(null);
+		IQuery q = conn.newQuery(null);
 		q.setAppContext( appContext );
 		q.prepare( PojoQueryWriter.write( query ) );
 		ResultSet rs = (ResultSet)q.executeQuery( );
@@ -95,7 +94,11 @@ public class ResultSetTest extends TestCase
 		PojoQuery query = PojoQueryCreator.createWithA1tonMap( );
 		query.setDataSetClass( TeacherDataSet.class.getName( ) );
 		List<Teacher> ts = new TeacherDataSet( ).getTeachers( );
-		IQuery q = new Query( getAbsolutePath( ) );
+		Properties prop = new Properties();
+		prop.setProperty(Constants.POJO_DATA_SET_CLASS_PATH, getAbsolutePath( ));
+		Connection conn = new Connection();
+		conn.open(prop);
+		IQuery q = conn.newQuery(null);
 		q.prepare( PojoQueryWriter.write( query ) );
 		ResultSet rs = (ResultSet)q.executeQuery( );
 
@@ -109,7 +112,11 @@ public class ResultSetTest extends TestCase
 	{
 		PojoQuery query = PojoQueryCreator.createWithParameters( );
 		query.setDataSetClass( TeacherDataSet.class.getName( ) );
-		Query q = new Query( getAbsolutePath( ) );
+		Properties prop = new Properties();
+		prop.setProperty(Constants.POJO_DATA_SET_CLASS_PATH, getAbsolutePath( ));
+		Connection conn = new Connection();
+		conn.open(prop);
+		IQuery q = conn.newQuery(null);
 		q.prepare( PojoQueryWriter.write( query ) );
 		q.setBoolean( "sex", false );
 		q.setInt( "id", 1 );
@@ -151,7 +158,11 @@ public class ResultSetTest extends TestCase
 		PojoQuery query = PojoQueryCreator.createWithA1tonMap( );
 		query.setDataSetClass( CustomTeacherDataSet.class.getName( ) );
 		List<Teacher> ts = new TeacherDataSet( ).getTeachers( );
-		Query q = new Query( getAbsolutePath( ) );
+		Properties prop = new Properties();
+		prop.setProperty(Constants.POJO_DATA_SET_CLASS_PATH, getAbsolutePath( ));
+		Connection conn = new Connection();
+		conn.open(prop);
+		IQuery q = conn.newQuery(null);
 		q.prepare( PojoQueryWriter.write( query ) );
 		ResultSet rs = (ResultSet)q.executeQuery( );
 
@@ -167,7 +178,9 @@ public class ResultSetTest extends TestCase
 		ResultSet rs = null;
 		try
 		{
-			IQuery q = new Query( null );
+			Connection conn = new Connection();	
+			conn.open(null);
+			IQuery q = conn.newQuery(null);
 			q.prepare( PojoQueryWriter.write( query ) );
 			rs = (ResultSet)q.executeQuery( );
 			rs.next( );
@@ -196,7 +209,9 @@ public class ResultSetTest extends TestCase
 		Map appContext = new HashMap( );
 		appContext.put( query.getAppContextKey( ), ts );
 		
-		IQuery q = new Query( null );
+		Connection conn = new Connection();
+		conn.open(null);
+		IQuery q = conn.newQuery(null);
 		q.setAppContext( appContext );
 		q.prepare( PojoQueryWriter.write( query ) );
 		ResultSet rs = (ResultSet)q.executeQuery( );
@@ -226,7 +241,9 @@ public class ResultSetTest extends TestCase
 		// All Teachers currently has no course, so in fact, no 2 1-to-maps are
 		// checked during runtime.
 		// ResultSet should works
-		IQuery q = new Query( null );
+		Connection conn = new Connection();
+		conn.open(null);
+		IQuery q = conn.newQuery(null);
 		q.setAppContext( appContext );
 		q.prepare( PojoQueryWriter.write( query ) );
 		ResultSet rs = (ResultSet)q.executeQuery( );
@@ -238,7 +255,7 @@ public class ResultSetTest extends TestCase
 		ts.get( 1 ).addCourse( new Course( 1, "c1" ) );
 		try
 		{
-			q = new Query( null );
+			q = conn.newQuery(null);
 			q.setAppContext( appContext );
 			q.prepare( PojoQueryWriter.write( query ) );
 			rs = (ResultSet)q.executeQuery( );
@@ -400,7 +417,9 @@ public class ResultSetTest extends TestCase
 		Map appContext = new HashMap( );
 		appContext.put( query.getAppContextKey( ), ts );
 
-		IQuery q = new Query( null );
+		Connection conn = new Connection();	
+		conn.open(null);
+		IQuery q = conn.newQuery(null);
 		q.setAppContext( appContext );
 		q.prepare( PojoQueryWriter.write( query ) );
 		ResultSet rs = (ResultSet)q.executeQuery( );

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/Connection.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/Connection.java
@@ -29,7 +29,9 @@ public class Connection implements IConnection
 {
     private boolean isOpen = false;
     
-    private String pojoDataSetClassPath;
+    private String pojoDataSetClassPath = null;
+    
+    private ClassMethodFieldBuffer classMethodFieldBuffer = null;
     
 	/*
 	 * @see org.eclipse.datatools.connectivity.oda.IConnection#open(java.util.Properties)
@@ -44,7 +46,7 @@ public class Connection implements IConnection
 		pojoDataSetClassPath = 
 			connProperties == null ? null : connProperties.getProperty( Constants.POJO_DATA_SET_CLASS_PATH );
 	    isOpen = true;        
-	    ClassMethodFieldBuffer.createInstance( );
+	    classMethodFieldBuffer = new ClassMethodFieldBuffer();
  	}
 
 	/*
@@ -62,7 +64,8 @@ public class Connection implements IConnection
 	{
         // TODO replace with data source specific implementation
 	    isOpen = false;
-	    ClassMethodFieldBuffer.release( );
+	    classMethodFieldBuffer.release();
+	    classMethodFieldBuffer = null;
 	}
 
 	/*
@@ -90,7 +93,9 @@ public class Connection implements IConnection
 	{
         // this driver supports only one type of data set,
         // ignores the specified dataSetType
-		return new Query( pojoDataSetClassPath );
+		Query query = new Query( pojoDataSetClassPath );
+		query.setConnection(this);
+		return query;
 	}
 
 	/*
@@ -124,6 +129,11 @@ public class Connection implements IConnection
     {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException();
+    }
+    
+    public ClassMethodFieldBuffer getClassMethodFieldBuffer( )
+    {
+    	return classMethodFieldBuffer;
     }
     
 }

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/Query.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/Query.java
@@ -31,6 +31,7 @@ import org.eclipse.birt.data.oda.pojo.api.PojoDataSetFromArray;
 import org.eclipse.birt.data.oda.pojo.api.PojoDataSetFromCollection;
 import org.eclipse.birt.data.oda.pojo.api.PojoDataSetFromIterator;
 import org.eclipse.birt.data.oda.pojo.i18n.Messages;
+import org.eclipse.birt.data.oda.pojo.impl.internal.ClassMethodFieldBuffer;
 import org.eclipse.birt.data.oda.pojo.impl.internal.PojoDataSetFromCustomClass;
 import org.eclipse.birt.data.oda.pojo.querymodel.PojoQuery;
 import org.eclipse.birt.data.oda.pojo.util.PojoQueryParser;
@@ -57,6 +58,8 @@ public class Query implements IQuery
 	
 	private PojoQuery pojoQuery;
 	
+	private Connection connection;
+	
 	private Map<String, Object> passedInParams = new HashMap<String, Object>( );
 	
 	@SuppressWarnings("unchecked")
@@ -65,6 +68,7 @@ public class Query implements IQuery
 	public Query( String pojoDataSetClassPath )
 	{
 		this.pojoDataSetClassPath = pojoDataSetClassPath;
+		this.connection = null;
 	}
 	
 	/*
@@ -78,6 +82,7 @@ public class Query implements IQuery
 			throw new OdaException( Messages.getString( "Query.NoQueryText" ) ); //$NON-NLS-1$
 		}
 		pojoQuery = PojoQueryParser.parse( queryText );
+		pojoQuery.setConnection(connection);
 	}
 	
 	/*
@@ -513,6 +518,11 @@ public class Query implements IQuery
     public String getEffectiveQueryText()
     {
         throw new UnsupportedOperationException( );
+    }
+    
+    public void setConnection( Connection connection )
+    {
+    	this.connection = connection;
     }
     
 	/**

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/internal/ClassMethodFieldBuffer.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/internal/ClassMethodFieldBuffer.java
@@ -22,47 +22,31 @@ import org.eclipse.datatools.connectivity.oda.OdaException;
  * The buffer is created when Connection is opened and released when Connection is closed.
  */
 public class ClassMethodFieldBuffer 
-{
-	private static ClassMethodFieldBuffer instance;
+{	
+	@SuppressWarnings("unchecked")
+	private Map<Class, Map<MethodIdentifier, Method>> classMethods;
 	
 	@SuppressWarnings("unchecked")
-	private Map<Class, Map<MethodIdentifier, Method>> classMethods = new HashMap<Class, Map<MethodIdentifier, Method>>( );
+	private Map<Class, Map<String, Field>> classFields;
 	
-	@SuppressWarnings("unchecked")
-	private Map<Class, Map<String, Field>> classFields = new HashMap<Class, Map<String, Field>>( );
-	
-	private ClassMethodFieldBuffer( )
+	public ClassMethodFieldBuffer( )
 	{
-		
+		classMethods = new HashMap<Class, Map<MethodIdentifier, Method>>( );
+		classFields = new HashMap<Class, Map<String, Field>>( );
 	}
 	
-	public static void createInstance( )
+	public void release( )
 	{
-		instance = new ClassMethodFieldBuffer( );
-	}
-	
-	public static ClassMethodFieldBuffer getInstance( )
-	{
-		return instance;
-	}
-	
-	public static void release( )
-	{
-		if ( instance == null )
-		{
-			return; //already released
-		}
-		for ( Map<MethodIdentifier, Method> methods : instance.classMethods.values( ))
+		for ( Map<MethodIdentifier, Method> methods : classMethods.values( ))
 		{
 			methods.clear( );
 		}
-		instance.classMethods.clear( );
-		for ( Map<String, Field> fields : instance.classFields.values( ))
+		classMethods.clear( );
+		for ( Map<String, Field> fields : classFields.values( ))
 		{
 			fields.clear( );
 		}
-		instance.classFields.clear( );
-		instance = null;
+		classFields.clear( );
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/internal/ResultSetFromPojoInstance.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/impl/internal/ResultSetFromPojoInstance.java
@@ -126,13 +126,13 @@ public class ResultSetFromPojoInstance
 	private void fetchColumnReferenceNodeValue( ColumnReferenceNode crn, Object from ) throws OdaException
 	{
 		IMappingSource ms = crn.getReference( );
-		referenceValues.put( crn, ms.fetchValue( from, pojoClassLoader ) );
+		referenceValues.put( crn, ms.fetchValue( from, pojoClassLoader, query.getConnection().getClassMethodFieldBuffer() ) );
 	}
 	
 	private Object fetchRelayReferenceNodeValue( RelayReferenceNode rrn, Object from ) throws OdaException
 	{
 		IMappingSource ms = rrn.getReference( );
-		Object value = ms.fetchValue( from, pojoClassLoader );
+		Object value = ms.fetchValue( from, pojoClassLoader, query.getConnection().getClassMethodFieldBuffer() );
 		if ( Nextable.isNextable( value ))
 		{
 			Nextable n = Nextable.createNextable( value );

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/FieldSource.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/FieldSource.java
@@ -45,15 +45,14 @@ public class FieldSource implements IMappingSource
 	{
 		return name;
 	}
-	
-
-	public Object fetchValue( Object from, ClassLoader pojoClassLoader ) throws OdaException
+		
+	public Object fetchValue( Object from, ClassLoader pojoClassLoader, ClassMethodFieldBuffer cmfbInstance ) throws OdaException
 	{
-		if ( from == null )
+		if ( from == null || cmfbInstance == null )
 		{
 			return null;
 		}
-		Field f = ClassMethodFieldBuffer.getInstance( ).getField( from.getClass( ), getName( ) );
+		Field f = cmfbInstance.getField( from.getClass( ), getName( ) );
 		try
 		{
 			return f.get( from );

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/IMappingSource.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/IMappingSource.java
@@ -12,6 +12,7 @@ package org.eclipse.birt.data.oda.pojo.querymodel;
 
 import java.util.Map;
 
+import org.eclipse.birt.data.oda.pojo.impl.internal.ClassMethodFieldBuffer;
 import org.eclipse.datatools.connectivity.oda.OdaException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -32,7 +33,7 @@ public interface IMappingSource
 	 * @return the mapped value from the <code>from</code> object
 	 * @throws OdaException
 	 */
-	Object fetchValue( Object from, ClassLoader pojoClassLoader ) throws OdaException;
+	Object fetchValue( Object from, ClassLoader pojoClassLoader, ClassMethodFieldBuffer cmfbInstance ) throws OdaException;
 	
 	Element createElement( Document doc );
 	

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/MethodSource.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/MethodSource.java
@@ -70,10 +70,9 @@ public class MethodSource implements IMappingSource
 		}
 	}
 	
-
-	public Object fetchValue( Object from, ClassLoader pojoClassLoader ) throws OdaException
+	public Object fetchValue( Object from, ClassLoader pojoClassLoader, ClassMethodFieldBuffer cmfbInstance ) throws OdaException
 	{
-		if ( from == null )
+		if ( from == null || cmfbInstance == null )
 		{
 			return null;
 		}
@@ -81,7 +80,7 @@ public class MethodSource implements IMappingSource
 		{
 			mi = MethodIdentifier.newInstance( this, pojoClassLoader );
 		}
-		Method m = ClassMethodFieldBuffer.getInstance( ).getMethod( from.getClass( ), mi );
+		Method m = cmfbInstance.getMethod( from.getClass( ), mi );
 		try
 		{
 			return m.getReturnType( ).equals( Void.TYPE ) ? 
@@ -163,8 +162,5 @@ public class MethodSource implements IMappingSource
 			return false;
 		return true;
 	}
-	
-
-
 	
 }

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/PojoQuery.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/querymodel/PojoQuery.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.birt.data.oda.pojo.impl.Connection;
 import org.eclipse.datatools.connectivity.oda.OdaException;
 
 /**
@@ -33,11 +34,14 @@ public class PojoQuery
 	
 	private QueryParameters qps;
 	
+	private Connection connection;
+	
 	public PojoQuery( String version, String dataSetClass, String appContextKey )
 	{
 		this.version = version;
 		this.dataSetClass = dataSetClass;
 		this.appContextKey = appContextKey;
+		this.connection = null;
 	}
 	
 	public String getVersion( )
@@ -132,6 +136,16 @@ public class PojoQuery
 		{
 			prepareParameterValues( rn, inputValues, pojoClassLoader );
 		}
+	}
+	
+	public void setConnection( Connection connection )
+	{
+		this.connection = connection;
+	}
+	
+	public Connection getConnection( )
+	{
+		return connection;
 	}
 	
 	private static void prepareParameterValues( ReferenceNode rn,


### PR DESCRIPTION
Issue happens because of race condition on shared
ClassMethodFieldBuffer. 

Rework on ClassMethodFieldBuffer.
In this fix, each connection will has its own instance of
ClassMethodFieldBuffer.

Signed-off-by: xinzhao-acutate xzhao@actuate.com
