### PR TITLE
Fixed a pom file, which wasn't well-formed XML

### DIFF
--- a/build/org.eclipse.birt.sdk/pom.xml
+++ b/build/org.eclipse.birt.sdk/pom.xml
@@ -146,33 +146,5 @@
 			 </plugin>
 		 </plugins>
 	 </build>	
-<project>
-	...
-	<build>
-		<plugins>
-			...
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<execution>
-						<phase> <!-- a lifecycle phase --> </phase>
-						<configuration>
-
-							<target unless="maven.test.skip">
-								<echo message="To skip me, just call mvn -Dmaven.test.skip=true"/>
-							</target>
-
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			...
-		</plugins>
-	</build>	
 
 </project>


### PR DESCRIPTION
build/org.eclipse.birt.sdk/pom.xml has an extra <project> block at the bottom. It looks like a copy-paste error and can be removed.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>