### PR TITLE
fix bug 456545 defensive code to avoid NPE

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
@@ -570,6 +570,8 @@ public class PDFPage extends AbstractPage
 				|| "_self".equalsIgnoreCase( target ) )
 		// Opens the target in a new window.
 		{
+			if ( hyperlink == null )
+				hyperlink = "";
 			boolean isUrl = hyperlink.startsWith( "http" );
 			if ( !isUrl )
 			{


### PR DESCRIPTION
fix bug 456545 defensive code to avoid NPE on null hyperlink

Signed-off-by: sguan <sguan@actuate.com>