### PR TITLE
Remove tycho-surefire dependency on JUnit 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.19.1</version>
 				<configuration>
 					<aggregate>true</aggregate>
 				</configuration>
@@ -372,13 +372,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit3</artifactId>
-						<version>2.18.1</version>
-					</dependency>
-				</dependencies>
 <!-- Exclude integration tests that may hang or cause other occasional delays
 	in integration test. Uncomment the following config block to disable these
 	tests temporarely. -->


### PR DESCRIPTION
Allow tycho-surefire plugin to detect required JUnit runner automatically. Also bumped up surefire-report plugin version to the most current.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>