### PR TITLE
- Summary: Background image not sized properly in PPTX

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/PPTXCanvas.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/PPTXCanvas.java
@@ -414,7 +414,8 @@ public class PPTXCanvas
 					: imageInfo.getWidth( );
 			float originalImageHeight = imageHeight != 0 ? imageHeight
 					: imageInfo.getHeight( );
-
+			originalImageHeight = Math.min( originalImageHeight, height );
+			originalImageWidth = Math.min( originalImageWidth, width );
 			Position areaPosition = new Position( x, y );
 			Position areaSize = new Position( width, height );
 			Position imagePosition = new Position( x + offsetX, y + offsetY );

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/emitter/PageDeviceRender.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/emitter/PageDeviceRender.java
@@ -256,12 +256,10 @@ public abstract class PageDeviceRender implements IAreaVisitor
 		}
 		if ( container instanceof RowArea )
 		{
-			System.out.println("read a row...");
 			rowStyleStack.push( container.getBoxStyle( ) );
 		}
 		else if ( container instanceof CellArea )
 		{
-			System.out.println("read a cell...");
 			drawCell( (CellArea) container );
 		}
 		


### PR DESCRIPTION
- Description of Issue: Background image overflow outside page

- Description of Resolution: limit image size

- TED(s) Resolved: BIRT-1235

- Code Owner Team: BIRT

- Code Reviewers: 

- Project ID:

- Tests: 
Ran locally

- Tests Automated (Yes/No, if “No”, then explain why):
No, only through report generation

- Special Notes:

Signed-off-by: sguan <sguan@actuate.com>