### PR TITLE
Allow for customization of extended items to have additional property

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/ui/views/attributes/AbstractPageGenerator.java
+++ b/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/ui/views/attributes/AbstractPageGenerator.java
@@ -3,8 +3,10 @@ package org.eclipse.birt.report.designer.ui.views.attributes;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 
 import org.eclipse.birt.report.designer.internal.ui.views.attributes.page.AttributePage;
+import org.eclipse.birt.report.designer.ui.views.ElementAdapterManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.widgets.Composite;
@@ -141,4 +143,40 @@ public class AbstractPageGenerator extends CategoryPageGenerator
 			}
 		}
 	}
+
+	@Override
+	public void createTabItems( List input )
+	{
+		super.createTabItems( input );
+		AbstractPageGenerator adaptable = new AbstractPageGenerator( );
+		IPageGeneratorHelper helper = (IPageGeneratorHelper) ElementAdapterManager
+				.getAdapter( adaptable, IPageGeneratorHelper.class );
+		if ( helper != null )
+		{
+			String[] tabKeys = helper.createTabItems( input );
+			for ( String tabKey : tabKeys )
+			{
+				if ( !existTabItem( tabKey ) )
+				{
+					int index = this.tabFolder.getItemCount( );
+					String precedingItemKey = this.tabFolder
+							.getItem( index - 1 ).getText( );
+					createTabItem( tabKey, precedingItemKey );
+					TabPage page = helper.buildTabContent( tabKey );
+					CTabItem item = tabFolder.getItem( getItemIndex( tabKey ) );
+					setPageInput( page );
+					refresh( tabFolder, page, true );
+					item.setControl( page.getControl( ) );
+					itemMap.put( item, page );
+				}
+				else
+				{
+					CTabItem item = tabFolder.getItem( getItemIndex( tabKey ) );
+					setPageInput( itemMap.get( item ) );
+					refresh( tabFolder, itemMap.get( item ), false );
+				}
+			}
+		}
+	}
+
 }

--- a/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/ui/views/attributes/BasePageGenerator.java
+++ b/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/ui/views/attributes/BasePageGenerator.java
@@ -94,15 +94,6 @@ abstract public class BasePageGenerator extends AbstractPageGenerator
 			( (PreviewPage) page ).setPreview( new MapPropertyDescriptor( true ) );
 			( (PreviewPage) page ).setProvider( new MapDescriptorProvider( ) );
 		}
-		else
-		{
-			IPageGeneratorHelper helper = (IPageGeneratorHelper) ElementAdapterManager.getAdapter( this,
-					IPageGeneratorHelper.class );
-			if ( helper != null )
-			{
-				page = helper.buildTabContent( tabKey );
-			}
-		}
 
 		return page;
 	}
@@ -148,18 +139,6 @@ abstract public class BasePageGenerator extends AbstractPageGenerator
 		this.input = input;
 		addSelectionListener( this );
 		createTabItems( );
-		IPageGeneratorHelper helper = (IPageGeneratorHelper) ElementAdapterManager.getAdapter( this,
-				IPageGeneratorHelper.class );
-		if ( helper != null )
-		{
-			String[] tabKeys = helper.createTabItems( );
-			for ( String tabKey : tabKeys )
-			{
-				int index = this.tabFolder.getItemCount( );
-				String precedingItemKey = this.tabFolder.getItem( index - 1 ).getText( );
-				this.createTabItem( tabKey, precedingItemKey );
-			}
-		}
 		if ( tabFolder.getSelection( ) != null )
 		{
 			buildItemContent( tabFolder.getSelection( ) );

--- a/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/ui/views/attributes/IPageGeneratorHelper.java
+++ b/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/ui/views/attributes/IPageGeneratorHelper.java
@@ -4,6 +4,8 @@
  *******************************************************************************/
 package org.eclipse.birt.report.designer.ui.views.attributes;
 
+import java.util.List;
+
 /**
  * 
  */
@@ -11,7 +13,7 @@ package org.eclipse.birt.report.designer.ui.views.attributes;
 public interface IPageGeneratorHelper
 {
 
-	public String[] createTabItems( );
+	public String[] createTabItems(List input );
 
 	public TabPage buildTabContent( String tabKey );
 


### PR DESCRIPTION
pages.  Move the page generator helper code deeper in the class hierarchy
so it can be applied to more types of report items.

Signed-off-by: Carl Thronson <cthronson@actuate.com>