### PR TITLE
Synchronized build parent package version

### DIFF
--- a/build/birt-packages/pom.xml
+++ b/build/birt-packages/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build</groupId>
 		<artifactId>org.eclipse.birt.build-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.6.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 

--- a/build/org.eclipse.birt.api/pom.xml
+++ b/build/org.eclipse.birt.api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.birt.build</groupId>
     <artifactId>org.eclipse.birt.build-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.eclipse.birt</groupId>

--- a/build/org.eclipse.birt.p2updatesite/pom.xml
+++ b/build/org.eclipse.birt.p2updatesite/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build</groupId>
 		<artifactId>org.eclipse.birt.build-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.6.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/build/org.eclipse.birt.sdk/pom.xml
+++ b/build/org.eclipse.birt.sdk/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build</groupId>
 		<artifactId>org.eclipse.birt.build-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.6.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	


### PR DESCRIPTION
Updated org.eclipse.birt.build-parent version to 4.6.0-SNAPSHOT in all
subpackages

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>