### PR TITLE
Bug 478548 - fontsConfig.xml is missing system default font paths.

### DIFF
--- a/engine/org.eclipse.birt.report.engine.fonts/fontsConfig.xml
+++ b/engine/org.eclipse.birt.report.engine.fonts/fontsConfig.xml
@@ -178,6 +178,8 @@
 		<path path="/usr/share/fonts/zh_CN/TrueType" />
 		<path path="/usr/share/fonts/zh_TW/TrueType" />
 		<path path="/var/lib/defoma/x-ttcidfont-conf.d/dirs/TrueType" />
+		<path path="/usr/share/fonts/TTF" />
+		<path path="/usr/share/fonts/OTF" />
 	</font-paths>
 <!--
 	For <font-encodings> section,


### PR DESCRIPTION
Signed-off-by: Carl Thronson <cthronson@actuate.com>