### PR TITLE
Add SourceReferences to plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 		<Replace_By_Date>v${maven.build.timestamp}</Replace_By_Date>
 		<!--<build>v${maven.build.timestamp}</build>-->
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+		<tycho.scmUrl>scm:git:https://github.com/eclipse/birt.git</tycho.scmUrl>
 	</properties>
 
 	<!-- make release builds in particular quicker and more reliable -->
@@ -209,7 +210,17 @@
 						<archive>
 						  <addMavenDescriptor>false</addMavenDescriptor>
 						</archive>
+						<sourceReferences>
+							<generate>true</generate>
+						</sourceReferences>
 					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.eclipse.tycho.extras</groupId>
+							<artifactId>tycho-sourceref-jgit</artifactId>
+							<version>${tycho.version}</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho.extras</groupId>


### PR DESCRIPTION
This allows the user to clone and checkout the source code of Birt
without knowing where the repository is. See:
https://wiki.eclipse.org/PDE/UI/SourceReferences

One use case is to right-click on a plug-in under the Plug-in
dependencies in Package Explorer view and select Import from Repository.
Note that for this EGit needs to be installed.

Another use case is to go to
File > Import > Plug-In Development > Plug-ins and Fragments then select
Projects from a repository.

What this patch does is to let Tycho generate the source references in
the MANIFEST.MF of the built jars. So to test this patch, one can build
the update site locally and inspect the manifests of the (non-source)
jars.

Also see:
http://download.eclipse.org/releases/staging/buildInfo/reporeports/reports/esdata.txt

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>