### PR TITLE
Fix for Bug 416562 - BIRT does not recognize Oracle TIMESTAMP WITH LOCAL

### DIFF
--- a/data/org.eclipse.birt.report.data.oda.jdbc/plugin.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/plugin.xml
@@ -142,6 +142,11 @@
                nativeDataType="TIMESTAMPTZ"
                nativeDataTypeCode="-101"
                odaScalarDataType="Timestamp"/>
+         <!--For Oracle TIMESTAMPLTZ type -->
+         <dataTypeMapping
+               nativeDataType="TIMESTAMPLTZ"
+               nativeDataTypeCode="-102"
+               odaScalarDataType="Timestamp"/>
          <dataTypeMapping
                nativeDataType="BOOLEAN"
                nativeDataTypeCode="16"


### PR DESCRIPTION
TIME ZONE as date values.

Added a DataTypeMapping item in ODA JDBC Driver:
nativeDataTypeCode="-102", odaScalarDataType="Timestamp" to fix this
issue.

Signed-off-by: xinzhao-acutate xzhao@actuate.com
