### PR TITLE
Eclipse bug 483950

### DIFF
--- a/features/org.eclipse.birt.feature/feature.xml
+++ b/features/org.eclipse.birt.feature/feature.xml
@@ -845,4 +845,10 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="uk.co.spudsoft.birt.emitters.excel"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 </feature>


### PR DESCRIPTION
Export to Excel in XLS & XLSX formats missing in BIRT Open Source v.4.6
modified feature.xml file to make org.eclipse.birt.feature includes xls & xlsx plugins. 

Signed-off-by: Shijie Zhang <szhang@opentext.com>