### PR TITLE
Bugzilla 490551 UI depends on obsolete eclipse class.

### DIFF
--- a/UI/org.eclipse.birt.report.debug.ui/src/org/eclipse/birt/report/debug/ui/launching/ReportAdvancedLauncherTab.java
+++ b/UI/org.eclipse.birt.report.debug.ui/src/org/eclipse/birt/report/debug/ui/launching/ReportAdvancedLauncherTab.java
@@ -38,12 +38,12 @@ import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
 import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.internal.core.plugin.WorkspacePluginModelBase;
 import org.eclipse.pde.internal.ui.PDELabelProvider;
 import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.pde.internal.ui.PDEPluginImages;
-import org.eclipse.pde.internal.ui.elements.DefaultContentProvider;
 import org.eclipse.pde.internal.ui.elements.NamedElement;
 import org.eclipse.pde.internal.ui.util.SWTUtil;
 import org.eclipse.pde.internal.ui.wizards.ListUtil;
@@ -85,7 +85,7 @@ public class ReportAdvancedLauncherTab extends AbstractLauncherTab implements
 	private Button fSelectAllButton;
 	private Button fDeselectButton;
 
-	class PluginContentProvider extends DefaultContentProvider implements
+	class PluginContentProvider implements
 			ITreeContentProvider
 	{
 
@@ -132,6 +132,16 @@ public class ReportAdvancedLauncherTab extends AbstractLauncherTab implements
 		{
 			// return ( new Object[]{fWorkspacePlugins} );
 			return fWorkspacePlugins;
+		}
+
+		@Override
+		public void dispose()
+		{
+		}
+
+		@Override
+		public void inputChanged(Viewer arg0, Object arg1, Object arg2)
+		{
 		}
 
 	}

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/utility/ParameterAccessor.java
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/utility/ParameterAccessor.java
@@ -716,7 +716,7 @@ public class ParameterAccessor
 			title = BirtResources.getMessage( ResourceConstants.BIRT_VIEWER_TITLE );
 		}
 
-		return htmlEncode( title );
+		return title;
 	}
 
 	/**
@@ -971,6 +971,16 @@ public class ParameterAccessor
 
 		// Use icu4j to normalize the locale string
 		ULocale ulocale = new ULocale( locale );
+
+		// In case locale string has garbage characters from xss attack
+		// We ignore the locale if it is not one of the recognized available locales
+		ULocale[] availableLocales = ULocale.getAvailableLocales( );
+		List<ULocale> list = Arrays.asList( availableLocales );
+		if ( !list.contains( ulocale ) )
+		{
+			return null;
+		}
+
 		return ulocale.toLocale( );
 	}
 

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/layout/FramesetFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/layout/FramesetFragment.jsp
@@ -38,9 +38,9 @@
 	Viewer root fragment
 -----------------------------------------------------------------------------%>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<HTML lang="<%= attributeBean.getLanguage() %>">
+<HTML lang="<%= ParameterAccessor.htmlEncode( attributeBean.getLanguage() ) %>">
 	<HEAD>
-		<TITLE><%= attributeBean.getReportTitle( ) %></TITLE>
+		<TITLE><%= ParameterAccessor.htmlEncode( attributeBean.getReportTitle( ) ) %></TITLE>
 		<BASE href="<%= baseHref %>" >
 		
 		<META HTTP-EQUIV="Content-Type" CONTENT="text/html; CHARSET=utf-8">
@@ -156,7 +156,7 @@
 						<TR>
 							<TD WIDTH="3px"/>
 							<TD>
-								<B><%= attributeBean.getReportTitle( ) %>
+								<B><%= ParameterAccessor.htmlEncode( attributeBean.getReportTitle( ) ) %>
 								</B>
 							</TD>
 							<TD ALIGN='right'>

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/layout/RequesterFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/layout/RequesterFragment.jsp
@@ -34,7 +34,7 @@
 %>
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<HTML lang="<%= attributeBean.getLanguage() %>">
+<HTML lang="<%= ParameterAccessor.htmlEncode( attributeBean.getLanguage() ) %>">
 	<HEAD>
 		<TITLE>PARAMETER SELECTION PAGE</TITLE>
 		<BASE href="<%= baseHref %>" >

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/layout/RunFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/layout/RunFragment.jsp
@@ -38,9 +38,9 @@
 	Viewer run fragment
 -----------------------------------------------------------------------------%>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<HTML lang="<%= attributeBean.getLanguage() %>">
+<HTML lang="<%= ParameterAccessor.htmlEncode( attributeBean.getLanguage() ) %>">
 	<HEAD>
-		<TITLE><%= attributeBean.getReportTitle( ) %></TITLE>
+		<TITLE><%= ParameterAccessor.htmlEncode( attributeBean.getReportTitle( ) ) %></TITLE>
 		<BASE href="<%= baseHref %>" >
 		
 		<META HTTP-EQUIV="Content-Type" CONTENT="text/html; CHARSET=utf-8">


### PR DESCRIPTION
DefaultContentProvider was removed in Neon causing compile error.

This class had only empty methods to satisfy the interface.  So, the solution is to simply move these 2 empty methods into the class ReportAdvancedLauncherTab.PluginContentProvider.

Signed-off-by: Carl Thronson <cthronson@actuate.com>