### PR TITLE
Remove Jetty icon in opensource 4.6 for report viewer

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty.xml
+++ b/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty.xml
@@ -31,7 +31,7 @@
              <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
            </Item>
            <Item>
-             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"> <Set name="serveIcon">false</Set> </New>
            </Item>
            <Item>
              <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler"/>


### PR DESCRIPTION
For Jetty 9 - you will need to edit jetty.xml which is located
$Jetty_Home/etc


Signed-off-by: Shijie Zhang <szhang@opentext.com>