### PR TITLE
fixes NPE and wrong assumptions for an assert

### DIFF
--- a/data/org.eclipse.birt.report.data.oda.jdbc.tests/test/org/eclipse/birt/report/data/oda/jdbc/ConnectionTest.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.tests/test/org/eclipse/birt/report/data/oda/jdbc/ConnectionTest.java
@@ -175,6 +175,15 @@ public class ConnectionTest {
 		assertFalse( conn.isOpen( ) );
 	}
 
+	@Test
+    public void testJndiConnection( ) throws Exception
+	{
+		Connection conn = TestUtil.openJndiConnection( );
+		assertTrue( conn.isOpen( ) );
+		conn.close( );
+		assertFalse( conn.isOpen( ) );
+	}
+
 	/*
 	 * Class under test for void open(Properties)
 	 */

--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
@@ -187,7 +187,6 @@ public class Connection implements IConnection
 			throws OdaException
 	{
 		assert connProperties != null;
-		assert url != null;
 
 		// Copy connProperties to props; skip property starting with
 		// "oda"; those are properties read by this driver

--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/utils/JDBCDriverInfoManager.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/utils/JDBCDriverInfoManager.java
@@ -52,7 +52,7 @@ public class JDBCDriverInfoManager
 	public JDBCDriverInformation getDriversInfo( String driverClassName )
 	{
 		JDBCDriverInformation[] infos = getDriversInfo( );
-    	for( JDBCDriverInformation info: infos )
+    	if (driverClassName != null) for( JDBCDriverInformation info: infos )
     	{
     		if( driverClassName.equals( info.getDriverClassName( )) )
 			{


### PR DESCRIPTION
NPE in JDBCDriverInfoManager
remove assertion for url != null in Connection
adding test for jndi connection without any other properties

maybe you use the test without the other changes to see that birt has changed its behaviour with jndi name only connection since version 4.4.2 