### PR TITLE
fix NPE when ODADriverClass not set

### DIFF
--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
@@ -28,7 +28,6 @@ import org.eclipse.birt.report.data.bidi.utils.core.BidiTransform;
 import org.eclipse.birt.report.data.oda.i18n.ResourceConstants;
 import org.eclipse.birt.report.data.oda.jdbc.bidi.BidiCallStatement;
 import org.eclipse.birt.report.data.oda.jdbc.bidi.BidiStatement;
-import org.eclipse.birt.report.data.oda.jdbc.utils.ResourceLocator;
 import org.eclipse.datatools.connectivity.oda.IConnection;
 import org.eclipse.datatools.connectivity.oda.IDataSetMetaData;
 import org.eclipse.datatools.connectivity.oda.IQuery;
@@ -211,7 +210,6 @@ public class Connection implements IConnection
 		String driverClass = connProperties.getProperty( Constants.ODADriverClass );
         String jndiNameUrl = connProperties.getProperty( Constants.ODAJndiName );
 
-        ResourceLocator.resolveConnectionProperties( props, driverClass, this.appContext );
 		try
 		{
 			if ( ( jndiNameUrl == null || jndiNameUrl.trim( ).length( ) == 0 )


### PR DESCRIPTION
works now if reports set ODAJndiName only

if driverClass is null because ODADriverClass is not set the call to:

org.eclipse.birt.report.data.oda.jdbc.utils.ResourceLocator.resolveConnectionProperties

will lead to an NPE in

org.eclipse.birt.report.data.oda.jdbc.utils.JDBCDriverInfoManager.getDriversInfo

Line 57: if( **driverClassName.**equals( info.getDriverClassName( )) )