### PR TITLE
BIRT bug fixes (model property hidden in designer.)

### DIFF
--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/rom.def
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/rom.def
@@ -3320,6 +3320,7 @@
       <Argument name="reportContext" tagID="Element.Row.onRender.reportContext" type="org.eclipse.birt.report.engine.api.script.IReportContext"/>
     </Method>    
     <PropertyVisibility name="viewAction" visibility="hide"/>                                                      
+	<PropertyVisibility name="suppressDuplicates" visibility="hide"/>
     <Slot displayNameID="Element.Row.slot.cells" multipleCardinality="true" name="cells" since="1.0">
       <Type name="Cell"/>
       <Trigger validator="CellOverlappingValidator"/>


### PR DESCRIPTION
- Description of Issue: This property is not defined and not implemented
  so it should be hidden.
- Description of Resolution: Add property visibility in rom.def.
- Bugzilla(s) Resolved: 144383

Signed-off-by: Carl Thronson <cthronson@actuate.com>