### PR TITLE
Improve image comparison in chart unit tests

### DIFF
--- a/chart/org.eclipse.birt.chart.tests/META-INF/MANIFEST.MF
+++ b/chart/org.eclipse.birt.chart.tests/META-INF/MANIFEST.MF
@@ -35,7 +35,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.junit,
  org.eclipse.birt.chart.device.pdf,
  org.eclipse.birt.report.model,
- org.eclipse.birt.chart.reportitem
+ org.eclipse.birt.chart.reportitem,
+ org.eclipse.birt.tests.core,
+ org.apache.batik.transcoder,
+ org.apache.xerces;bundle-version="[2.8.0,3.0.0)";resolution:=optional
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: com.ibm.icu.text;version="3.4.4",

--- a/chart/org.eclipse.birt.chart.tests/pom.xml
+++ b/chart/org.eclipse.birt.chart.tests/pom.xml
@@ -11,4 +11,17 @@
 	<artifactId>org.eclipse.birt.chart.tests</artifactId>
 	<version>4.6.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<testSuite>org.eclipse.birt.chart.tests</testSuite>
+					<testClass>org.eclipse.birt.chart.tests.AllTests</testClass>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/render/ImageOutputBaseTest.java
+++ b/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/render/ImageOutputBaseTest.java
@@ -66,7 +66,8 @@ public class ImageOutputBaseTest extends TestCase {
 		Image result =
 			ImageUtil.compare(
 				workspaceDir+File.separator+ImageRenderTest.CONTROLDIR+dirName+File.separator+filename+".png", //$NON-NLS-1$
-				workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".png"); //$NON-NLS-1$
+				workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".png",
+				params); //$NON-NLS-1$
 		if(result != null) {
 			ImageUtil.savePNG(result, workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".diff.png");
 			fail();

--- a/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/render/ImageOutputBaseTest.java
+++ b/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/render/ImageOutputBaseTest.java
@@ -11,12 +11,22 @@
 
 package org.eclipse.birt.chart.tests.device.render;
 
+import java.awt.Image;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.batik.transcoder.TranscoderInput;
+import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.image.PNGTranscoder;
 
 import junit.framework.TestCase;
-
-import org.eclipse.birt.chart.tests.util.FileUtil;
+import utility.ImageUtil;
+import utility.ImageUtil.ImageCompParam;
 
 /**
  * BaseTest is a JUnit test case that will generate image files based on 
@@ -24,7 +34,7 @@ import org.eclipse.birt.chart.tests.util.FileUtil;
  * and then compare the generated files with the expected files.
  */
 public class ImageOutputBaseTest extends TestCase {
-	
+
 	protected File file;
 	protected String dirName;
 	protected String filename;
@@ -45,22 +55,56 @@ public class ImageOutputBaseTest extends TestCase {
 	}
 	
 	public void runTest( ) throws Throwable {
-
 		
-			Png24PrimitiveGen generator2 = new Png24PrimitiveGen(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.INDIR+dirName+File.separator+filename+ImageRenderTest.DRAWEXT), workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".png");//$NON-NLS-1$
-			generator2.generate();
-			generator2.flush();
-			assertTrue(FileUtil.compareFiles(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".png"), new FileInputStream(workspaceDir+File.separator+ImageRenderTest.CONTROLDIR+dirName+File.separator+filename+".png")));//$NON-NLS-1$//$NON-NLS-2$
-			
-			SvgPrimitiveGen generator3 = new SvgPrimitiveGen(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.INDIR+dirName+File.separator+filename+ImageRenderTest.DRAWEXT), workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".svg");//$NON-NLS-1$
-			generator3.generate();
-			generator3.flush();
-			assertTrue(FileUtil.compareFiles(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".svg"), new FileInputStream(workspaceDir+File.separator+ImageRenderTest.CONTROLDIR+dirName+File.separator+filename+".svg")));//$NON-NLS-1$//$NON-NLS-2$
+		Map<ImageCompParam, Integer> params = new HashMap<ImageCompParam, Integer>();
+		params.put(ImageCompParam.TOLERANCE, 4);
 
-//			PdfPrimitiveGen generator4 = new PdfPrimitiveGen(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.INDIR+dirName+File.separator+filename+ImageRenderTest.DRAWEXT), workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".pdf");//$NON-NLS-1$
-//			generator4.generate();
-//			generator4.flush();
-//			assertTrue(FileUtil.compareFiles(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".pdf"), new FileInputStream(workspaceDir+File.separator+ImageRenderTest.CONTROLDIR+dirName+File.separator+filename+".pdf")));//$NON-NLS-1$//$NON-NLS-2$
+		// 1: verify PNG
+		Png24PrimitiveGen generator2 = new Png24PrimitiveGen(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.INDIR+dirName+File.separator+filename+ImageRenderTest.DRAWEXT), workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".png");//$NON-NLS-1$
+		generator2.generate();
+		generator2.flush();
+		Image result =
+			ImageUtil.compare(
+				workspaceDir+File.separator+ImageRenderTest.CONTROLDIR+dirName+File.separator+filename+".png", //$NON-NLS-1$
+				workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".png"); //$NON-NLS-1$
+		if(result != null) {
+			ImageUtil.savePNG(result, workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".diff.png");
+			fail();
+		}
+
+		// 2: verify SVG
+		SvgPrimitiveGen generator3 = new SvgPrimitiveGen(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.INDIR+dirName+File.separator+filename+ImageRenderTest.DRAWEXT), workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".svg"); //$NON-NLS-1$
+		generator3.generate();
+		generator3.flush();
+
+		// convert golden and actual SVG to PNG
+		String[] files = {
+			workspaceDir+File.separator+ImageRenderTest.CONTROLDIR+dirName+File.separator+filename+".svg", //$NON-NLS-1$
+			workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".svg" //$NON-NLS-1$
+		};
+		for(String file: files) {
+			InputStream inStream = new FileInputStream(file);
+			TranscoderInput input = new TranscoderInput( inStream );
+			OutputStream outStream = new FileOutputStream(file + ".png"); //$NON-NLS-1$
+	        TranscoderOutput output = new TranscoderOutput(outStream);
+	        PNGTranscoder converter = new PNGTranscoder();
+	        converter.transcode(input, output);
+	        outStream.flush();
+	        outStream.close();
+		}
+		result =
+			ImageUtil.compare(
+				files[0] + ".png", //$NON-NLS-1$
+				files[1] + ".png"); //$NON-NLS-1$
+		if(result != null) {
+			ImageUtil.savePNG(result, files[1] + ".diff.png"); //$NON-NLS-1$
+			fail();
+		}
+
+//		PdfPrimitiveGen generator4 = new PdfPrimitiveGen(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.INDIR+dirName+File.separator+filename+ImageRenderTest.DRAWEXT), workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".pdf");//$NON-NLS-1$
+//		generator4.generate();
+//		generator4.flush();
+//		assertTrue(FileUtil.compareFiles(new FileInputStream(workspaceDir+File.separator+ImageRenderTest.OUTDIR+dirName+File.separator+filename+".pdf"), new FileInputStream(workspaceDir+File.separator+ImageRenderTest.CONTROLDIR+dirName+File.separator+filename+".pdf")));//$NON-NLS-1$//$NON-NLS-2$
 	}
 }
 

--- a/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/util/FileUtil.java
+++ b/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/util/FileUtil.java
@@ -11,7 +11,15 @@
 
 package org.eclipse.birt.chart.tests.util;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * 
@@ -27,14 +35,26 @@ public class FileUtil {
  * @return true if the contents match; otherwise, false is returned.
  * @throws Exception thrown if io errors occur
  */
+	public static boolean compareFiles(InputStream left, InputStream right, boolean ignoreLineBreaks)
+			throws Exception {
+		
+		int leftChar, rightChar;
+		do {
+			do {
+				leftChar = left.read();
+			} while(ignoreLineBreaks && (leftChar == 0x0D || leftChar == 0x0A));
+			do {
+				rightChar = right.read();
+			} while(ignoreLineBreaks && (rightChar == 0x0D || rightChar == 0x0A));
+			if(leftChar != rightChar) {
+				return false;
+			}
+		} while(leftChar != -1 && rightChar != -1);
+		return true;
+	}
+
 	public static boolean compareFiles(InputStream left, InputStream right)
 			throws Exception {
-		int leftChar = -1;
-		while ((leftChar = left.read()) != -1){
-			if (leftChar != right.read())
-				return false;
-			
-		}
-		return true;
+		return compareFiles(left, right, false);
 	}
 }

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_101039.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_101039.java
@@ -138,7 +138,7 @@ public class Regression_101039 extends ChartTestCase
 	public void test_regression_101039( ) throws Exception
 	{
 		Regression_101039 st = new Regression_101039( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_101855.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_101855.java
@@ -139,7 +139,7 @@ public class Regression_101855 extends ChartTestCase
 	public void test_regression_101855( ) throws Exception
 	{
 		Regression_101855 st = new Regression_101855( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_103787.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_103787.java
@@ -137,7 +137,7 @@ public class Regression_103787 extends ChartTestCase
 	public void test_regression_103787( ) throws Exception
 	{
 		Regression_103787 st = new Regression_103787( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_104472.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_104472.java
@@ -144,7 +144,7 @@ public class Regression_104472 extends ChartTestCase
 	public void test_regression_104472( ) throws Exception
 	{
 		Regression_104472 st = new Regression_104472( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_104627.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_104627.java
@@ -136,7 +136,7 @@ public class Regression_104627 extends ChartTestCase
 	public void test_regression_104627( ) throws Exception
 	{
 		Regression_104627 st = new Regression_104627( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_106126.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_106126.java
@@ -137,7 +137,7 @@ public class Regression_106126 extends ChartTestCase
 	public void test_regression_106126( ) throws Exception
 	{
 		Regression_106126 st = new Regression_106126( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_109622_1.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_109622_1.java
@@ -139,7 +139,7 @@ public class Regression_109622_1 extends ChartTestCase
 	public void test_regression_109622_1( ) throws Exception
 	{
 		Regression_109622_1 st = new Regression_109622_1( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	private void bindGroupingData( Chart chart )

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_109641.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_109641.java
@@ -139,7 +139,7 @@ public class Regression_109641 extends ChartTestCase
 	public void test_regression_109641( ) throws Exception
 	{
 		Regression_109641 st = new Regression_109641( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	private void bindGroupingData( Chart chart )

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_113536.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_113536.java
@@ -142,7 +142,7 @@ public class Regression_113536 extends ChartTestCase
 	public void test_regression_113536( ) throws Exception
 	{
 		new Regression_113536( );
-		assertTrue( this.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( this.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_115433.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_115433.java
@@ -143,7 +143,7 @@ public class Regression_115433 extends ChartTestCase
 	public void test_regression_115433( ) throws Exception
 	{
 		Regression_115433 st = new Regression_115433( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_119411.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_119411.java
@@ -150,7 +150,7 @@ public class Regression_119411 extends ChartTestCase
 	public void test_regression_119411( ) throws Exception
 	{
 		Regression_119411 st = new Regression_119411( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_119805.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_119805.java
@@ -146,7 +146,7 @@ public class Regression_119805 extends ChartTestCase
 	public void test_regression_119805( ) throws Exception
 	{
 		Regression_119805 st = new Regression_119805( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_120557.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_120557.java
@@ -142,7 +142,7 @@ public class Regression_120557 extends ChartTestCase
 	public void test_regression_120557( ) throws Exception
 	{
 		Regression_120557 st = new Regression_120557( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_120919.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_120919.java
@@ -139,7 +139,7 @@ public class Regression_120919 extends ChartTestCase
 	public void test_regression_120919( ) throws Exception
 	{
 		Regression_120919 st = new Regression_120919( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	private void bindGroupingData( Chart chart )

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121383.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121383.java
@@ -139,7 +139,7 @@ public class Regression_121383 extends ChartTestCase
 	public void test_regression_121383( ) throws Exception
 	{
 		Regression_121383 st = new Regression_121383( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121813.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121813.java
@@ -140,7 +140,7 @@ public class Regression_121813 extends ChartTestCase
 	public void test_regression_121813( ) throws Exception
 	{
 		Regression_121813 st = new Regression_121813( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121828.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121828.java
@@ -142,7 +142,7 @@ public class Regression_121828 extends ChartTestCase
 	public void test_regression_121828( ) throws Exception
 	{
 		Regression_121828 st = new Regression_121828( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121831.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121831.java
@@ -141,7 +141,7 @@ public class Regression_121831 extends ChartTestCase
 	public void test_regression_121831( ) throws Exception
 	{
 		Regression_121831 st = new Regression_121831( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121836.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_121836.java
@@ -139,7 +139,7 @@ public class Regression_121836 extends ChartTestCase
 	public void test_regression_121836( ) throws Exception
 	{
 		Regression_121836 st = new Regression_121836( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_122396.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_122396.java
@@ -145,7 +145,7 @@ public class Regression_122396 extends ChartTestCase
 	public void test_regression_122396( ) throws Exception
 	{
 		Regression_122396 st = new Regression_122396( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_122807.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_122807.java
@@ -141,7 +141,7 @@ public class Regression_122807 extends ChartTestCase
 	public void test_regression_122807( ) throws Exception
 	{
 		Regression_122807 st = new Regression_122807( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_123202.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_123202.java
@@ -137,7 +137,7 @@ public class Regression_123202 extends ChartTestCase
 	public void test_regression_123202( ) throws Exception
 	{
 		Regression_123202 st = new Regression_123202( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_123208.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_123208.java
@@ -139,7 +139,7 @@ public class Regression_123208 extends ChartTestCase
 	public void test_regression_123208( ) throws Exception
 	{
 		Regression_123208 st = new Regression_123208( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_123554.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_123554.java
@@ -147,7 +147,7 @@ public class Regression_123554 extends ChartTestCase
 	public void test_regression_123554( ) throws Exception
 	{
 		Regression_123554 st = new Regression_123554( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_128582.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_128582.java
@@ -137,7 +137,7 @@ public class Regression_128582 extends ChartTestCase
 	public void test_regression_128582( ) throws Exception
 	{
 		Regression_128582 st = new Regression_128582( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_131285.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_131285.java
@@ -147,7 +147,7 @@ public class Regression_131285 extends ChartTestCase
 	public void test_regression_131285( ) throws Exception
 	{
 		Regression_131285 st = new Regression_131285( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_131308.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_131308.java
@@ -138,7 +138,7 @@ public class Regression_131308 extends ChartTestCase
 	public void test_regression_131308( ) throws Exception
 	{
 		Regression_131308 st = new Regression_131308( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_132783.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_132783.java
@@ -152,7 +152,7 @@ public class Regression_132783 extends ChartTestCase
 	public void test_regression_132783( ) throws Exception
 	{
 		Regression_132783 st = new Regression_132783( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_133237.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_133237.java
@@ -142,7 +142,7 @@ public class Regression_133237 extends ChartTestCase
 	public void test_regression_133237( ) throws Exception
 	{
 		Regression_133237 st = new Regression_133237( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134309.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134309.java
@@ -152,7 +152,7 @@ public class Regression_134309 extends ChartTestCase
 	public void test_regression_134309( ) throws Exception
 	{
 		Regression_134309 st = new Regression_134309( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134885.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134885.java
@@ -137,7 +137,7 @@ public class Regression_134885 extends ChartTestCase
 	public void test_regression_134885( ) throws Exception
 	{
 		Regression_134885 st = new Regression_134885( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_135814.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_135814.java
@@ -137,7 +137,7 @@ public class Regression_135814 extends ChartTestCase
 	public void test_regression_135814( ) throws Exception
 	{
 		Regression_135814 st = new Regression_135814( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_136841.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_136841.java
@@ -145,7 +145,7 @@ public class Regression_136841 extends ChartTestCase
 	public void test_regression_136841( ) throws Exception
 	{
 		Regression_136841 st = new Regression_136841( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_137166.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_137166.java
@@ -53,7 +53,7 @@ import org.eclipse.birt.report.tests.chart.ChartTestCase;
  * </p>
  * Test description:
  * <p>
- * Chart with have value of 0 and only one row£¬ render the chart, verify if Y
+ * Chart with have value of 0 and only one rowï¿½ï¿½ render the chart, verify if Y
  * Axis tick label is displayed correclty.
  * </p>
  */
@@ -144,7 +144,7 @@ public class Regression_137166 extends ChartTestCase
 	public void test_regression_137166( ) throws Exception
 	{
 		Regression_137166 st = new Regression_137166( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_141214.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_141214.java
@@ -136,7 +136,7 @@ public class Regression_141214 extends ChartTestCase
 	public void test_regression_141214( ) throws Exception
 	{
 		Regression_141214 st = new Regression_141214( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_142685.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_142685.java
@@ -147,7 +147,7 @@ public class Regression_142685 extends ChartTestCase
 	public void test_regression_142685( ) throws Exception
 	{
 		Regression_142685 st = new Regression_142685( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_142689.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_142689.java
@@ -138,7 +138,7 @@ public class Regression_142689 extends ChartTestCase
 	public void test_regression_142689( ) throws Exception
 	{
 		Regression_142689 st = new Regression_142689( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_143105.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_143105.java
@@ -142,7 +142,7 @@ public class Regression_143105 extends ChartTestCase
 	public void test_regression_143105( ) throws Exception
 	{
 		Regression_143105 st = new Regression_143105( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_144845.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_144845.java
@@ -138,7 +138,7 @@ public class Regression_144845 extends ChartTestCase
 	public void test_regression_144845( ) throws Exception
 	{
 		Regression_144845 st = new Regression_144845( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_145473.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_145473.java
@@ -137,7 +137,7 @@ public class Regression_145473 extends ChartTestCase
 	public void test_regression_145473( ) throws Exception
 	{
 		Regression_145473 st = new Regression_145473( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_146308.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_146308.java
@@ -137,7 +137,7 @@ public class Regression_146308 extends ChartTestCase
 	public void test_regression_146308( ) throws Exception
 	{
 		Regression_146308 st = new Regression_146308( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_148308.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_148308.java
@@ -140,7 +140,7 @@ public class Regression_148308 extends ChartTestCase
 	public void test_regression_148308( ) throws Exception
 	{
 		Regression_148308 st = new Regression_148308( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_148393.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_148393.java
@@ -138,7 +138,7 @@ public class Regression_148393 extends ChartTestCase
 	public void test_regression_148393( ) throws Exception
 	{
 		Regression_148393 st = new Regression_148393( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_149936.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_149936.java
@@ -144,7 +144,7 @@ public class Regression_149936 extends ChartTestCase
 	public void test_regression_149936( ) throws Exception
 	{
 		Regression_149936 st = new Regression_149936( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_150240.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_150240.java
@@ -144,7 +144,7 @@ public class Regression_150240 extends ChartTestCase
 	public void test_regression_150240( ) throws Exception
 	{
 		Regression_150240 st = new Regression_150240( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_151575.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_151575.java
@@ -137,7 +137,7 @@ public class Regression_151575 extends ChartTestCase
 	public void test_regression_151575( ) throws Exception
 	{
 		Regression_151575 st = new Regression_151575( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	private void bindGroupingData( Chart chart )

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_152127.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_152127.java
@@ -144,7 +144,7 @@ public class Regression_152127 extends ChartTestCase
 	public void test_regression_152127( ) throws Exception
 	{
 		Regression_152127 st = new Regression_152127( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_152545.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_152545.java
@@ -137,7 +137,7 @@ public class Regression_152545 extends ChartTestCase
 	public void test_regression_152545( ) throws Exception
 	{
 		Regression_152545 st = new Regression_152545( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	private void bindGroupingData( Chart chart )

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_155185.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_155185.java
@@ -131,7 +131,7 @@ public class Regression_155185 extends ChartTestCase
 	public void test_regression_155185( ) throws Exception
 	{
 		Regression_155185 st = new Regression_155185( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_157608.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_157608.java
@@ -139,7 +139,7 @@ public class Regression_157608 extends ChartTestCase
 	public void test_regression_157608( ) throws Exception
 	{
 		Regression_157608 st = new Regression_157608( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_160144.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_160144.java
@@ -148,7 +148,7 @@ public class Regression_160144 extends ChartTestCase {
 
 	public void test_regression_160144() throws Exception {
 		Regression_160144 st = new Regression_160144();
-		assertTrue(st.compareBytes(GOLDEN, OUTPUT));
+		assertTrue(st.compareImages(GOLDEN, OUTPUT));
 	}
 
 	public static final Chart createScatter() {

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_160432.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_160432.java
@@ -156,7 +156,7 @@ public class Regression_160432 extends ChartTestCase
 	public void test_regression_160432( ) throws Exception
 	{
 		Regression_160432 st = new Regression_160432( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_285009.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_285009.java
@@ -187,7 +187,7 @@ public	Regression_285009( )
 	public void test_regression_285009( ) throws Exception
 	{
 		Regression_285009 st = new Regression_285009( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 }
 

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76910.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76910.java
@@ -141,7 +141,7 @@ public class Regression_76910 extends ChartTestCase
 	public void test_regression_76910( ) throws Exception
 	{
 		Regression_76910 st = new Regression_76910( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76963.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76963.java
@@ -142,7 +142,7 @@ public class Regression_76963 extends ChartTestCase
 	public void test_regression_76963( ) throws Exception
 	{
 		Regression_76963 st = new Regression_76963( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_94138.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_94138.java
@@ -149,7 +149,7 @@ public class Regression_94138 extends ChartTestCase
 	public void test_regression_94138( ) throws Exception
 	{
 		Regression_94138 st = new Regression_94138( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_98257.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_98257.java
@@ -143,7 +143,7 @@ public class Regression_98257 extends ChartTestCase
 	public void test_regression_98257( ) throws Exception
 	{
 		Regression_98257 st = new Regression_98257( );
-		assertTrue( st.compareBytes( GOLDEN, OUTPUT ) );
+		assertTrue( st.compareImages( GOLDEN, OUTPUT ) );
 	}
 
 	/**

--- a/testsuites/org.eclipse.birt.tests.core/build.properties
+++ b/testsuites/org.eclipse.birt.tests.core/build.properties
@@ -1,5 +1,6 @@
 bin.includes = META-INF/,\
                about.html,\
+               utility.jar,\
                lib/
 jars.compile.order = utility.jar
 source.utility.jar = src/

--- a/testsuites/org.eclipse.birt.tests.core/src/utility/ImageUtil.java
+++ b/testsuites/org.eclipse.birt.tests.core/src/utility/ImageUtil.java
@@ -1,0 +1,171 @@
+package utility;
+
+import javax.imageio.ImageIO;
+import javax.swing.GrayFilter;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.awt.image.Raster;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ * Perform operations on images and image files: read, save, compare etc. 
+ */
+public class ImageUtil {
+
+	// private constructor
+	private ImageUtil() {
+	}
+
+	public static enum ImageCompParam {
+		XBLOCKS,	// number of blocks by x-axis
+		YBLOCKS,	// number of blocks by y-axis
+		TOLERANCE,	// mismatch tolerance (max difference)
+		STABILIZER,	// algorithm stabilizer value
+		DEBUG		// 1: textual indication of change, 2: difference of factors
+	};
+
+	public static Map<ImageCompParam, Integer> getDefaultCompParams() {
+		Map<ImageCompParam, Integer> params = new HashMap<ImageCompParam, Integer>();
+		params.put(ImageCompParam.XBLOCKS, 20);
+		params.put(ImageCompParam.YBLOCKS, 20);
+		params.put(ImageCompParam.TOLERANCE, 3);
+		params.put(ImageCompParam.STABILIZER, 10);
+		params.put(ImageCompParam.DEBUG, 2);
+		return params;
+	}
+	
+	public static Map<ImageCompParam, Integer> mergeDefaultCompParams(Map<ImageCompParam, Integer> params) {
+		Map<ImageCompParam, Integer> result = getDefaultCompParams();
+		if(params != null) {
+			result.putAll(params);
+		}
+		return result;
+	}
+
+	/*
+	 * Compare actual image generated during test to expected golden result.
+	 * Returns null if there is a match or an image with mismatched blocks marked
+	 * in red if there is no match.
+	 * Algorithm is based on dividing images on number of blocks and comparing
+	 * average weighted brightness in corresponding blocks. The images are converted
+	 * to gray scale for comparison.
+	 */
+	public static Image compare(BufferedImage golden, BufferedImage actual, Map<ImageCompParam, Integer> p) {
+
+		Map<ImageCompParam, Integer> params = mergeDefaultCompParams(p);
+
+		// prepare image for indicating potential mismatched blocks
+		BufferedImage noMatch = imageToBufferedImage(actual);
+		Graphics2D gc = noMatch.createGraphics();
+		gc.setColor(Color.RED);
+
+		// convert to gray images
+		golden = imageToBufferedImage(GrayFilter.createDisabledImage(golden));
+		actual = imageToBufferedImage(GrayFilter.createDisabledImage(actual));
+
+		// get block size
+		int goldenBlockXSize = (int)(golden.getWidth() / params.get(ImageCompParam.XBLOCKS));
+		int goldenBlockYSize = (int)(golden.getHeight() / params.get(ImageCompParam.YBLOCKS));
+		int actualBlockXSize = (int)(actual.getWidth() / params.get(ImageCompParam.XBLOCKS));
+		int actualBlockYSize = (int)(actual.getHeight() / params.get(ImageCompParam.YBLOCKS));
+
+		boolean match = true;
+
+		// traverse and compare respective blocks of both images
+		for (int y = 0; y < params.get(ImageCompParam.YBLOCKS); y++) {
+			if (params.get(ImageCompParam.DEBUG) > 0) System.out.print("|");
+			for (int x = 0; x < params.get(ImageCompParam.XBLOCKS); x++) {
+				int goldenBrightness = getAverageBrightness(golden.getSubimage(x*goldenBlockXSize, y*goldenBlockYSize, goldenBlockXSize - 1, goldenBlockYSize - 1), params);
+				int actualBrightness = getAverageBrightness(actual.getSubimage(x*actualBlockXSize, y*actualBlockYSize, actualBlockXSize - 1, actualBlockYSize - 1), params);
+				int diff = Math.abs(goldenBrightness - actualBrightness);
+				if (diff > params.get(ImageCompParam.TOLERANCE)) {
+					// the difference in a certain region has passed the threshold value
+					// draw an indicator on the change image to show where the change was detected
+					gc.drawRect(x*actualBlockXSize, y*actualBlockYSize, actualBlockXSize - 1, actualBlockYSize - 1);
+					match = false;
+				}
+				if (params.get(ImageCompParam.DEBUG) == 1) System.out.print((diff > params.get(ImageCompParam.TOLERANCE) ? "X" : " "));
+				if (params.get(ImageCompParam.DEBUG) == 2) System.out.print(diff + (x < params.get(ImageCompParam.XBLOCKS) - 1 ? "," : ""));
+			}
+			if (params.get(ImageCompParam.DEBUG) > 0) System.out.println("|");
+		}
+
+		return match ? null : noMatch;
+	}
+	
+	public static Image compare(String golden, String actual) throws IOException {
+		return compare(loadImageFromFile(golden), loadImageFromFile(actual), getDefaultCompParams());
+	}
+
+	public static Image compare(String golden, String actual, Map<ImageCompParam, Integer> params) throws IOException {
+		return compare(loadImageFromFile(golden), loadImageFromFile(actual), params);
+	}
+
+	public static Image compare(Image golden, Image actual, Map<ImageCompParam, Integer> params) {
+		return compare(imageToBufferedImage(golden), imageToBufferedImage(actual), params);
+	}
+
+	/*
+	 * Returns a value indicating the average brightness in the image
+	 */
+	protected static int getAverageBrightness(BufferedImage img, Map<ImageCompParam, Integer> p) {
+		Map<ImageCompParam, Integer> params = mergeDefaultCompParams(p);
+		Raster r = img.getData();
+		int total = 0;
+		for (int y = 0; y < r.getHeight(); y++) {
+			for (int x = 0; x < r.getWidth(); x++) {
+				total += r.getSample(r.getMinX() + x, r.getMinY() + y, 0);
+			}
+		}
+		return (int)(total / ((r.getWidth()/params.get(ImageCompParam.STABILIZER))*(r.getHeight()/params.get(ImageCompParam.STABILIZER))));
+	}
+
+	public static BufferedImage imageToBufferedImage(Image img) {
+		assert img != null;
+		BufferedImage bi = new BufferedImage(img.getWidth(null), img.getHeight(null), BufferedImage.TYPE_INT_RGB);
+		Graphics2D g2 = bi.createGraphics();
+		g2.drawImage(img, null, null);
+		return bi;
+	}
+
+	/*
+	 * Write an image to a file in the specified image format
+	 */
+	public static void saveImageToFile(Image img, String filename, String format) throws IOException {
+		assert img != null;
+		BufferedImage bi = imageToBufferedImage(img);
+	    File outputfile = new File(filename);
+	    ImageIO.write(bi, format, outputfile);
+	}
+
+	public static void saveJPG(Image img, String filename) throws IOException {
+		saveImageToFile(img, filename, "jpg");
+	}
+
+	public static void savePNG(Image img, String filename) throws IOException {
+		saveImageToFile(img, filename, "png");
+	}
+
+	/*
+	 * Read JPEG or other image file into a buffered image
+	 */
+	public static Image loadImageFromFile(String filename) throws IOException {
+		return ImageIO.read(new File(filename));
+	}
+
+
+	public static void main(String[] args) throws IOException {
+		Image ic = compare("C:\\8\\golden.jpg", "C:\\8\\actual.jpg");
+		System.out.println("Match: " + (ic == null));
+		if (ic != null) {
+			savePNG(ic, "C:\\8\\diff.png ");
+		}
+	}
+
+}


### PR DESCRIPTION
Number of tests in /testsuites/org.eclipse.birt.report.tests.chart and /chart/org.eclipse.birt.chart.tests packages may fail on Linux due to actual-to-golden image (JPG, PNG, SVG) comparison is done using byte comparison. The files may look similar visually, but different internally. This is solved as:
* New image comparison utility was implemented to compare image files by comparing average weighted brightness in corresponding blocks. It can also compare images of different sizes. Settings are parameterized. The default settings were confirmed to work in most tests. If the images are found to be different, a difference image is returned with blocks failed validation marked in red.
* Updated failed regression and unit test cases to use the new image comparison where appropriate.
* File comparison utility was updated to (optionally) ignore line breaks for comparing text files created on different platforms.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>