### PR TITLE
- Summary: Date Format changed on default behavior

### DIFF
--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/DateFormatterTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/DateFormatterTest.java
@@ -145,6 +145,10 @@ public class DateFormatterTest extends TestCase
 
 		Locale locale = new Locale( "en", "us" );
 		DateFormatter sample = new DateFormatter( ULocale.forLocale(locale) );
+		//default null
+		sample.applyPattern( null );
+		assertEquals( "Sep 13, 1998 8:01 PM", sample.format( date ) );
+		
 		sample.applyPattern( "Long Date" );
 		assertEquals( "September 13, 1998", sample.format( date ) );
 		sample.applyPattern( "D" );

--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/DateFormatter.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/DateFormatter.java
@@ -171,7 +171,8 @@ public class DateFormatter implements IFormatter
 	}
 	
 	/**
-	 *   Convert into predefine pattern, when format is null, the case cover english. It will add if other language is require
+	 *   Convert into predefine pattern, when format is null, the case cover english. 
+	 *   It will add if other language is require
 	 * @param dateformat
 	 * @param locale
 	 * @return 
@@ -181,7 +182,7 @@ public class DateFormatter implements IFormatter
 			ULocale locale )
 	{
 		if ( "en".equals( locale.getLanguage( ) ) )
-		{
+		{	//predefine format for US_en:  MMM d, y h:mm a 
 			String PredefinePattern = dateformat.toPattern( ).replace( "y,",
 					"y" );
 			return new SimpleDateFormat( PredefinePattern, locale );

--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/DateFormatter.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/DateFormatter.java
@@ -169,11 +169,32 @@ public class DateFormatter implements IFormatter
 		
 		applyTimeZone( );
 	}
+	
+	/**
+	 *   Convert into predefine pattern, when format is null, the case cover english. It will add if other language is require
+	 * @param dateformat
+	 * @param locale
+	 * @return 
+	 */
+	@SuppressWarnings("nls")
+	private SimpleDateFormat toPredefinedPattern( SimpleDateFormat dateformat,
+			ULocale locale )
+	{
+		if ( "en".equals( locale.getLanguage( ) ) )
+		{
+			String PredefinePattern = dateformat.toPattern( ).replace( "y,",
+					"y" );
+			return new SimpleDateFormat( PredefinePattern, locale );
+		}
+		return dateformat;
+	}
+	
 	/**
 	 * define pattern and locale here
 	 * 
 	 * @param formatString
 	 */
+	@SuppressWarnings("nls")
 	private void createPattern( String formatString )
 	{
 		try
@@ -194,6 +215,8 @@ public class DateFormatter implements IFormatter
 						.getDateTimeInstance(
 								com.ibm.icu.text.DateFormat.MEDIUM,
 								com.ibm.icu.text.DateFormat.SHORT, locale );
+				dateTimeFormat = toPredefinedPattern(
+						(SimpleDateFormat) dateTimeFormat, locale );
 				dateFormat = com.ibm.icu.text.DateFormat.getDateInstance(
 						com.ibm.icu.text.DateFormat.MEDIUM, locale );
 				timeFormat = com.ibm.icu.text.DateFormat.getTimeInstance(


### PR DESCRIPTION
- Description of Issue:  The new ibm.icu has a different datetime format

- Description of Resolution: customize to a predefine format on english

- bug Resolved: bug 478576

- Tests: 
Ran locally

- Tests Automated (Yes/No, if “No”, then explain why):
Yes

Signed-off-by: sguan <sguan@actuate.com>