### PR TITLE
We allow for ComputedMeasureView to have direct reference to measures if

### DIFF
--- a/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/de/ComputedMeasureViewHandle.java
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/de/ComputedMeasureViewHandle.java
@@ -12,6 +12,7 @@
 package org.eclipse.birt.report.item.crosstab.core.de;
 
 import org.eclipse.birt.report.item.crosstab.core.IComputedMeasureViewConstants;
+import org.eclipse.birt.report.item.crosstab.core.util.CrosstabUtil;
 import org.eclipse.birt.report.model.api.DesignElementHandle;
 import org.eclipse.birt.report.model.api.olap.MeasureHandle;
 
@@ -39,6 +40,17 @@ public class ComputedMeasureViewHandle extends MeasureViewHandle implements
 	@Override
 	public MeasureHandle getCubeMeasure( )
 	{
+		// this does not apply to regular data cubes
+		if ( CrosstabUtil.isBoundToLinkedDataSet( this.getCrosstab( ) ) )
+		{
+			// this only applies if measure has its own aggregation
+			if ( CrosstabUtil.measureHasItsOwnAggregation( this.getCrosstab( ), super.getCubeMeasure( ) ) )
+			{
+				// return the super implementation
+				return super.getCubeMeasure( );
+			}
+		}
+		// otherwise in all other cases return normal
 		return null;
 	}
 

--- a/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/util/CrosstabUtil.java
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/util/CrosstabUtil.java
@@ -1270,9 +1270,12 @@ public final class CrosstabUtil implements ICrosstabConstants
 		if( mv instanceof ComputedMeasureViewHandle )
 		{
 			ComputedColumnHandle ch = getMeasureBindingColumnHandle( mv );
-			if( ch != null 
-					&& ch.getAggregateFunction() != null 
-					&& !ch.getAggregateFunction().isEmpty() )
+			if ( ch != null
+					&& ( ( ch.getAggregateFunction( ) != null
+							&& !ch.getAggregateFunction( ).isEmpty( ) )
+							|| CrosstabUtil.measureHasItsOwnAggregation(
+									mv.getCrosstab( ),
+									mv.getCubeMeasure( ) ) ) )
 			{	
 				if( ignoreRTP && ch.getCalculationType( ) != null )
 				{
@@ -1310,7 +1313,11 @@ public final class CrosstabUtil implements ICrosstabConstants
 					Pattern p = null;
 					if( ExpressionType.JAVASCRIPT.equalsIgnoreCase( expr.getType( ) ) )
 					{
-						p = Pattern.compile( ExpressionUtil.DATASET_ROW_INDICATOR + "\\[\\s*\\\"([^\\]]+)\\\"\\s*\\]" );						
+						p = Pattern.compile( ExpressionUtil.DATASET_ROW_INDICATOR + "\\[\\s*\\\"([^\\]]+)\\\"\\s*\\]" );
+						if ( CrosstabUtil.measureHasItsOwnAggregation( mv.getCrosstab( ), mv.getCubeMeasure( ) ) )
+						{
+							p = Pattern.compile( ExpressionUtil.MEASURE_INDICATOR + "\\[\\s*\\\"([^\\]]+)\\\"\\s*\\]" );
+						}
 					}
 					else
 					{
@@ -1332,7 +1339,7 @@ public final class CrosstabUtil implements ICrosstabConstants
 		
 		return refColumnName;
 	}
-	
+
 	public static void setLabelDisplayNameKey( String key )
 	{
 		labelDisplayNameKey = key;


### PR DESCRIPTION
and only if those measures are not from data cubes and they also have
their own aggregation.

Signed-off-by: Carl Thronson <cthronson@actuate.com>