### PR TITLE
This fix is for the "Select Data" page of the chart builder and for the

### DIFF
--- a/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/wizard/data/BaseDataDefinitionComponent.java
+++ b/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/wizard/data/BaseDataDefinitionComponent.java
@@ -335,7 +335,9 @@ public class BaseDataDefinitionComponent extends DefaultSelectDataComponent impl
 								{
 									onModifyExpression( );
 								}
-							} );
+							},
+							null,
+							queryType );
 		}
 		catch ( ChartException e )
 		{


### PR DESCRIPTION
expression builder of "Category (X) Series" and "Optional Y Series
Grouping." When the user selected "Available Column BIndings" and "Chart"
the far right column should not show invalid items.  Invalid items are
items that can not be chosen from the dropdown list and can not be dragged
and dropped into the expression field.

Signed-off-by: Carl Thronson <cthronson@actuate.com>