### PR TITLE
MongoDB ODA issue with empty collections

### DIFF
--- a/data/org.eclipse.birt.data.oda.mongodb/src/org/eclipse/birt/data/oda/mongodb/internal/impl/MDbMetaData.java
+++ b/data/org.eclipse.birt.data.oda.mongodb/src/org/eclipse/birt/data/oda/mongodb/internal/impl/MDbMetaData.java
@@ -281,14 +281,6 @@ public class MDbMetaData
         if( nameFragments.length == 1 )  // specified field has only 1 level
             return firstLevelMd;
 
-        // Sanity check for multiple-level no-data case:
-        // getFieldMetaData() currently returns empty-field-metadata if metadata
-        // is not found by the field name. So if field has more than two levels,
-        // but the first level MD points to the static empty-field-metadata instance,
-        // then return the first level MD (empty-field-metadata) like in 1-level case.
-        if( firstLevelMd == sm_emptyFieldMetaData )
-        	return firstLevelMd;
-
         // expects the first level to be a parent field
         if( ! firstLevelMd.hasChildDocuments() )
             return null;    // does not match metadata; not able to find a match

--- a/data/org.eclipse.birt.data.oda.mongodb/src/org/eclipse/birt/data/oda/mongodb/internal/impl/MDbMetaData.java
+++ b/data/org.eclipse.birt.data.oda.mongodb/src/org/eclipse/birt/data/oda/mongodb/internal/impl/MDbMetaData.java
@@ -281,6 +281,14 @@ public class MDbMetaData
         if( nameFragments.length == 1 )  // specified field has only 1 level
             return firstLevelMd;
 
+        // Sanity check for multiple-level no-data case:
+        // getFieldMetaData() currently returns empty-field-metadata if metadata
+        // is not found by the field name. So if field has more than two levels,
+        // but the first level MD points to the static empty-field-metadata instance,
+        // then return the first level MD (empty-field-metadata) like in 1-level case.
+        if( firstLevelMd == sm_emptyFieldMetaData )
+        	return firstLevelMd;
+
         // expects the first level to be a parent field
         if( ! firstLevelMd.hasChildDocuments() )
             return null;    // does not match metadata; not able to find a match


### PR DESCRIPTION
Fixed MongoDB ODA plugin issue with report failing with "Column binding
"x.y" has referred to a data set column "x.y" which does not exist"
error for empty collections with subdocument fields.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>