### PR TITLE
Summary: An error to add Cassandra Scripted Data Source.

### DIFF
--- a/data/org.eclipse.birt.me.prettyprint.hector/lib/hector-LICENSE
+++ b/data/org.eclipse.birt.me.prettyprint.hector/lib/hector-LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2010 Ran Tavory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/data/org.eclipse.birt.me.prettyprint.hector/lib/slf4j-license.html
+++ b/data/org.eclipse.birt.me.prettyprint.hector/lib/slf4j-license.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+  <html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+      <meta http-equiv="content-type" content="text/html; charset=iso-8859-1" />
+      <title>SLF4J License</title>
+      <link rel="stylesheet" type="text/css" media="screen" href="css/site.css" />
+    </head>
+    <body>
+      <script type="text/javascript">prefix='';</script>
+      
+      <script src="templates/header.js" type="text/javascript"></script>
+      <div id="left">
+        <script src="templates/left.js" type="text/javascript"></script>
+      </div>
+      <div id="content">
+
+
+  <h1>Licensing terms for SLF4J</h1>
+
+  <p>SLF4J source code and binaries are distributed under the
+  MIT license.
+  </p>
+
+  <div class="source">
+ Copyright (c) 2004-2011 QOS.ch
+ All rights reserved.
+
+ Permission is hereby granted, free  of charge, to any person obtaining
+ a  copy  of this  software  and  associated  documentation files  (the
+ "Software"), to  deal in  the Software without  restriction, including
+ without limitation  the rights to  use, copy, modify,  merge, publish,
+ distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ permit persons to whom the Software  is furnished to do so, subject to
+ the following conditions:
+ 
+ The  above  copyright  notice  and  this permission  notice  shall  be
+ included in all copies or substantial portions of the Software.
+ 
+ THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  </div> 
+
+  <p>These terms are <em>identical</em> to those of the <a
+  href="http://en.wikipedia.org/wiki/MIT_License">MIT License</a>,
+  also called the X License or the X11 License, which is a simple,
+  permissive non-copyleft free software license. It is deemed
+  compatible with virtually all types of licenses, commercial or
+  otherwise. In particular, the Free Software Foundation has declared
+  it compatible with <a
+  href="http://www.fsf.org/licensing/licenses/license-list.html#GPLCompatibleLicenses">
+  GNU GPL</a>. It is also known to be approved by the Apache Software
+  Foundation as compatible with <a
+  href="http://www.apache.org/licenses/">Apache Software License</a>.
+  </p>
+
+
+  <script src="templates/footer.js" type="text/javascript"></script>
+
+</div>
+</body>
+</html>

--- a/data/org.eclipse.birt.me.prettyprint.hector/pom.xml
+++ b/data/org.eclipse.birt.me.prettyprint.hector/pom.xml
@@ -11,4 +11,64 @@
 	<artifactId>org.eclipse.birt.me.prettyprint.hector</artifactId>
 	<version>4.6.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.cassandra</groupId>
+			<artifactId>cassandra-thrift</artifactId>
+			<version>1.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.4</version>
+		</dependency>
+		<dependency>
+			<!-- http://mvnrepository.com/artifact/com.google.guava/guava -->
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>r09</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hectorclient</groupId>
+			<artifactId>hector-core</artifactId>
+			<version>1.1-2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.thrift</groupId>
+			<artifactId>libthrift</artifactId>
+			<version>0.7.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-nop</artifactId>
+			<version>1.6.1</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/../lib</outputDirectory>
+							<includeArtifactIds>cassandra-thrift,commons-lang,guava,hector-core,libthrift,slf4j-api,slf4j-nop</includeArtifactIds>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
When dialog is opened select Cassandra Scripted Data Source. Result. there
is the error message: "Unable to find Hector client library jars to
support Cassandra Scripted Data Source."

Solution: Modify build script to add missing files.
Include dependencies jar files and license in lib folder.

Signed-off-by: Carl Thronson <cthronson@actuate.com>