### PR TITLE
BIRT-2403 - Setting the display property to 'none'

### DIFF
--- a/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/re/CrosstabReportItemPreparation.java
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/re/CrosstabReportItemPreparation.java
@@ -103,14 +103,10 @@ public class CrosstabReportItemPreparation extends ReportItemPreparationBase
 		for ( MeasureViewHandle mv : crosstab.getAllMeasures( ) )
 		{
 			AggregationCellHandle cell = mv.getCell( );
-			cell.getModelHandle( ).setProperty( hideRow
-					? IStyleModel.HEIGHT_PROP : IStyleModel.WIDTH_PROP,
-					ZERO );
-
-			// If hiding row, have to remove all items in the measure cell and
-			// grand total cell
-			if ( hideRow )
+			
+			if(hideRow)
 			{
+				// Remove all items in the measure cell and grand total cell
 				clearCellContents( cell );
 				clearCellContents( mv.getAggregationCell(
 						cell.getDimensionName(
@@ -119,11 +115,15 @@ public class CrosstabReportItemPreparation extends ReportItemPreparationBase
 						null,
 						null ) );
 			}
+			else
+			{
+				cell.getModelHandle( ).setProperty( IStyleModel.WIDTH_PROP,ZERO);
+			}
 		}
-
-		// If hiding row, have to remove all items in the dimension cell
-		if ( hideRow )
-		{
+		
+		if(hideRow)
+		{		
+			// Remove all items in the dimension cell
 			int dimCount = crosstab
 					.getDimensionCount( ICrosstabConstants.ROW_AXIS_TYPE );
 			for ( int i = 0; i < dimCount; i++ )
@@ -136,7 +136,13 @@ public class CrosstabReportItemPreparation extends ReportItemPreparationBase
 					clearCellContents( level.getCell( ) );
 				}
 			}
+				
+			// Hide measure header to avoid meaningless header
+			handle.setProperty(
+					ICrosstabReportItemConstants.HIDE_MEASURE_HEADER_PROP,
+					true );
 		}
+
 
 		// Set big pageBreakInterval to avoid page break
 		final int NO_PAGE_BREAK = 10000;
@@ -145,18 +151,12 @@ public class CrosstabReportItemPreparation extends ReportItemPreparationBase
 						: ICrosstabConstants.COLUMN_PAGE_BREAK_INTERVAL_PROP,
 				NO_PAGE_BREAK );
 
-		// If hiding row, hide measure header to avoid meaningless header
-		if ( hideRow )
-		{
-			handle.setProperty(
-					ICrosstabReportItemConstants.HIDE_MEASURE_HEADER_PROP,
-					true );
-		}
 
 		// Fixed Layout to avoid white space
 		( (ReportDesignHandle) crosstab.getModuleHandle( ) )
 				.setLayoutPreference(
 						DesignChoiceConstants.REPORT_LAYOUT_PREFERENCE_FIXED_LAYOUT );
+		
 	}
 
 	private void clearCellContents( CrosstabCellHandle cell )
@@ -164,6 +164,8 @@ public class CrosstabReportItemPreparation extends ReportItemPreparationBase
 	{
 		if ( cell != null )
 		{
+			
+			
 			// No outline
 			cell.getModelHandle( ).setProperty(
 					IStyleModel.BORDER_TOP_STYLE_PROP,
@@ -188,13 +190,13 @@ public class CrosstabReportItemPreparation extends ReportItemPreparationBase
 					ZERO );
 			cell.getModelHandle( ).setProperty( IStyleModel.PADDING_RIGHT_PROP,
 					ZERO );
-
 			// No contents
 			for ( Object child : cell.getContents( ) )
 			{
 				if ( child instanceof DesignElementHandle )
 				{
-					( (DesignElementHandle) child ).dropAndClear( );
+					DesignElementHandle designElement = (DesignElementHandle) child;
+					designElement.setProperty(IStyleModel.DISPLAY_PROP, "none");			
 				}
 			}
 		}


### PR DESCRIPTION
BIRT-2403 CrosstabCellHandle returns empty contents after hiding the row
details in Crosstab
Setting the display property to 'none' instead of removing the cell
content

Reported-by: Sathya Thiruvengada
Signed-off-by: aswanib@opentext.com