### PR TITLE
Sorting not applied on X Series when optional Y series is enabled.

### DIFF
--- a/chart/org.eclipse.birt.chart.reportitem/src/org/eclipse/birt/chart/reportitem/AbstractChartBaseQueryGenerator.java
+++ b/chart/org.eclipse.birt.chart.reportitem/src/org/eclipse/birt/chart/reportitem/AbstractChartBaseQueryGenerator.java
@@ -517,9 +517,7 @@ public abstract class AbstractChartBaseQueryGenerator
 			Axis[] orthAxisArray ) throws ChartException
 	{
 		String baseSortExpr = getValidSortExpr( categorySD );
-		if ( !categorySD.isSetSorting( )
-				|| baseSortExpr == null
-				|| categoryGroupDefinition == null )
+		if ( !categorySD.isSetSorting( ) || baseSortExpr == null )
 		{
 			return;
 		}
@@ -547,7 +545,8 @@ public abstract class AbstractChartBaseQueryGenerator
 
 		String sortExpr = baseSortExpr;
 
-		if ( ChartReportItemUtil.isBaseGroupingDefined( categorySD ) )
+		if ( ChartReportItemUtil.isBaseGroupingDefined( categorySD )
+				&& categoryGroupDefinition != null )
 		{
 			categoryGroupDefinition.addSort( sd );
 


### PR DESCRIPTION
Fixed a previous NPE protection which was implied too early. 


Signed-off-by: Shijie Zhang <szhang@opentext.com>