### PR TITLE
Chart Builder - support extended pre-defined aggregation

### DIFF
--- a/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/wizard/data/BaseDataDefinitionComponent.java
+++ b/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/wizard/data/BaseDataDefinitionComponent.java
@@ -803,6 +803,8 @@ public class BaseDataDefinitionComponent extends DefaultSelectDataComponent impl
 		{
 			setQueryExpression( expression );
 		}
+
+		enableAggEditor(expression);
 	}
 
 	/**
@@ -1059,6 +1061,17 @@ public class BaseDataDefinitionComponent extends DefaultSelectDataComponent impl
 		if ( btnBuilder != null )
 		{
 			btnBuilder.setExpression( expression );
+		}
+		
+		enableAggEditor(expression);
+	}
+
+	private void enableAggEditor( String expression )
+	{
+		if ( expression != null && fAggEditorComposite != null )
+		{
+			boolean isMeasure = expression.startsWith( "data" ); //$NON-NLS-1$
+			fAggEditorComposite.setEnabled( !isMeasure );
 		}
 	}
 	


### PR DESCRIPTION
When expression for series starts with data, disable aggregation function
combo box.

Otherwise, enable normal behavior.

Signed-off-by: Carl Thronson <cthronson@actuate.com>