### PR TITLE
Summary: Remove Report examples view from BIRT designer 

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.samplesview/plugin.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.samplesview/plugin.xml
@@ -2,14 +2,4 @@
 <?eclipse version="3.0"?>
 <plugin
 >
-   <extension
-         point="org.eclipse.ui.views">
-      <view
-            allowMultiple="false"
-            category="org.eclipse.birt.core.ui.category"
-            class="org.eclipse.birt.report.designer.ui.samplesview.view.ReportExamplesView"
-            icon="icons/reportExample.gif"
-            id="org.eclipse.birt.report.examples.view.examplesview"
-            name="%ReportSamplesView"/>
-   </extension>
 </plugin>

--- a/features/org.eclipse.birt.example.feature/feature.xml
+++ b/features/org.eclipse.birt.example.feature/feature.xml
@@ -55,13 +55,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.birt.report.designer.samplereports"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.birt.report.data.oda.sampledb"
          download-size="0"
          install-size="0"
@@ -76,20 +69,6 @@
 
    <plugin
          id="org.eclipse.birt.example"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.birt.report.designer.ui.samples.ide"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.birt.report.designer.ui.samplesview"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.eclipse.birt.nl.feature/feature.xml
+++ b/features/org.eclipse.birt.nl.feature/feature.xml
@@ -303,14 +303,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.birt.report.designer.ui.samplesview.nl1"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         fragment="true"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.birt.report.designer.ui.preview.nl1"
          download-size="0"
          install-size="0"
@@ -399,14 +391,6 @@
 
    <plugin
          id="org.eclipse.birt.report.designer.ui.editors.nl1"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         fragment="true"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.birt.report.designer.ui.samples.ide.nl1"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Remove Report examples view from BIRT designer 

Note: following plugins need to remove from BIRT open source:

org.eclipse.birt.report.designer.samplereports
org.eclipse.birt.report.designer.ui.samples.ide
org.eclipse.birt.report.designer.ui.samplesview

Signed-off-by: Yuxuan Dai <ydai@actuate.com>