### PR TITLE
Fix this compile error.

### DIFF
--- a/UI/org.eclipse.birt.report.debug.ui/build.properties
+++ b/UI/org.eclipse.birt.report.debug.ui/build.properties
@@ -6,5 +6,4 @@ bin.includes = plugin.xml,\
                icons/,\
                plugin.properties,\
                about.html
-src.includes = about.html,\
-               .cvsignore
+src.includes = about.html


### PR DESCRIPTION
[ERROR] Failed to execute goal
org.eclipse.tycho:tycho-source-plugin:0.21.0:plugin-source (plugin-source)
on project org.eclipse.birt.report.debug.ui:

By removing .cvsignore from src.includes

Signed-off-by: Carl Thronson <cthronson@actuate.com>