### PR TITLE
Engine adds join information when creating queries

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/olap/impl/query/CubeQueryDefinition.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/olap/impl/query/CubeQueryDefinition.java
@@ -442,6 +442,7 @@ public class CubeQueryDefinition extends NamedObject
         cloned.queryResultsID = this.queryResultsID;
         cloned.rowEdge = this.rowEdge != null ? this.rowEdge.clone( ) : null;
         cloned.sortList.addAll( this.sortList );
+        cloned.getLinks().addAll( this.getLinks( ) );
     }
     
     @Override

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/data/dte/ReportQueryBuilder.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/data/dte/ReportQueryBuilder.java
@@ -32,6 +32,7 @@ import org.eclipse.birt.data.engine.api.IInputParameterBinding;
 import org.eclipse.birt.data.engine.api.IQueryDefinition;
 import org.eclipse.birt.data.engine.api.ISortDefinition;
 import org.eclipse.birt.data.engine.api.ISubqueryDefinition;
+import org.eclipse.birt.data.engine.api.querydefn.BaseLinkDefinition;
 import org.eclipse.birt.data.engine.api.querydefn.BaseQueryDefinition;
 import org.eclipse.birt.data.engine.api.querydefn.QueryDefinition;
 import org.eclipse.birt.data.engine.api.querydefn.QueryExecutionHints;
@@ -97,6 +98,8 @@ import org.eclipse.birt.report.model.api.ReportItemHandle;
 import org.eclipse.birt.report.model.api.SlotHandle;
 import org.eclipse.birt.report.model.api.SortKeyHandle;
 import org.eclipse.birt.report.model.api.TableHandle;
+
+import com.actuate.birt.report.model.api.JoinDefinitionHandle;
 
 /**
  * visit the report design and prepare all report queries and sub-queries to
@@ -672,7 +675,7 @@ public class ReportQueryBuilder
 				}
 			}
 
-			// TODO: check in plugin registry whetherthe needQuery property is
+			// TODO: check in plugin registry whether the needQuery property is
 			// set to host or item.
 			// Only do the following for "host"
 			IReportItemQuery itemQuery = context.getExtendedItemManager( )
@@ -728,6 +731,7 @@ public class ReportQueryBuilder
 								context.addException( handle, ex );
 							}
 						}
+						addQueryTimeJoins(handle.joinDefinitionsIterator( ),query);
 					}
 					return queries;
 				}
@@ -974,8 +978,8 @@ public class ReportQueryBuilder
 		
 		private void setUsesDetails( BaseQueryDefinition baseQuery )
 		{
-			if ( baseQuery instanceof QueryDefinition
-					&& !baseQuery.cacheQueryResults( ) )
+			if ( baseQuery instanceof QueryDefinition &&  !baseQuery.cacheQueryResults( ) )
+
 			{
 				( (QueryDefinition) baseQuery ).setIsSummaryQuery( true );
 			}
@@ -1426,9 +1430,39 @@ public class ReportQueryBuilder
 			addParamBinding( item, query );
 			addColumnBinding( item, query );
 			addSortAndFilter( item, query );
+			addQueryTimeJoins(designHandle.joinDefinitionsIterator( ),query);
 
 			return query;
 		}
+		
+        private void addQueryTimeJoins( Iterator<JoinDefinitionHandle> joins,
+                IDataQueryDefinition query )
+        {
+            if ( query instanceof IQueryDefinition )
+            {
+                while ( joins.hasNext( ) )
+                {
+                    JoinDefinitionHandle join = joins.next( );
+                    ( (IQueryDefinition) query )
+                            .addLink( new BaseLinkDefinition( join
+                                    .getLeftDataSet( ),
+                                    join.getRightDataSet( ), null, null, join
+                                            .getJoinType( ) ) );
+                }
+            }
+            else if ( query instanceof ICubeQueryDefinition )
+            {
+                while ( joins.hasNext( ) )
+                {
+                    JoinDefinitionHandle join = joins.next( );
+                    ( (ICubeQueryDefinition) query )
+                            .addLink( new BaseLinkDefinition( join
+                                    .getLeftDataSet( ),
+                                    join.getRightDataSet( ), null, null, join
+                                            .getJoinType( ) ) );
+                }
+            }
+        }
 
 		protected BaseQueryDefinition createSubQuery( ReportItemDesign item,
 				IDataQueryDefinition parent )
@@ -2124,5 +2158,7 @@ public class ReportQueryBuilder
 				}
 			}
 		}
+		
+		
 	}
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/data/dte/ReportQueryBuilder.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/data/dte/ReportQueryBuilder.java
@@ -978,8 +978,8 @@ public class ReportQueryBuilder
 		
 		private void setUsesDetails( BaseQueryDefinition baseQuery )
 		{
-			if ( baseQuery instanceof QueryDefinition &&  !baseQuery.cacheQueryResults( ) )
-
+            if ( baseQuery instanceof QueryDefinition
+                    && !baseQuery.cacheQueryResults( ) )
 			{
 				( (QueryDefinition) baseQuery ).setIsSummaryQuery( true );
 			}


### PR DESCRIPTION
Data Engine uses the new Model API for query time join to create QueryDefinitions