### PR TITLE
Implemented Double to Date conversion in DataTypeUtil

### DIFF
--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/data/DataTypeUtil.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/data/DataTypeUtil.java
@@ -479,6 +479,14 @@ public final class DataTypeUtil
 		{
 			return toDate( (String) source );
 		}
+		else if ( source instanceof Double )
+		{
+			// Rounding Double to the nearest Long.
+			// This should be a relatively safe operation since this type
+			// of conversion is usually done for representing aggregate
+			// function results as Date.
+			return new Date( Math.round( (Double) source ) );
+		}
 		else
 		{
 			throw new CoreException(

--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/aggregation/TotalTest.java
@@ -705,6 +705,14 @@ public class TotalTest extends TestCase
         assertTrue(!ag.getParameterDefn()[0].isOptional());
 
         ac.start();
+        for ( int i = 0; i < dates.length; i++ )
+        {
+            ac.onRow( new Object[]{dates[i]} );
+        }
+        ac.finish();
+        assertEquals( 2500000D, ac.getValue() );
+
+        ac.start();
         for(int i=0; i<doubleArray1.length; i++)
         {
             ac.onRow(new Double[]{new Double(doubleArray1[i])});


### PR DESCRIPTION
Recent aggregate functions/calculators enhancement caused some aggregate
functions result to be Double even for Date operands.
Also added a unit test for AVE(Date).

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>