### PR TITLE
Updated jacoco configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,7 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
@@ -303,6 +304,7 @@
 					</environments>
 				</configuration>
 			</plugin>
+
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
@@ -390,33 +392,44 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.4.201502262128</version>
+				<version>0.7.6.201602180812</version>
 				<executions>
 					<execution>
-						<id>prepare-integration-tests</id>
-						<phase>pre-integration-test</phase>
+						<id>jacoco-prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-prepare-agent-integration</id>
 						<goals>
 							<goal>prepare-agent-integration</goal>
 						</goals>
-						<configuration>
-							<append>true</append>
-							<output>file</output>
-							<destFile>${basedir}/target/coverage/jacoco-integration.exec</destFile>
-						</configuration>
 					</execution>
 					<execution>
-						<id>report-integration</id>
-						<phase>post-integration-test</phase>
+						<id>jacoco-report</id>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-integration</id>
 						<goals>
 							<goal>report-integration</goal>
 						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
 						<configuration>
-							<outputDirectory>${basedir}/target/coverage/reports</outputDirectory>
-							<dataFile>${basedir}/target/coverage/jacoco-integration.exec</dataFile>
+							<rules/>
 						</configuration>
 					</execution>
 				</executions>
 			</plugin>
+
            <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
@@ -447,6 +460,7 @@
 					</execution>
 				</executions>
 			</plugin>
+
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>


### PR DESCRIPTION
Updated jacoco to the most current release version. Also changed jacoco configuration to more generic. This solved the issue with generating coverage report in Jenkins builds.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>