### PR TITLE
Bug 481003 - Report onPageEnd and onPageStart scripts broken at report render time with ClassCastException

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/OnPageBreakLayoutPageHandle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/OnPageBreakLayoutPageHandle.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.LinkedHashSet;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IContent;
@@ -140,7 +140,7 @@ public class OnPageBreakLayoutPageHandle implements ILayoutPageHandler
 	private void doAddContent(IContent content)
 	{
 		if (contents.size() == CONTENTS_CONVERTION_THRESHOLD) {
-			contents = new TreeSet<IContent>(contents);
+			contents = new LinkedHashSet<IContent>(contents);
 		}
 		contents.add( content );
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/OnPageBreakLayoutPageHandle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/OnPageBreakLayoutPageHandle.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.SortedSet;
-import java.util.LinkedHashSet;
+import java.util.TreeSet;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IContent;
@@ -140,7 +140,7 @@ public class OnPageBreakLayoutPageHandle implements ILayoutPageHandler
 	private void doAddContent(IContent content)
 	{
 		if (contents.size() == CONTENTS_CONVERTION_THRESHOLD) {
-			contents = new LinkedHashSet<IContent>(contents);
+			contents = new TreeSet<IContent>(contents);
 		}
 		contents.add( content );
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/OnPageBreakLayoutPageHandle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/OnPageBreakLayoutPageHandle.java
@@ -14,8 +14,7 @@ package org.eclipse.birt.report.engine.executor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.LinkedHashSet;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IContent;
@@ -140,7 +139,7 @@ public class OnPageBreakLayoutPageHandle implements ILayoutPageHandler
 	private void doAddContent(IContent content)
 	{
 		if (contents.size() == CONTENTS_CONVERTION_THRESHOLD) {
-			contents = new TreeSet<IContent>(contents);
+			contents = new LinkedHashSet<IContent>(contents);
 		}
 		contents.add( content );
 	}


### PR DESCRIPTION
1. Bug was introduced in fixing Bug 431702 (Performance bottleneck in engine executor because of using arrayList.contains() method a lot.) The committer used a TreeSet to improve performance but does not implement Comparable interface, which result in ClassCastException
2. A linkedHashedSet will be enough for improving performance of contains method and simultaneously maintains the insertion order implied by arrayList.add() method
