### PR TITLE
Fixed issue with Double.NaN and Double.Infinity handling in TotalSum

### DIFF
--- a/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/TotalSum.java
+++ b/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/TotalSum.java
@@ -90,12 +90,12 @@ public class TotalSum extends AggrFunction
 	private static class MyAccumulator extends SummaryAccumulator
 	{
 
-		private Number sum = BigDecimal.ZERO;
+		private Number sum = 0.0D;
 
 		public void start( )
 		{
 			super.start( );
-			sum = new BigDecimal( new char[]{'0'}, 0, 1 );
+			sum = 0D;
 		}
 
 		/*
@@ -124,7 +124,7 @@ public class TotalSum extends AggrFunction
 		 */
 		public Object getSummaryValue( )
 		{
-			return sum;
+			return new BigDecimal(sum.toString());
 		}
 
 	}

--- a/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/TotalSum.java
+++ b/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/TotalSum.java
@@ -90,12 +90,12 @@ public class TotalSum extends AggrFunction
 	private static class MyAccumulator extends SummaryAccumulator
 	{
 
-		private Number sum = 0.0D;
+		private Number sum = BigDecimal.ZERO;
 
 		public void start( )
 		{
 			super.start( );
-			sum = 0D;
+			sum = new BigDecimal( new char[]{'0'}, 0, 1 );
 		}
 
 		/*
@@ -124,7 +124,7 @@ public class TotalSum extends AggrFunction
 		 */
 		public Object getSummaryValue( )
 		{
-			return new BigDecimal(sum.toString());
+			return sum;
 		}
 
 	}

--- a/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/TotalSum.java
+++ b/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/TotalSum.java
@@ -90,12 +90,12 @@ public class TotalSum extends AggrFunction
 	private static class MyAccumulator extends SummaryAccumulator
 	{
 
-		private Number sum = 0.0D;
+		private Number sum = BigDecimal.ZERO;
 
 		public void start( )
 		{
 			super.start( );
-			sum = 0D;
+			sum = BigDecimal.ZERO;
 		}
 
 		/*
@@ -124,7 +124,7 @@ public class TotalSum extends AggrFunction
 		 */
 		public Object getSummaryValue( )
 		{
-			return new BigDecimal(sum.toString());
+			return sum;
 		}
 
 	}

--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
@@ -38,7 +38,7 @@ public class TotalTest extends TestCase
     private double[] doubleArray6 = {1, 2, 2, 3, 1, 3, 4, 2, 1};
     private Object[] anyObjectArray = { "aa", "bb", null, new Integer( 0 ), null, new Double( 1 ), new Float( 0 ), null };
     private Object[] anyObjectArray2 = { "aa", "bb", null, new Integer( 0 ), null, new Double( 1 ), new Float( 0 ), null, false, new Date(1000000L) };
-    
+
     private Date[] dates = new Date[]
                             {
             new Date(1000000L),
@@ -46,7 +46,7 @@ public class TotalTest extends TestCase
             new Date(3000000L),
             new Date(4000000L)
                             };
-    
+
     private Date[] dates2 = new Date[]
                             {
             new Date(1000000L),
@@ -55,7 +55,7 @@ public class TotalTest extends TestCase
             new Date(3000000L),
             new Date(4000000L)
                             };
-    
+
     private String[] str2 = new String[]
                                        {
             "test",
@@ -64,7 +64,7 @@ public class TotalTest extends TestCase
             "for",
             "aggregation"
                                        };
-    
+
     private String[] str4 = new String[]
                                        {
             "test",
@@ -80,52 +80,52 @@ public class TotalTest extends TestCase
                                        };
 
     private BigDecimal[] bigDecimalArray = new BigDecimal[]{
-			new BigDecimal( "1" ),
-			new BigDecimal( "3" ),
-			new BigDecimal( "5" ),
-			new BigDecimal( "4" ),
-			new BigDecimal( "6" ),
-			new BigDecimal( "8" ),
-			new BigDecimal( "3" ),
-			new BigDecimal( "4" ),
-			new BigDecimal( "5" ),
-			new BigDecimal( "7" ),
-			new BigDecimal( "9" ),
-			new BigDecimal( "10" ),
-			new BigDecimal( "4" ),
-			new BigDecimal( "6" ),
-			new BigDecimal( "7" )
-	};
-    
-    private int[] bigDecimalRankAsc = {
-			1, 2, 7, 4, 9, 13, 2, 4, 7, 11, 14, 15, 4, 9, 11
-	};
-    
-    private int[] bigDecimalPercentRank = new int[]{
-			0,
-			71,
-			428,
-			214,
-			571,
-			857,
-			71,
-			214,
-			428,
-			714,
-			928,
-			1000,
-			214,
-			571,
-			714
+            new BigDecimal( "1" ),
+            new BigDecimal( "3" ),
+            new BigDecimal( "5" ),
+            new BigDecimal( "4" ),
+            new BigDecimal( "6" ),
+            new BigDecimal( "8" ),
+            new BigDecimal( "3" ),
+            new BigDecimal( "4" ),
+            new BigDecimal( "5" ),
+            new BigDecimal( "7" ),
+            new BigDecimal( "9" ),
+            new BigDecimal( "10" ),
+            new BigDecimal( "4" ),
+            new BigDecimal( "6" ),
+            new BigDecimal( "7" )
+    };
 
-	};
-    
+    private int[] bigDecimalRankAsc = {
+            1, 2, 7, 4, 9, 13, 2, 4, 7, 11, 14, 15, 4, 9, 11
+    };
+
+    private int[] bigDecimalPercentRank = new int[]{
+            0,
+            71,
+            428,
+            214,
+            571,
+            857,
+            71,
+            214,
+            428,
+            714,
+            928,
+            1000,
+            214,
+            571,
+            714
+
+    };
+
     private int[] bigDecimalPercentSum = new int[]{
-			12, 36, 60, 48, 73, 97, 36, 48, 60, 85, 109, 121, 48, 73, 85
-	};
-    
-	private BuildInAggregationFactory buildInAggrFactory = new BuildInAggregationFactory();
-    
+            12, 36, 60, 48, 73, 97, 36, 48, 60, 85, 109, 121, 48, 73, 85
+    };
+
+    private BuildInAggregationFactory buildInAggrFactory = new BuildInAggregationFactory();
+
     /*
      * @see TestCase#setUp()
      */
@@ -141,249 +141,249 @@ public class TotalTest extends TestCase
     {
         super.tearDown();
     }
-    
+
     public void testTotalConcatenate( ) throws Exception
-	{
-		IAggrFunction ag = buildInAggrFactory.getAggregation( "concatenate" );
-		Accumulator ac = ag.newAccumulator( );
-		assertEquals( IBuildInAggregation.TOTAL_CONCATENATE_FUNC, ag.getName( ) );
-		assertEquals( IAggrFunction.SUMMARY_AGGR, ag.getType( ) );
-		assertEquals( 4, ag.getParameterDefn( ).length );
-		String separator = "-";
+    {
+        IAggrFunction ag = buildInAggrFactory.getAggregation( "concatenate" );
+        Accumulator ac = ag.newAccumulator( );
+        assertEquals( IBuildInAggregation.TOTAL_CONCATENATE_FUNC, ag.getName( ) );
+        assertEquals( IAggrFunction.SUMMARY_AGGR, ag.getType( ) );
+        assertEquals( 4, ag.getParameterDefn( ).length );
+        String separator = "-";
 
-		String result = "";
+        String result = "";
 
-		ac.start( );
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str2[i], separator, null, null
-			} );
-			result += str2[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		for ( int i = 0; i < str4.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str4[i], separator, null, null
-			} );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		boolean exceedsMaxLength = false;
-		for ( int i = 0; i < str4.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str4[i], separator, 50, true
-			} );
-			if ( exceedsMaxLength || result.getBytes( ).length > 50 - str4[i].length( ) )
-			{
-				exceedsMaxLength = true;
-				continue;
-			}
-			result += str4[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		exceedsMaxLength = false;
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str2[i], separator, 20, null
-			} );
-			if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
-			{
-				exceedsMaxLength = true;
-				continue;
-			}
-			result += str2[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		separator = ";  ";
-		exceedsMaxLength = false;
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str2[i], separator, 20, null
-			} );
-			if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
-			{
-				exceedsMaxLength = true;
-				continue;
-			}
-			result += str2[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		separator = "\n";
-		exceedsMaxLength = false;
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str2[i], separator, 20, null
-			} );
-			if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
-			{
-				exceedsMaxLength = true;
-				continue;
-			}
-			result += str2[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		separator = "\t";
-		exceedsMaxLength = false;
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str2[i], separator, 20, null
-			} );
-			if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
-			{
-				exceedsMaxLength = true;
-				continue;
-			}
-			result += str2[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		separator = "   ";
-		exceedsMaxLength = false;
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str2[i], separator, 20, null
-			} );
-			if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
-			{
-				exceedsMaxLength = true;
-				continue;
-			}
-			result += str2[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		separator = ",,, ";
-		exceedsMaxLength = false;
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					str2[i], separator, 20, null
-			} );
-			if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
-			{
-				exceedsMaxLength = true;
-				continue;
-			}
-			result += str2[i];
-			result += separator;
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-		
-		ac.start( );
-		result = "";
-		separator = "#";
-		exceedsMaxLength = false;
-		LinkedHashSet<String> objects = new LinkedHashSet<String>( );
-		for ( int i = 0; i < anyObjectArray2.length; i++ )
-		{
-			if ( anyObjectArray2[i] != null )
-			{
-				objects.add( anyObjectArray2[i].toString( ) );
-			}
-		}
-		Iterator<String> iterator = objects.iterator( );
-		while ( iterator.hasNext( ) )
-		{
-			String value = iterator.next( );
-			ac.onRow( new Object[]{
-					value, separator, 30, false
-			} );
-			if ( value != null )
-			{
-				if ( exceedsMaxLength
-						|| result.getBytes( ).length > 30 - value.length( ) )
-				{
-					exceedsMaxLength = true;
-					continue;
-				}
-				result += value;
-				result += separator;
-			}
-		}
-		if ( result.length( ) > 0 )
-		{
-			result = result.substring( 0, result.length( ) - separator.length( ) );
-		}
-		ac.finish( );
-		assertEquals( result, ac.getValue( ) );
-        
-	}
+        ac.start( );
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str2[i], separator, null, null
+            } );
+            result += str2[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        for ( int i = 0; i < str4.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str4[i], separator, null, null
+            } );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        boolean exceedsMaxLength = false;
+        for ( int i = 0; i < str4.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str4[i], separator, 50, true
+            } );
+            if ( exceedsMaxLength || result.getBytes( ).length > 50 - str4[i].length( ) )
+            {
+                exceedsMaxLength = true;
+                continue;
+            }
+            result += str4[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        exceedsMaxLength = false;
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str2[i], separator, 20, null
+            } );
+            if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
+            {
+                exceedsMaxLength = true;
+                continue;
+            }
+            result += str2[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        separator = ";  ";
+        exceedsMaxLength = false;
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str2[i], separator, 20, null
+            } );
+            if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
+            {
+                exceedsMaxLength = true;
+                continue;
+            }
+            result += str2[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        separator = "\n";
+        exceedsMaxLength = false;
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str2[i], separator, 20, null
+            } );
+            if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
+            {
+                exceedsMaxLength = true;
+                continue;
+            }
+            result += str2[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        separator = "\t";
+        exceedsMaxLength = false;
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str2[i], separator, 20, null
+            } );
+            if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
+            {
+                exceedsMaxLength = true;
+                continue;
+            }
+            result += str2[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        separator = "   ";
+        exceedsMaxLength = false;
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str2[i], separator, 20, null
+            } );
+            if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
+            {
+                exceedsMaxLength = true;
+                continue;
+            }
+            result += str2[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        separator = ",,, ";
+        exceedsMaxLength = false;
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    str2[i], separator, 20, null
+            } );
+            if ( exceedsMaxLength || result.getBytes( ).length > 20 - str2[i].length( ) )
+            {
+                exceedsMaxLength = true;
+                continue;
+            }
+            result += str2[i];
+            result += separator;
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+        ac.start( );
+        result = "";
+        separator = "#";
+        exceedsMaxLength = false;
+        LinkedHashSet<String> objects = new LinkedHashSet<String>( );
+        for ( int i = 0; i < anyObjectArray2.length; i++ )
+        {
+            if ( anyObjectArray2[i] != null )
+            {
+                objects.add( anyObjectArray2[i].toString( ) );
+            }
+        }
+        Iterator<String> iterator = objects.iterator( );
+        while ( iterator.hasNext( ) )
+        {
+            String value = iterator.next( );
+            ac.onRow( new Object[]{
+                    value, separator, 30, false
+            } );
+            if ( value != null )
+            {
+                if ( exceedsMaxLength
+                        || result.getBytes( ).length > 30 - value.length( ) )
+                {
+                    exceedsMaxLength = true;
+                    continue;
+                }
+                result += value;
+                result += separator;
+            }
+        }
+        if ( result.length( ) > 0 )
+        {
+            result = result.substring( 0, result.length( ) - separator.length( ) );
+        }
+        ac.finish( );
+        assertEquals( result, ac.getValue( ) );
+
+    }
 
     public void testTotalCount() throws Exception
     {
@@ -392,25 +392,25 @@ public class TotalTest extends TestCase
         assertEquals(IBuildInAggregation.TOTAL_COUNT_FUNC, ag.getName());
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
-        
-        ac.start( );
-		for ( int i = 0; i < anyObjectArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				anyObjectArray[i]
-			} );
-		}
-		ac.finish( );
-		assertEquals( new Integer( 5 ), ac.getValue( ) );
 
-		ac.start( );
-		for ( int i = 0; i < anyObjectArray.length; i++ )
-		{
-			ac.onRow( null );
-		}
-		ac.finish( );
-		assertEquals( new Integer( 8 ), ac.getValue( ) );
-        
+        ac.start( );
+        for ( int i = 0; i < anyObjectArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                anyObjectArray[i]
+            } );
+        }
+        ac.finish( );
+        assertEquals( new Integer( 5 ), ac.getValue( ) );
+
+        ac.start( );
+        for ( int i = 0; i < anyObjectArray.length; i++ )
+        {
+            ac.onRow( null );
+        }
+        ac.finish( );
+        assertEquals( new Integer( 8 ), ac.getValue( ) );
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -418,7 +418,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Integer(15), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -426,20 +426,20 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Integer(14), ac.getValue());
-        
+
         ac.start();
-        
+
         for(int i=0; i<str1.length; i++)
         {
             ac.onRow(new Object[]{});
         }
         ac.finish();
         assertEquals(new Integer(14), ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(new Integer(0), ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -451,7 +451,7 @@ public class TotalTest extends TestCase
             assertTrue(true);
         }
     }
-    
+
     public void testTotalSum() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("sum");
@@ -460,7 +460,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -468,7 +468,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(82.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -476,7 +476,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(69.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -484,11 +484,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(69.0), ac.getValue());
-        
+
         ac.start();
         ac.finish();
-        assertEquals(new Double(0.0), ac.getValue());
-        
+        assertEquals(new BigDecimal("0"), ac.getValue());
+
         ac.start();
         try
         {
@@ -499,36 +499,108 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         // test Total.sum() on String objects with data which can't be convert
-		// to Number
-		ac.start( );
-		try
-		{
-			for ( int i = 0; i < str2.length; i++ )
-			{
-				ac.onRow( new Object[]{
-					str2[i]
-				} );
-			}
-			fail( );
-		}
-		catch ( DataException e )
-		{
-			assertTrue( true );
-		}
-		ac.finish( );
-		
+        // to Number
+        ac.start( );
+        try
+        {
+            for ( int i = 0; i < str2.length; i++ )
+            {
+                ac.onRow( new Object[]{
+                    str2[i]
+                } );
+            }
+            fail( );
+        }
+        catch ( DataException e )
+        {
+            assertTrue( true );
+        }
+        ac.finish( );
+
         // test Total.sum() for BigDecimal data
         ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		assertEquals( new BigDecimal( "82.0" ), ac.getValue( ) );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        assertEquals( new BigDecimal( "82" ), ac.getValue( ) );
+
+        // test Total.sum() for heterogeneous Number array data
+        {
+            Number numberArray[] = new Number[] {
+                BigDecimal.ZERO,
+                BigDecimal.ONE,
+                BigDecimal.TEN,
+                Double.valueOf("0.1"),
+                new BigDecimal("0.1"),
+                new BigDecimal(0.1D),
+                new BigDecimal("0.1"),
+                new Double(0.1D),
+            };
+            ac.start( );
+            for ( int i = 0; i < numberArray.length; i++ )
+            {
+                ac.onRow( new Object[]{
+                    numberArray[i]
+                } );
+            }
+            ac.finish( );
+            Number x = ( Number )ac.getValue( );
+            assertTrue( new BigDecimal( "11.49" ).compareTo( new BigDecimal( x.toString( ) ) ) == -1 );
+            assertTrue( new BigDecimal( "11.51" ).compareTo( new BigDecimal( x.toString( ) ) ) == 1 );
+        }
+
+        // test Total.sum() for data with NaN
+        {
+            ac.start( );
+            ac.onRow( new Object[]{ 0D/0D } );
+            ac.onRow( new Object[]{ Double.valueOf( "0.1" ), Double.valueOf( "0.2" ) } );
+            ac.onRow( new Object[]{ new BigDecimal( "0.3" ) } );
+            ac.finish( );
+            Number x = ( Number )ac.getValue( );
+            assertTrue( x instanceof Double && ( ( Double )x ).isNaN( ) );
+
+            ac.start( );
+            ac.onRow( new Object[]{ Double.valueOf( "0.1" ) } );
+            ac.onRow( new Object[]{ new BigDecimal( "0.2" ), new BigDecimal( "0.3" ) } );
+            ac.onRow( new Object[]{ Double.NaN } );
+            ac.onRow( new Object[]{ new BigDecimal( "0.4" ) } );
+            ac.finish( );
+            x = ( Number )ac.getValue( );
+            assertTrue( x instanceof Double && ( ( Double )x ).isNaN( ) );
+        }
+
+        // test Total.sum() for data with Infinity
+        {
+            ac.start( );
+            ac.onRow( new Object[]{ Double.POSITIVE_INFINITY } );
+            ac.onRow( new Object[]{ Double.valueOf( "0.1" ), Double.valueOf( "0.2" ) } );
+            ac.onRow( new Object[]{ new BigDecimal( "0.3" ) } );
+            ac.finish( );
+            Number x = ( Number )ac.getValue( );
+            assertTrue( x instanceof Double && ( ( Double )x ).isInfinite( ) );
+
+            ac.start( );
+            ac.onRow( new Object[]{ Double.valueOf( "0.1" ), Double.valueOf( "0.2" ) } );
+            ac.onRow( new Object[]{ new BigDecimal( "0.3" ) } );
+            ac.onRow( new Object[]{ -1D/0D } );
+            ac.finish( );
+            x = ( Number )ac.getValue( );
+            assertTrue( x instanceof Double && ( ( Double )x ).isInfinite( ) );
+
+            ac.start( );
+            ac.onRow( new Object[]{ Double.valueOf( "0.1" ) } );
+            ac.onRow( new Object[]{ Double.NEGATIVE_INFINITY } );
+            ac.onRow( new Object[]{ new BigDecimal( "0.3" ) } );
+            ac.finish( );
+            x = ( Number )ac.getValue( );
+            assertTrue( x instanceof Double && ( ( Double )x ).isInfinite( ) );
+        }
     }
 
     public void testTotalRunningSum() throws Exception
@@ -541,14 +613,14 @@ public class TotalTest extends TestCase
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         double sum = 0D;
         ac.start( );
-		for ( int i = 0; i < doubleArray1.length; i++ )
-		{
-			ac.onRow( new Double[]{
-				new Double( doubleArray1[i] )
-			} );
-			sum += doubleArray1[i];
-			assertEquals( new Double( sum ), ac.getValue( ) );
-		}
+        for ( int i = 0; i < doubleArray1.length; i++ )
+        {
+            ac.onRow( new Double[]{
+                new Double( doubleArray1[i] )
+            } );
+            sum += doubleArray1[i];
+            assertEquals( new Double( sum ), ac.getValue( ) );
+        }
         ac.finish();
         sum = 0D;
         ac.start();
@@ -556,41 +628,41 @@ public class TotalTest extends TestCase
         {
             ac.onRow(new Double[]{new Double(doubleArray2[i])});
             sum += doubleArray2[i];
-			assertEquals( new Double( sum ), ac.getValue( ) );
+            assertEquals( new Double( sum ), ac.getValue( ) );
         }
         ac.finish();
         sum = 0D;
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
             ac.onRow(new Object[]{str1[i]});
             sum += new Double(str1[i]).doubleValue();
-			assertEquals( new Double( sum ), ac.getValue( ) );
+            assertEquals( new Double( sum ), ac.getValue( ) );
         }
         ac.finish();
         sum = 0D;
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         // test Total.RUNNINGSUM() for BigDecimal data
         BigDecimal bigSum = BigDecimal.ZERO;
         ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-			bigSum = bigSum.add( bigDecimalArray[i] );
-			Object ret = ac.getValue( );
-			assertTrue( ret instanceof BigDecimal );
-			assertTrue( bigSum.compareTo( (BigDecimal) ret ) == 0 );
-		}
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+            bigSum = bigSum.add( bigDecimalArray[i] );
+            Object ret = ac.getValue( );
+            assertTrue( ret instanceof BigDecimal );
+            assertTrue( bigSum.compareTo( (BigDecimal) ret ) == 0 );
+        }
         ac.finish();
     }
-    
+
     public void testTotalAve() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("ave");
@@ -599,7 +671,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -607,7 +679,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(5.466666666666667), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -615,7 +687,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(4.928571428571429), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -623,11 +695,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(4.928571428571429), ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -638,21 +710,21 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         // test Total.AVE() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( "5.466666666666666666666666666666667" ).compareTo( (BigDecimal) ret ) == 0 );
-	}
-    
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( "5.466666666666666666666666666666667" ).compareTo( (BigDecimal) ret ) == 0 );
+    }
+
     public void testTotalFirst() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("first");
@@ -661,7 +733,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -669,7 +741,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(1.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -677,7 +749,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(4), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -685,11 +757,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals("4", ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -700,21 +772,21 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         // test Total.FIRST() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( 1 ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( 1 ).compareTo( (BigDecimal) ret ) == 0 );
     }
-    
+
     public void testTotalLast() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("last");
@@ -723,7 +795,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -731,7 +803,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(7.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -739,7 +811,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(34.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -747,11 +819,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals("34", ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -763,19 +835,19 @@ public class TotalTest extends TestCase
             assertTrue(true);
         }
         // test Total.LAST() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( 7 ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( 7 ).compareTo( (BigDecimal) ret ) == 0 );
     }
-    
+
     public void testTotalMax() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("max");
@@ -784,7 +856,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -792,7 +864,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(10.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -800,7 +872,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(63.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -808,11 +880,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals("63", ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -824,19 +896,19 @@ public class TotalTest extends TestCase
             assertTrue(true);
         }
         // test Total.MAX() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( 10 ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( 10 ).compareTo( (BigDecimal) ret ) == 0 );
     }
-    
+
     public void testTotalMin() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("min");
@@ -845,7 +917,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -853,7 +925,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(1.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -861,7 +933,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(-43), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -869,11 +941,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals("-15", ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -884,21 +956,21 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         // test Total.MIN() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( 1 ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( 1 ).compareTo( (BigDecimal) ret ) == 0 );
     }
-    
+
     public void testTotalMedian() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("median");
@@ -907,7 +979,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -915,7 +987,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(5.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -923,7 +995,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(3.5), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -931,11 +1003,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(3.5), ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -946,40 +1018,40 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         //median test for Date
         //1:
         ac.start();
-	    for ( int i = 0; i < dates.length; i++ )
-		{
-			ac.onRow( new Object[]{dates[i]} );
-		}
+        for ( int i = 0; i < dates.length; i++ )
+        {
+            ac.onRow( new Object[]{dates[i]} );
+        }
         ac.finish();
         assertEquals( ac.getValue(), new Date(2500000L) );
         //2:
         ac.start();
-	    for ( int i = 0; i < dates2.length; i++ )
-		{
-			ac.onRow( new Object[]{dates2[i]} );
-		}
+        for ( int i = 0; i < dates2.length; i++ )
+        {
+            ac.onRow( new Object[]{dates2[i]} );
+        }
         ac.finish();
         assertEquals( ac.getValue(),  new Date(2000000L) );
-        
+
         // test Total.MEDIAN() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( 5 ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( 5 ).compareTo( (BigDecimal) ret ) == 0 );
 
     }
-    
+
     public void testTotalMode() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("mode");
@@ -988,7 +1060,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -996,7 +1068,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(4.0), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -1004,7 +1076,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(4.0), ac.getValue());
-        
+
         // double4: unique numbers
         ac.start();
         for(int i=0; i<doubleArray4.length; i++)
@@ -1021,16 +1093,16 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(1.0), ac.getValue());
-        
-		ac.start( );
-		for ( int i = 0; i < doubleArray6.length; i++ )
-		{
-			ac.onRow( new Double[]{
-				new Double( doubleArray6[i] )
-			} );
-		}
-		ac.finish( );
-		assertEquals( new Double( 1.0 ), ac.getValue( ) );
+
+        ac.start( );
+        for ( int i = 0; i < doubleArray6.length; i++ )
+        {
+            ac.onRow( new Double[]{
+                new Double( doubleArray6[i] )
+            } );
+        }
+        ac.finish( );
+        assertEquals( new Double( 1.0 ), ac.getValue( ) );
 
         ac.start();
         for(int i=0; i<str1.length; i++)
@@ -1039,11 +1111,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(4.0), ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -1054,7 +1126,7 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         ac.start();
         ac.onRow( new Double[]{ new Double(4)} );
         ac.onRow( new Double[]{ new Double(4)} );
@@ -1064,35 +1136,35 @@ public class TotalTest extends TestCase
         //mode test for Date
         //1: no mode date
         ac.start();
-	    for ( int i = 0; i < dates.length; i++ )
-		{
-			ac.onRow( new Object[]{dates[i]} );
-		}
+        for ( int i = 0; i < dates.length; i++ )
+        {
+            ac.onRow( new Object[]{dates[i]} );
+        }
         ac.finish();
         assertEquals( ac.getValue(), null );
         //2: mode date is  new Date(2000000L)
         ac.start();
-	    for ( int i = 0; i < dates2.length; i++ )
-		{
-			ac.onRow( new Object[]{dates2[i]} );
-		}
+        for ( int i = 0; i < dates2.length; i++ )
+        {
+            ac.onRow( new Object[]{dates2[i]} );
+        }
         ac.finish();
         assertEquals( ac.getValue(),  new Date(2000000L) );
 
         // test Total.MODE() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( 4 ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( 4 ).compareTo( (BigDecimal) ret ) == 0 );
     }
-    
+
     public void testTotalStdDev() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("stddev");
@@ -1101,7 +1173,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -1109,7 +1181,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(2.445598573141631), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -1117,7 +1189,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(26.560422510872147), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -1125,11 +1197,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(26.560422510872147), ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -1140,23 +1212,23 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         // test Total.StdDEV() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( "2.445598573141631" ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( "2.445598573141631" ).compareTo( (BigDecimal) ret ) == 0 );
 
     }
-    
-    
+
+
     public void testTotalVariance() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("variance");
@@ -1165,7 +1237,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -1173,7 +1245,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(5.980952380952381), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -1181,7 +1253,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(705.4560439560439), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -1189,11 +1261,11 @@ public class TotalTest extends TestCase
         }
         ac.finish();
         assertEquals(new Double(705.4560439560439), ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -1204,21 +1276,21 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         // test Total.Variance() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( "5.980952380952380952380952380952381" ).compareTo( (BigDecimal) ret ) == 0 );
-	}
-    
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( "5.980952380952380952380952380952381" ).compareTo( (BigDecimal) ret ) == 0 );
+    }
+
 
     public void testTotalWeightedAva() throws Exception
     {
@@ -1229,63 +1301,63 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
             ac.onRow(new Double[]{new Double(doubleArray1[i]), new Double(weight[i])});
         }
         ac.finish();
-       
+
         assertEquals(new Double(5.343042071197409), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
             ac.onRow(new Double[]{new Double(doubleArray2[i]), new Double(weight[i])});
         }
         ac.finish();
-        
+
         assertEquals(new Double(3.236104279390063), ac.getValue());
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
             ac.onRow(new Object[]{str1[i], new Double(weight[i])});
         }
         ac.finish();
-       
+
         assertEquals(new Double(3.236104279390063), ac.getValue());
-       
+
         ac.start();
         ac.onRow(new Object[]{new Double(1), new Double(1)});
         ac.onRow(new Object[]{new Double(2), new Double(2)});
         ac.finish();
         assertEquals(new Double(1.6666666666666667), ac.getValue());
-        
+
         ac.start();
         ac.onRow(new Object[]{null, new Double(3)});
         ac.onRow(new Object[]{new Double(2), new Double(2)});
         ac.onRow(new Object[]{new Double(2), null});
         ac.finish();
         assertEquals(new Double(2), ac.getValue());
-        
+
         ac.start();
         ac.onRow(new Object[]{new Double(1), new Double(3)});
         ac.onRow(new Object[]{new Double(1), new Double(-3)});
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         ac.onRow(new Object[]{new Double(1), new Double(2)});
         ac.onRow(new Object[]{new Double(2), new Double(-4)});
         ac.finish();
         assertEquals(new Double(3.0), ac.getValue());
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         ac.start();
         try
         {
@@ -1296,22 +1368,22 @@ public class TotalTest extends TestCase
         {
             assertTrue(true);
         }
-        
+
         // test Total.WeightedAve() for BigDecimal data
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( weight[i] )
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( "5.343042071197411003236245954692557" ).compareTo( (BigDecimal) ret ) == 0 );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( weight[i] )
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( "5.343042071197411003236245954692557" ).compareTo( (BigDecimal) ret ) == 0 );
 
     }
-    
+
     public void testTotalMovingAve() throws Exception
     {
         double[] values1 = new double[]{1.0, 2.0, 3.0, 3.25, 3.8, 4.5, 4.285714285714286, 4.25, 4.75, 5.25, 5.75, 6.5, 6.25, 6, 6.5};
@@ -1323,7 +1395,7 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
 
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
@@ -1332,7 +1404,7 @@ public class TotalTest extends TestCase
             assertEquals(new Double(values1[i]), ac.getValue());
         }
         ac.finish();
-        
+
         ac.start();
         for(int i=0; i<doubleArray2.length; i++)
         {
@@ -1340,7 +1412,7 @@ public class TotalTest extends TestCase
             assertEquals(new Double(values2[i]), ac.getValue());
         }
         ac.finish();
-        
+
         ac.start();
         for(int i=0; i<str1.length; i++)
         {
@@ -1348,47 +1420,47 @@ public class TotalTest extends TestCase
             assertEquals(new Double(values2[i]), ac.getValue());
         }
         ac.finish();
-        
+
         ac.start();
         ac.finish();
         assertEquals(null, ac.getValue());
-        
+
         // test Total.MovingAve() for BigDecimal data
         BigDecimal[] expectResults = new BigDecimal[]{
-				new BigDecimal( "1.0" ),
-				new BigDecimal( "2.0" ),
-				new BigDecimal( "3.0" ),
-				new BigDecimal( "3.25" ),
-				new BigDecimal( "3.8" ),
-				new BigDecimal( "4.5" ),
-				new BigDecimal( "4.285714285714285714285714285714286" ),
-				new BigDecimal( "4.25" ),
-				new BigDecimal( "4.75" ),
-				new BigDecimal( "5.25" ),
-				new BigDecimal( "5.75" ),
-				new BigDecimal( "6.5" ),
-				new BigDecimal( "6.25" ),
-				new BigDecimal( "6.0" ),
-				new BigDecimal( "6.5" )
-		};
-        
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], 8
-			} );
-			Object ret = ac.getValue( );
-			assertTrue( ret instanceof BigDecimal );
-			assertTrue( expectResults[i].compareTo( (BigDecimal) ret ) == 0 );
-		}
-		ac.finish( );
-        
+                new BigDecimal( "1.0" ),
+                new BigDecimal( "2.0" ),
+                new BigDecimal( "3.0" ),
+                new BigDecimal( "3.25" ),
+                new BigDecimal( "3.8" ),
+                new BigDecimal( "4.5" ),
+                new BigDecimal( "4.285714285714285714285714285714286" ),
+                new BigDecimal( "4.25" ),
+                new BigDecimal( "4.75" ),
+                new BigDecimal( "5.25" ),
+                new BigDecimal( "5.75" ),
+                new BigDecimal( "6.5" ),
+                new BigDecimal( "6.25" ),
+                new BigDecimal( "6.0" ),
+                new BigDecimal( "6.5" )
+        };
+
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], 8
+            } );
+            Object ret = ac.getValue( );
+            assertTrue( ret instanceof BigDecimal );
+            assertTrue( expectResults[i].compareTo( (BigDecimal) ret ) == 0 );
+        }
+        ac.finish( );
+
     }
-    
+
     public void testTotalAveDate() throws Exception
     {
-                                
+
         IAggrFunction ag = buildInAggrFactory.getAggregation("ave");
         Accumulator ac = ag.newAccumulator();
         ac.start();
@@ -1415,7 +1487,7 @@ public class TotalTest extends TestCase
         assertEquals(new Date(4000000L), ac.getValue());
 
     }
-    
+
     public void testTotalMinDate() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("min");
@@ -1429,7 +1501,7 @@ public class TotalTest extends TestCase
         assertEquals(new Date(1000000L), ac.getValue());
 
     }
-    
+
     public void testTotalMaxString() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("max");
@@ -1442,7 +1514,7 @@ public class TotalTest extends TestCase
         ac.finish();
         assertEquals("test", ac.getValue());
     }
-    
+
     public void testTotalMinString() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("min");
@@ -1455,7 +1527,7 @@ public class TotalTest extends TestCase
         ac.finish();
         assertEquals("aggregation", ac.getValue());
     }
-    
+
     public void testTotalTop() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("isTopN");
@@ -1465,14 +1537,14 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
             ac.onRow(new Double[]{new Double(doubleArray1[i]), new Double(5)});
         }
         ac.finish();
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -1480,7 +1552,7 @@ public class TotalTest extends TestCase
             assertEquals(new Boolean(doubleArray1TopBottom[i]), ac.getValue());
         }
         ac.finish();
-        
+
         ag = buildInAggrFactory.getAggregation("isTopN");
         ac = ag.newAccumulator();
         assertEquals(IBuildInAggregation.TOTAL_TOP_N_FUNC, ag.getName());
@@ -1488,38 +1560,38 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
-        	ac.onRow(new Double[]{new Double(6), new Double(5)});
+            ac.onRow(new Double[]{new Double(6), new Double(5)});
         ac.finish();
         ac.start();
-    	ac.onRow(new Double[]{new Double(6), new Double(5)});
-    	ac.finish();
- 
-        
-       	assertEquals(new Boolean(true), ac.getValue());
-       	
+        ac.onRow(new Double[]{new Double(6), new Double(5)});
+        ac.finish();
+
+
+           assertEquals(new Boolean(true), ac.getValue());
+
         // test Total.ISTOPN() for BigDecimal data
         ac = ag.newAccumulator();
         ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 5 )
-			} );
-		}
-		ac.finish( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 5 )
-			} );
-			assertEquals( new Boolean( doubleArray1TopBottom[i] ),
-					ac.getValue( ) );
-		}
-		ac.finish( );
-      	     
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 5 )
+            } );
+        }
+        ac.finish( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 5 )
+            } );
+            assertEquals( new Boolean( doubleArray1TopBottom[i] ),
+                    ac.getValue( ) );
+        }
+        ac.finish( );
+
         ag = buildInAggrFactory.getAggregation("isTopNPercent");
         ac = ag.newAccumulator();
         assertEquals(IBuildInAggregation.TOTAL_TOP_PERCENT_FUNC, ag.getName());
@@ -1527,7 +1599,7 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -1541,29 +1613,29 @@ public class TotalTest extends TestCase
             assertEquals(new Boolean(doubleArray1TopBottom[i]),ac.getValue());
         }
         ac.finish();
-        
+
         // test Total.ISTOPNPercent() for BigDecimal data
         ac = ag.newAccumulator();
         ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 33 )
-			} );
-		}
-		ac.finish( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 33 )
-			} );
-			assertEquals( new Boolean( doubleArray1TopBottom[i] ),
-					ac.getValue( ) );
-		}
-		ac.finish( );
-        
-        
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 33 )
+            } );
+        }
+        ac.finish( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 33 )
+            } );
+            assertEquals( new Boolean( doubleArray1TopBottom[i] ),
+                    ac.getValue( ) );
+        }
+        ac.finish( );
+
+
         ag = buildInAggrFactory.getAggregation("isTopNPercent");
         ac = ag.newAccumulator();
         assertEquals(IBuildInAggregation.TOTAL_TOP_PERCENT_FUNC, ag.getName());
@@ -1571,21 +1643,21 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         ac.onRow(new Double[]{new Double(6), new Double(100)});
         ac.finish();
         ac.start();
         ac.onRow(new Double[]{new Double(6), new Double(100)});
         ac.finish();
-        
+
         assertEquals(new Boolean(true), ac.getValue());
     }
-    
+
     /**
-	 * test top n aggregation with null values. Note: the null values will not
-	 * be considered as the candidates for the result.
-	 */
+     * test top n aggregation with null values. Note: the null values will not
+     * be considered as the candidates for the result.
+     */
     public void testTotalTop2() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("isTopN");
@@ -1595,14 +1667,14 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
             ac.onRow(new Double[]{doubleArray3[i], new Double(2)});
         }
         ac.finish();
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1611,7 +1683,7 @@ public class TotalTest extends TestCase
         }
         ac.finish();
     }
-    
+
     public void testTotalBottom() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("isBottomN");
@@ -1621,7 +1693,7 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -1632,31 +1704,31 @@ public class TotalTest extends TestCase
         for(int i=0; i<doubleArray1.length; i++)
         {
             ac.onRow(new Double[]{new Double(doubleArray1[i]), new Double(10)});
-        	assertEquals(new Boolean(!doubleArray1TopBottom[i]), ac.getValue());
+            assertEquals(new Boolean(!doubleArray1TopBottom[i]), ac.getValue());
         }
         ac.finish();
-        
+
         // test Total.ISBottomN() for BigDecimal data
-		ac = ag.newAccumulator( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 10 )
-			} );
-		}
-		ac.finish( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 10 )
-			} );
-			assertEquals( new Boolean( !doubleArray1TopBottom[i] ),
-					ac.getValue( ) );
-		}
-		ac.finish( );
-        
+        ac = ag.newAccumulator( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 10 )
+            } );
+        }
+        ac.finish( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 10 )
+            } );
+            assertEquals( new Boolean( !doubleArray1TopBottom[i] ),
+                    ac.getValue( ) );
+        }
+        ac.finish( );
+
         ag = buildInAggrFactory.getAggregation("isBottomNPercent");
         ac = ag.newAccumulator();
         assertEquals(IBuildInAggregation.TOTAL_BOTTOM_PERCENT_FUNC, ag.getName());
@@ -1664,14 +1736,14 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertTrue(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
             ac.onRow(new Double[]{new Double(doubleArray1[i]), new Double(66)});
         }
         ac.finish();
-        
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -1679,29 +1751,29 @@ public class TotalTest extends TestCase
             assertEquals(new Boolean(!doubleArray1TopBottom[i]), ac.getValue());
         }
         ac.finish();
-        
+
         // test Total.ISBottomNPercent() for BigDecimal data
-		ac = ag.newAccumulator( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 66 )
-			} );
-		}
-		ac.finish( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 66 )
-			} );
-			assertEquals( new Boolean( !doubleArray1TopBottom[i] ),
-					ac.getValue( ) );
-		}
-		ac.finish( );
+        ac = ag.newAccumulator( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 66 )
+            } );
+        }
+        ac.finish( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 66 )
+            } );
+            assertEquals( new Boolean( !doubleArray1TopBottom[i] ),
+                    ac.getValue( ) );
+        }
+        ac.finish( );
     }
-    
+
     public void testTotalRank() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("rank");
@@ -1711,14 +1783,14 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertFalse(!ag.getParameterDefn()[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
             ac.onRow(new Object[]{doubleArray3[i], new Boolean(false)});
         }
         ac.finish();
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1726,10 +1798,10 @@ public class TotalTest extends TestCase
             assertEquals(new Integer(doubleArray3RankDec[i]), ac.getValue());
         }
         ac.finish();
-        
+
         ag = buildInAggrFactory.getAggregation("rank");
         ac = ag.newAccumulator();
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1740,31 +1812,31 @@ public class TotalTest extends TestCase
         for(int i=0; i<doubleArray3.length; i++)
         {
             ac.onRow(new Object[]{doubleArray3[i], new Integer(1)});
-        	assertEquals(new Integer(doubleArray3RankAsc[i]), ac.getValue());
+            assertEquals(new Integer(doubleArray3RankAsc[i]), ac.getValue());
         }
         ac.finish();
-        
-    	// test Total.rank() for BigDecimal data
-		ac = ag.newAccumulator( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Boolean( true )
-			} );
-		}
-		ac.finish( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 0 )
-			} );
-			assertEquals( new Integer( bigDecimalRankAsc[i] ), ac.getValue( ) );
-		}
-		ac.finish( );
+
+        // test Total.rank() for BigDecimal data
+        ac = ag.newAccumulator( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Boolean( true )
+            } );
+        }
+        ac.finish( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 0 )
+            } );
+            assertEquals( new Integer( bigDecimalRankAsc[i] ), ac.getValue( ) );
+        }
+        ac.finish( );
      }
-    
+
     public void testTotalPercentRank() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("percentrank");
@@ -1773,7 +1845,7 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.RUNNING_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1787,29 +1859,29 @@ public class TotalTest extends TestCase
             assertEquals(doubleArray3PercentRank[i], new Double((((Double)ac.getValue()).doubleValue( )*1000)).intValue( ));
         }
         ac.finish();
-        
+
         // test Total.PERCENTRANK() for BigDecimal data
-		ac = ag.newAccumulator( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-			assertEquals( bigDecimalPercentRank[i],
-					new Double( ( ( (Double) ac.getValue( ) ).doubleValue( ) * 1000 ) ).intValue( ) );
-		}
-		ac.finish( );
+        ac = ag.newAccumulator( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+            assertEquals( bigDecimalPercentRank[i],
+                    new Double( ( ( (Double) ac.getValue( ) ).doubleValue( ) * 1000 ) ).intValue( ) );
+        }
+        ac.finish( );
      }
-    
+
     public void testTotalPercentSum() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("percentsum");
@@ -1818,66 +1890,66 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.RUNNING_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
             ac.onRow(new Object[]{doubleArray3[i]});
         }
         ac.finish();
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
             ac.onRow( new Object[]{
-				doubleArray3[i]
-			} );
-			assertEquals( doubleArray3PercentSum[i] == null ? new Integer( 0 )
-					: doubleArray3PercentSum[i],
-					new Integer( (int) ( new Double( ac.getValue( ).toString( ) ).doubleValue( ) * 1000 ) ) );
+                doubleArray3[i]
+            } );
+            assertEquals( doubleArray3PercentSum[i] == null ? new Integer( 0 )
+                    : doubleArray3PercentSum[i],
+                    new Integer( (int) ( new Double( ac.getValue( ).toString( ) ).doubleValue( ) * 1000 ) ) );
         }
         ac.finish();
         //DataException should be throwed if the parameter is non-numeric
         ac.start( );
-		for ( int i = 0; i < str2.length; i++ )
-		{
-			try
-			{
-				ac.onRow( new Object[]{
-					str2[i]
-				} );
-				fail( );
-			}
-			catch ( DataException e )
-			{
-			}
-		}
-		ac.finish( );
-		
-		// test Total.PERCENTSUM() for BigDecimal data
-		ac = ag.newAccumulator( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-		}
-		ac.finish( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				bigDecimalArray[i]
-			} );
-			Object ret = ac.getValue( );
-			assertTrue( ret instanceof BigDecimal );
-			assertEquals( bigDecimalPercentSum[i],
-					new Double( ( ( (Number) ret ).doubleValue( ) * 1000 ) ).intValue( ) );
-		}
-		ac.finish( );
+        for ( int i = 0; i < str2.length; i++ )
+        {
+            try
+            {
+                ac.onRow( new Object[]{
+                    str2[i]
+                } );
+                fail( );
+            }
+            catch ( DataException e )
+            {
+            }
+        }
+        ac.finish( );
+
+        // test Total.PERCENTSUM() for BigDecimal data
+        ac = ag.newAccumulator( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+        }
+        ac.finish( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                bigDecimalArray[i]
+            } );
+            Object ret = ac.getValue( );
+            assertTrue( ret instanceof BigDecimal );
+            assertEquals( bigDecimalPercentSum[i],
+                    new Double( ( ( (Number) ret ).doubleValue( ) * 1000 ) ).intValue( ) );
+        }
+        ac.finish( );
     }
-    
+
     public void testTotalPercentile() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("percentile");
@@ -1887,7 +1959,7 @@ public class TotalTest extends TestCase
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
         assertFalse(ag.getParameterDefn( )[1].isOptional());
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1896,7 +1968,7 @@ public class TotalTest extends TestCase
         ac.finish();
         Object value = ac.getValue( );
         assertEquals(value, new Double( 10.0 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1905,7 +1977,7 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 10 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1914,7 +1986,7 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 300 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1923,7 +1995,7 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 70 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -1932,9 +2004,9 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 17.5 ));
-        
+
         try{
-        	 ac.start();
+             ac.start();
              for(int i=0; i<doubleArray3.length; i++)
              {
                  ac.onRow(new Object[]{doubleArray3[i], new Double(-1)});
@@ -1943,46 +2015,46 @@ public class TotalTest extends TestCase
              fail("should not arrive here");
         }catch ( DataException e )
         {}
-        
+
         //test the parameter boundary, which should be not less than 0 and greater than 4 
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
-        	try
-			{
-        		ac.onRow(new Object[]{doubleArray3[i], new Double(-0.9)});
-        		fail();
-			}
-			catch ( DataException e )
-			{
-			}
-			
-			try
-			{
-        		ac.onRow(new Object[]{doubleArray3[i], new Double(4.1)});
-        		fail();
-			}
-			catch ( DataException e )
-			{
-			}
+            try
+            {
+                ac.onRow(new Object[]{doubleArray3[i], new Double(-0.9)});
+                fail();
+            }
+            catch ( DataException e )
+            {
+            }
+
+            try
+            {
+                ac.onRow(new Object[]{doubleArray3[i], new Double(4.1)});
+                fail();
+            }
+            catch ( DataException e )
+            {
+            }
         }
         ac.finish();
-        
+
         // test Total.Percentile() for BigDecimal data
-		ac = ag.newAccumulator( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 0.1 )
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( "3.0" ).compareTo( (BigDecimal) ret ) == 0 );
+        ac = ag.newAccumulator( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 0.1 )
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( "3.0" ).compareTo( (BigDecimal) ret ) == 0 );
      }
-    
+
     public void testTotalQuartile() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory.getAggregation("quartile");
@@ -1991,8 +2063,8 @@ public class TotalTest extends TestCase
         assertEquals(IAggrFunction.SUMMARY_AGGR, ag.getType());
         assertEquals(2, ag.getParameterDefn().length);
         assertTrue(!ag.getParameterDefn()[0].isOptional());
-		assertFalse( ag.getParameterDefn( )[1].isOptional( ) );
-        
+        assertFalse( ag.getParameterDefn( )[1].isOptional( ) );
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -2001,7 +2073,7 @@ public class TotalTest extends TestCase
         ac.finish();
         Object value = ac.getValue( );
         assertEquals(value, new Double( 10 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -2010,7 +2082,7 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 12.5 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -2019,7 +2091,7 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 30 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -2028,7 +2100,7 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 85 ));
-        
+
         ac.start();
         for(int i=0; i<doubleArray3.length; i++)
         {
@@ -2037,9 +2109,9 @@ public class TotalTest extends TestCase
         ac.finish();
         value = ac.getValue( );
         assertEquals(value, new Double( 300 ));
-        
+
         try{
-       	 ac.start();
+            ac.start();
             for(int i=0; i<doubleArray3.length; i++)
             {
                 ac.onRow(new Object[]{doubleArray3[i], new Double(5)});
@@ -2049,20 +2121,20 @@ public class TotalTest extends TestCase
        }catch ( DataException e )
        {}
        // test Total.Quartile() for BigDecimal data
-		ac = ag.newAccumulator( );
-		ac.start( );
-		for ( int i = 0; i < bigDecimalArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-					bigDecimalArray[i], new Double( 1 )
-			} );
-		}
-		ac.finish( );
-		Object ret = ac.getValue( );
-		assertTrue( ret instanceof BigDecimal );
-		assertTrue( new BigDecimal( "4.0" ).compareTo( (BigDecimal) ret ) == 0 );
+        ac = ag.newAccumulator( );
+        ac.start( );
+        for ( int i = 0; i < bigDecimalArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                    bigDecimalArray[i], new Double( 1 )
+            } );
+        }
+        ac.finish( );
+        Object ret = ac.getValue( );
+        assertTrue( ret instanceof BigDecimal );
+        assertTrue( new BigDecimal( "4.0" ).compareTo( (BigDecimal) ret ) == 0 );
      }
-    
+
     public void testTotalRunningCount() throws Exception
     {
         IAggrFunction ag = buildInAggrFactory .getAggregation("runningcount");
@@ -2070,7 +2142,7 @@ public class TotalTest extends TestCase
         assertEquals(IBuildInAggregation.TOTAL_RUNNINGCOUNT_FUNC, ag.getName());
         assertEquals(IAggrFunction.RUNNING_AGGR, ag.getType());
         assertEquals(1, ag.getParameterDefn().length);
-               
+
         ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
@@ -2078,24 +2150,24 @@ public class TotalTest extends TestCase
             assertEquals( new Integer(i+1), ac.getValue());
         }
         ac.finish();
-        
-        ac.start( );
-		for ( int i = 0; i < anyObjectArray.length; i++ )
-		{
-			ac.onRow( new Object[]{
-				anyObjectArray[i]
-			} );
-		}
-		ac.finish( );
-		assertEquals( new Integer( 5 ), ac.getValue( ) );
 
-		ac.start( );
-		for ( int i = 0; i < anyObjectArray.length; i++ )
-		{
-			ac.onRow( null );
-		}
-		ac.finish( );
-		assertEquals( new Integer( 8 ), ac.getValue( ) );
-	}
-    
+        ac.start( );
+        for ( int i = 0; i < anyObjectArray.length; i++ )
+        {
+            ac.onRow( new Object[]{
+                anyObjectArray[i]
+            } );
+        }
+        ac.finish( );
+        assertEquals( new Integer( 5 ), ac.getValue( ) );
+
+        ac.start( );
+        for ( int i = 0; i < anyObjectArray.length; i++ )
+        {
+            ac.onRow( null );
+        }
+        ac.finish( );
+        assertEquals( new Integer( 8 ), ac.getValue( ) );
+    }
+
 }

--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
@@ -487,7 +487,7 @@ public class TotalTest extends TestCase
         
         ac.start();
         ac.finish();
-        assertEquals(new Double(0.0), ac.getValue());
+        assertEquals(new BigDecimal("0"), ac.getValue());
         
         ac.start();
         try
@@ -528,7 +528,7 @@ public class TotalTest extends TestCase
 			} );
 		}
 		ac.finish( );
-		assertEquals( new BigDecimal( "82.0" ), ac.getValue( ) );
+		assertEquals( new BigDecimal( "82" ), ac.getValue( ) );
     }
 
     public void testTotalRunningSum() throws Exception

--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
@@ -487,7 +487,7 @@ public class TotalTest extends TestCase
         
         ac.start();
         ac.finish();
-        assertEquals(new BigDecimal("0"), ac.getValue());
+        assertEquals(new Double(0.0), ac.getValue());
         
         ac.start();
         try
@@ -528,7 +528,7 @@ public class TotalTest extends TestCase
 			} );
 		}
 		ac.finish( );
-		assertEquals( new BigDecimal( "82" ), ac.getValue( ) );
+		assertEquals( new BigDecimal( "82.0" ), ac.getValue( ) );
     }
 
     public void testTotalRunningSum() throws Exception


### PR DESCRIPTION
Fixed issue with Double.NaN and Double.Infinity handling in TotalSum. In particular, this solves NumberFormatException thrown when NaN is encountered and some side effects caused by using NaN/Infinity in operations involving Double and BigDecimal.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>