### PR TITLE
Summary: Failed to close the indexes java.io.IOException

### DIFF
--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/btree/BTree.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/btree/BTree.java
@@ -528,20 +528,20 @@ public class BTree<K, V> implements BTreeConstants
 						if ( !value.isLocked( ) )
 						{
 							// remove this node
-							if ( node.isDirty( ) )
+							if ( value.isDirty( ) )
 							{
 								try
 								{
-									writeNode( node );
+									writeNode( value );
 								}
 								catch ( IOException ex )
 								{
 									logger.log(
 											Level.WARNING,
 											"failed to write node "
-													+ node.getNodeId( )
+													+ value.getNodeId( )
 													+ " type "
-													+ node.getNodeType( ), ex );
+													+ value.getNodeType( ), ex );
 									return false;
 								}
 							}


### PR DESCRIPTION
Issue: Failed to close the indexes java.io.IOException

solution:  btree removeEldestEntry have to pick the value to remove instead of
node.  When node is lock and value is dirty

Signed-off-by: sguan <sguan@actuate.com>