### PR TITLE
- Summary: Date Missing case for DateTimeFormat

### DIFF
--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/DateFormatter.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/DateFormatter.java
@@ -229,6 +229,8 @@ public class DateFormatter implements IFormatter
 				dateTimeFormat = com.ibm.icu.text.DateFormat.getDateTimeInstance( com.ibm.icu.text.DateFormat.MEDIUM,
 						com.ibm.icu.text.DateFormat.SHORT,
 						locale );
+				dateTimeFormat = toPredefinedPattern(
+						(SimpleDateFormat) dateTimeFormat, locale );
 				return;
 
 			}


### PR DESCRIPTION
- Description of Issue:  unformatted datetime does not work correctly

- Description of Resolution: include case on predefine patterns



Signed-off-by: sguan <sguan@actuate.com>