### PR TITLE
Internal refactor apis for enchancement

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/optimize/ExecutionOptimize.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/optimize/ExecutionOptimize.java
@@ -252,8 +252,6 @@ public class ExecutionOptimize
 
 		protected PolicyNode findPreviousNode( PolicyNode node )
 		{
-			if ( node.design instanceof GroupDesign )
-				return node;
 			if ( node == null || node.parent == null )
 			{
 				return null;
@@ -271,8 +269,6 @@ public class ExecutionOptimize
 
 		protected PolicyNode findNextNode( PolicyNode node )
 		{
-			if ( node.design instanceof GroupDesign )
-				return node;
 			if ( node == null || node.parent == null )
 			{
 				return null;
@@ -287,7 +283,7 @@ public class ExecutionOptimize
 			}
 			else
 			{
-				return findNextNode( node.parent );
+				return findPreviousNode( node.parent );
 			}
 		}
 
@@ -470,6 +466,7 @@ public class ExecutionOptimize
 			if ( ++groupLevel < listing.getGroupCount( ) )
 			{
 				processGroup( listing, groupLevel, header != null );
+				processGroup( listing, groupLevel, false );
 			}
 			else
 			{


### PR DESCRIPTION
The top level Group header should stretch over to preceding page for the the list of data that does not fit in one page.  At some point it happens in Auto layout but Fixed layout works fine.

And revert commit f49fecb31fd8c3e7a1ce872e06e719e2551995e7