### PR TITLE
- Summary: Support Tabular Measure Group containers that are not cubes.

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.cubebuilder/src/org/eclipse/birt/report/designer/ui/cubebuilder/provider/TabularMeasureGroupNodeProvider.java
+++ b/UI/org.eclipse.birt.report.designer.ui.cubebuilder/src/org/eclipse/birt/report/designer/ui/cubebuilder/provider/TabularMeasureGroupNodeProvider.java
@@ -81,9 +81,9 @@ public class TabularMeasureGroupNodeProvider extends DefaultNodeProvider
 	public Object getParent( Object model )
 	{
 		MeasureGroupHandle measures = (MeasureGroupHandle) model;
-		CubeHandle cube = (CubeHandle) measures.getContainer( );
-		if ( cube != null )
-			return cube.getPropertyHandle( ICubeModel.MEASURE_GROUPS_PROP );
+		DesignElementHandle container = measures.getContainer( );
+		if ( container != null )
+			return container.getPropertyHandle( ICubeModel.MEASURE_GROUPS_PROP );
 		return null;
 	}
 


### PR DESCRIPTION
- Description of Issue: BIRT extensions can modify the model to have
  measures outside of cubes.  So there is an exception raised from the
  TabularMeasureGroupNodeProvider because the container is not a cube.
- Description of Resolution: Support container that is not a cube.
- Regression ( Yes/No ): No
- Code owner Team: BIRT
- Code Reviewers:
- Project ID:
- Manual Test Description: Debug in dev env
- Tests Automated Cases Executed:
- Special Notes:

Signed-off-by: Carl Thronson <cthronson@actuate.com>