### PR TITLE
Bugzilla 483851 - Recent versions of BIRT/Eclipse show a blank pie chart

### DIFF
--- a/chart/org.eclipse.birt.chart.device.swt/src/org/eclipse/birt/chart/device/swt/SwtRendererImpl.java
+++ b/chart/org.eclipse.birt.chart.device.swt/src/org/eclipse/birt/chart/device/swt/SwtRendererImpl.java
@@ -1969,6 +1969,15 @@ public class SwtRendererImpl extends DeviceAdapter
 		{
 			getDisplayServer( ).setDpiResolution( ( (Integer) oValue ).intValue( ) );
 		}
+		else if ( sProperty.equals( IDeviceRenderer.EXPECTED_BOUNDS ) )
+		{
+			Bounds bo = (Bounds)oValue;
+			int x = (int)Math.round( bo.getLeft( ) );
+			int y = (int)Math.round( bo.getTop( ) );
+			int width = (int)Math.round( bo.getWidth( ) );
+			int height = (int)Math.round( bo.getHeight( ) );
+			this._gc.setClipping( x, y, width, height );
+		}
 	}
 
 	/**


### PR DESCRIPTION
with Eclipse MAT.

In the setProperty method of the SWT renderer implementation, check for
sProperty equals IDeviceRenderer.EXPECTED_BOUNDS, and if so, set clipping
on the graphics context.

Signed-off-by: Carl Thronson <cthronson@actuate.com>