### PR TITLE
Set root parent version to 0.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt-parent</artifactId>
-	<version>4.6.0-SNAPSHOT</version>
+	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>


### PR DESCRIPTION
Set root parent version to 0.0.1 since it's the new single parent
version throughout the POM hierarchy now.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>