### PR TITLE
report editor input property is "tested" during shutdown after being

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.ide/src/org/eclipse/birt/report/designer/ui/editors/ReportEditorProxy.java
+++ b/UI/org.eclipse.birt.report.designer.ui.ide/src/org/eclipse/birt/report/designer/ui/editors/ReportEditorProxy.java
@@ -27,6 +27,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartConstants;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.internal.part.NullEditorInput;
 import org.eclipse.ui.part.EditorPart;
 
 /**
@@ -70,13 +71,14 @@ public class ReportEditorProxy extends EditorPart implements
 	 * 
 	 * @see org.eclipse.ui.part.EditorPart#getEditorInput()
 	 */
+	@SuppressWarnings("restriction")
 	public IEditorInput getEditorInput( )
 	{
 		if ( instance != null )
 		{
 			return instance.getEditorInput( );
 		}
-		return null;
+		return new NullEditorInput( );
 	}
 
 	/*


### PR DESCRIPTION
already disposed.  To avoid an error message that is not useful, simply
return an instance of NullEditorInput so the property tester doesn't
complain.

Signed-off-by: Carl Thronson <cthronson@actuate.com>