### PR TITLE
fix certain report design that does not convert properly in PPTX

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/writer/Presentation.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/writer/Presentation.java
@@ -52,6 +52,8 @@ public class Presentation extends Component
 
 	private static final String TAG_SLIDE_MASTER_ID_LIST = "p:sldMasterIdLst";
 	
+	public static final int MAX_SLIDE_HEIGHT = 51206400;
+	
 	private final PPTXBookmarkManager bmkmanager;
 
 	private int slideMasterId = 1;
@@ -181,12 +183,16 @@ public class Presentation extends Component
 		writer.openTag( TAG_SLIDE_SZ );
 		// Set default page size to A4.
 		if ( width == 0 )
-		{
 			width = 612;
+		if ( height == 0 )
 			height = 792;
-		}
+
+
 		long convertedWidth = OOXmlUtil.convertPointerToEmus( width );
 		long convertedHeight = OOXmlUtil.convertPointerToEmus( height );
+		
+		if ( convertedHeight > MAX_SLIDE_HEIGHT )
+			convertedHeight = MAX_SLIDE_HEIGHT;
 		writer.attribute( TAG_CX, convertedWidth );
 		writer.attribute( TAG_CY, convertedHeight );
 		writer.closeTag( TAG_SLIDE_SZ );

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/util/DimensionUtil.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/util/DimensionUtil.java
@@ -144,6 +144,9 @@ public class DimensionUtil
 			else if ( DesignChoiceConstants.UNITS_PC
 					.equalsIgnoreCase( fromUnits ) )
 				targetMeasure = measure * POINTS_PER_PICA;
+			else if ( DesignChoiceConstants.UNITS_PX
+					.equalsIgnoreCase( fromUnits ) )
+				targetMeasure = measure * POINTS_PER_INCH / DEFAULT_DPI;
 			else
 				throw new IllegalArgumentException(
 						"\"fromUnits\"" + ILLEGAL_UNIT ); //$NON-NLS-1$


### PR DESCRIPTION
properties given in pixels need to be converted into points, the max height of the slide was reach and it corrupt the slide, so set the boundary

Signed-off-by: sguan <sguan@actuate.com>