### PR TITLE
If the column binding info expression property begins with a measure

### DIFF
--- a/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ChartExpressionButton.java
+++ b/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ChartExpressionButton.java
@@ -22,10 +22,12 @@ import org.eclipse.birt.chart.model.impl.ChartModelHelper;
 import org.eclipse.birt.chart.reportitem.ui.ChartExpressionButtonUtil.ChartExpressionHelper;
 import org.eclipse.birt.chart.reportitem.ui.ChartExpressionButtonUtil.ExpressionDescriptor;
 import org.eclipse.birt.chart.reportitem.ui.ChartExpressionButtonUtil.IExpressionDescriptor;
+import org.eclipse.birt.chart.ui.swt.ColumnBindingInfo;
 import org.eclipse.birt.chart.ui.swt.interfaces.IAssistField;
 import org.eclipse.birt.chart.ui.swt.interfaces.IExpressionButton;
 import org.eclipse.birt.chart.ui.util.ChartUIUtil.EAttributeAccessor;
 import org.eclipse.birt.chart.util.ChartExpressionUtil.ExpressionCodec;
+import org.eclipse.birt.core.data.ExpressionUtil;
 import org.eclipse.birt.report.designer.internal.ui.dialogs.expression.ExpressionButton;
 import org.eclipse.birt.report.designer.internal.ui.util.ExpressionButtonUtil;
 import org.eclipse.birt.report.designer.ui.dialogs.IExpressionProvider;
@@ -287,6 +289,15 @@ public class ChartExpressionButton implements IExpressionButton
 		Set<IExpressionDescriptor> set = new LinkedHashSet<IExpressionDescriptor>( );
 		for ( Object obj : predefinedQuery )
 		{
+			if ( obj instanceof ColumnBindingInfo )
+			{
+				String expr = ( (ColumnBindingInfo) obj ).getExpression( );
+				if ( expr.startsWith( ExpressionUtil.DATA_INDICATOR ) )
+				{
+					set.add( ExpressionDescriptor.getInstance( obj, true ) );
+					continue;
+				}
+			}
 			set.add( ExpressionDescriptor.getInstance( obj, isCube ) );
 		}
 

--- a/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ReportDataServiceProvider.java
+++ b/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ReportDataServiceProvider.java
@@ -630,11 +630,31 @@ public class ReportDataServiceProvider implements IDataServiceProvider
 			for ( int i = 0; i < columnHeaders.length; i++ )
 			{
 				ComputedColumnHandle cch = columnList.get( i );
-				columnHeaders[i] = new ColumnBindingInfo( cch.getName( ),
-						ExpressionUtil.createJSRowExpression( cch.getName( ) ),
-						null,
-						null,
-						cch );
+				if ( cch.getExpressionProperty(
+						ComputedColumn.EXPRESSION_MEMBER ) != null
+						&& cch.getExpressionProperty(
+								ComputedColumn.EXPRESSION_MEMBER )
+								.getStringValue( ) != null
+						&& cch.getExpressionProperty(
+								ComputedColumn.EXPRESSION_MEMBER )
+								.getStringValue( )
+								.startsWith(
+										ExpressionUtil.MEASURE_INDICATOR ) )
+				{
+					columnHeaders[i] = new ColumnBindingInfo( cch.getName( ),
+							ExpressionUtil.createJSDataExpression( cch.getName( ) ),
+							null,
+							null,
+							cch );
+				}
+				else
+				{
+					columnHeaders[i] = new ColumnBindingInfo( cch.getName( ),
+							ExpressionUtil.createJSRowExpression( cch.getName( ) ),
+							null,
+							null,
+							cch );
+				}
 			}
 		}
 


### PR DESCRIPTION
indicator, then the corresponding column header expression should be a
data expression ( i.e. not a row expression )

Signed-off-by: Carl Thronson <cthronson@actuate.com>