### PR TITLE
NPE when attempting to create debug configuration

### DIFF
--- a/UI/org.eclipse.birt.report.debug.ui/src/org/eclipse/birt/report/debug/ui/DebugUI.java
+++ b/UI/org.eclipse.birt.report.debug.ui/src/org/eclipse/birt/report/debug/ui/DebugUI.java
@@ -127,7 +127,11 @@ public class DebugUI extends AbstractUIPlugin
 	 * @return
 	 */
 	public static DebugUI getDefault( )
-	{
+	{	
+		if ( plugin == null )
+		{
+			plugin = new DebugUI( );
+		}
 		return plugin;
 	}
 


### PR DESCRIPTION
NPE when attempting to create debug configuration

Description: initialize the class before referencing static variables

Reported by: Jane Tatchell

Signed-off-by: Shijie Zhang <szhang@opentext.com>