### PR TITLE
Functions used in measure dialogue cause error in chart & xtab

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/api/aggregation/AggregationManager.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/api/aggregation/AggregationManager.java
@@ -69,8 +69,8 @@ public class AggregationManager
 			"MODE",
 			"STDDEV",
 			"VARIANCE",
-			"RANK",
-			"RUNNINGSUM"
+	//		"RANK",
+	//		"RUNNINGSUM"
 	};
 
 	public static final int AGGR_TABULAR = 0;


### PR DESCRIPTION
Removed unsupported aggregation function RANK and RUNNINGSUM from
aggregation builder


Signed-off-by: Shijie Zhang <szhang@opentext.com>