### PR TITLE
Bugzilla 448776 : WEIGHTEDAVE Expression is not set correctly

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/dialogs/BindingDialogHelper.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/dialogs/BindingDialogHelper.java
@@ -143,7 +143,7 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 	private Text txtDisplayName, txtDisplayNameID;
 	private ComputedColumn newBinding;
 	private CLabel messageLine;
-	private Combo cmbName, cmbDataField;
+	private Combo cmbName;
 	private Label lbName, lbDisplayNameID;
 
 	private boolean isCreate;
@@ -914,7 +914,7 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 			layout.horizontalSpacing = ( (GridLayout) parentLayout ).horizontalSpacing;
 		paramsComposite.setLayout( layout );
 
-		createFilterCondition(composite, gd);
+		createFilterCondition( composite, gd );
 
 		final Label lblAggOn = new Label( composite, SWT.NONE );
 		lblAggOn.setText( AGGREGATE_ON );
@@ -1024,8 +1024,8 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 			btnGroup.setEnabled( false );
 		}
 	}
-	
-	private void createFilterCondition( Composite composite,GridData gd)
+
+	private void createFilterCondition( Composite composite, GridData gd )
 	{
 		new Label( composite, SWT.NONE ).setText( FILTER_CONDITION );
 		txtFilter = new Text( composite, SWT.BORDER | SWT.MULTI );
@@ -1035,9 +1035,9 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 				* 2;
 		gd.horizontalSpan = 2;
 		txtFilter.setLayoutData( gd );
-		
+
 		txtFilter.addModifyListener( new ModifyListener( ) {
-			
+
 			public void modifyText( ModifyEvent arg0 )
 			{
 				modifyDialogContent( );
@@ -1122,7 +1122,7 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 		{
 			setErrorMessage( Messages.getFormattedString( "BindingDialogHelper.error.empty", //$NON-NLS-1$
 					new Object[]{
-					NAME_LABEL
+						NAME_LABEL
 					} ) );
 			dialog.setCanFinish( false );
 			return;
@@ -1200,8 +1200,11 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 								dialog.setCanFinish( false );
 								setErrorMessage( Messages.getFormattedString( "BindingDialogHelper.error.empty", //$NON-NLS-1$
 										new String[]{
-											param.getDisplayName( ).replaceAll("\\(&[a-zA-Z0-9]\\)", "").replaceAll("&", "") 
-										} ));
+											param.getDisplayName( )
+													.replaceAll( "\\(&[a-zA-Z0-9]\\)",
+															"" )
+													.replaceAll( "&", "" )
+										} ) );
 								return;
 							}
 						}
@@ -1289,7 +1292,8 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 
 					if ( param.isDataField( ) )
 					{
-						cmbDataField = new Combo( paramsComposite, SWT.BORDER );
+						final Combo cmbDataField = new Combo( paramsComposite,
+								SWT.BORDER );
 						cmbDataField.setLayoutData( new GridData( GridData.FILL_HORIZONTAL
 								| GridData.GRAB_HORIZONTAL ) );
 						cmbDataField.setVisibleItemCount( 30 );
@@ -1315,7 +1319,7 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 
 							public void widgetSelected( SelectionEvent e )
 							{
-								String expr = getColumnBindingExpressionByName( cmbDataField.getText( ) );
+								String expr = getColumnBindingExpressionByName( cmbDataField );
 								if ( expr != null )
 								{
 									cmbDataField.setText( expr );
@@ -1406,10 +1410,13 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 
 		if ( expressionProvider == null )
 		{
-			IExtendedDataModelUIAdapter adapter = ExtendedDataModelUIAdapterHelper.getInstance( ).getAdapter( );
-			if(adapter != null && adapter.getBoundExtendedData( this.bindingHolder ) != null)
+			IExtendedDataModelUIAdapter adapter = ExtendedDataModelUIAdapterHelper.getInstance( )
+					.getAdapter( );
+			if ( adapter != null
+					&& adapter.getBoundExtendedData( this.bindingHolder ) != null )
 			{
-				expressionProvider = adapter.getBindingExpressionProvider( this.bindingHolder, this.binding );
+				expressionProvider = adapter.getBindingExpressionProvider( this.bindingHolder,
+						this.binding );
 			}
 			else
 			{
@@ -1429,54 +1436,15 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 		}
 	}
 
-	private String getColumnBindingExpressionByName( String name )
+	private String getColumnBindingExpressionByName( Combo combo )
 	{
 		List elementsList = DEUtil.getVisiableColumnBindingsList( this.bindingHolder );
 		for ( Iterator iterator = elementsList.iterator( ); iterator.hasNext( ); )
 		{
 			ComputedColumnHandle binding = (ComputedColumnHandle) iterator.next( );
-			if ( binding.getName( ).equals( name ) )
-				return ExpressionButtonUtil.getCurrentExpressionConverter( cmbDataField )
-						.getBindingExpression( name );
-		}
-		return null;
-	}
-
-	private String getArgumentByDisplayName( String function, String argument )
-	{
-		try
-		{
-			IAggrFunction info = DataUtil.getAggregationManager( )
-					.getAggregation( function );
-			for ( IParameterDefn param : info.getParameterDefn( ) )
-			{
-				if ( param.getDisplayName( ).equals( argument ) )
-					return param.getName( );
-			}
-		}
-		catch ( BirtException e )
-		{
-			ExceptionHandler.handle( e );
-		}
-		return null;
-	}
-
-	private String getArgumentDisplayNameByName( String function,
-			String argument )
-	{
-		try
-		{
-			IAggrFunction info = DataUtil.getAggregationManager( )
-					.getAggregation( function );
-			for ( IParameterDefn param : info.getParameterDefn( ) )
-			{
-				if ( param.getName( ).equals( argument ) )
-					return param.getDisplayName( );
-			}
-		}
-		catch ( BirtException e )
-		{
-			ExceptionHandler.handle( e );
+			if ( binding.getName( ).equals( combo.getText( ) ) )
+				return ExpressionButtonUtil.getCurrentExpressionConverter( combo )
+						.getBindingExpression( combo.getText( ) );
 		}
 		return null;
 	}
@@ -1516,9 +1484,9 @@ public class BindingDialogHelper extends AbstractBindingDialogHelper
 			catch ( AdapterException e )
 			{
 			}
-			
+
 			if ( !expressionEquals( binding.getExpressionProperty( ComputedColumn.FILTER_MEMBER ),
-				txtFilter ) )
+					txtFilter ) )
 				return true;
 			if ( btnTable.getSelection( ) == ( binding.getAggregateOn( ) != null ) )
 				return true;


### PR DESCRIPTION
Original description of problem:
The Expression Field in a weighted average aggregation, does not resolve
to row[xxxxx] like it should, rather just xxxxx.

The workaround is to go through the fx expression builder).

The steps to recreate bug:
Create a data source and data set.
Create a table with a group.
From palette quick tools, drag "Aggregation" to the table.
Choose function is "WEIGHTEDAVE"
Try to populate "Expression" field by choosing data set column from the drop down list.
Note that the field is populated with <column name>.
It should be row[<column name>]
