### PR TITLE
Failed to generate .data file when datadesign includes a dataset with special characters

### DIFF
--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveUtilTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveUtilTest.java
@@ -11,14 +11,13 @@
 
 package org.eclipse.birt.core.archive;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
 public class ArchiveUtilTest
 {
@@ -174,8 +173,10 @@ public class ArchiveUtilTest
         assertEquals( "/%2E%2E%2E", ArchiveUtil.getFilePath( "/..." ) );
         assertEquals( "/%2F/", ArchiveUtil.getFilePath( "//" ) );
         assertEquals( "/%2F/%2F/", ArchiveUtil.getFilePath( "///" ) );
+        assertEquals( "/%2A", ArchiveUtil.getFilePath( "*" ) );
+        assertEquals( "/%40%23%24%25%5E%26%2A%3E", ArchiveUtil.getFilePath( "/@#$%^&*>" ) );
     }
-	
+
 	@Test
     public void testFileToEntry( )
     {
@@ -189,7 +190,17 @@ public class ArchiveUtilTest
 		assertEquals( "/", ArchiveUtil.getEntryName( "/%2F" ) );
 		assertEquals( "//", ArchiveUtil.getEntryName( "/%2F/%2F" ) );
 		assertEquals( "///", ArchiveUtil.getEntryName( "/%2F/%2F/" ) );
+		assertEquals( "/*", ArchiveUtil.getEntryName( "/%2A" ) );
+		assertEquals( "/@#$%^&*>", ArchiveUtil.getEntryName( "/%40%23%24%25%5E%26%2A%3E" ) );
     }
+
+	@Test
+	public void testFolderCreation( )
+	{
+		String EncodedFileName = ArchiveUtil.getFilePath( "/@#$%^&*>" );
+		File createdFile = new File( ARCHIVE_FOLDER + EncodedFileName );
+		assertEquals( EncodedFileName.substring( 1 ), createdFile.getName( ) );
+	}
 
     private void assertEQ( String[] v1, String[] v2 )
     {

--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/archive/ArchiveUtil.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/archive/ArchiveUtil.java
@@ -220,7 +220,13 @@ public class ArchiveUtil
 			{
 				path = path.replaceAll( "\\.", "%2E" ); //$NON-NLS-1$ //$NON-NLS-2$
 			}
-            return path;
+			// handle case /abc*/ where the File Object will remove "*"
+			// unexpectedly by encoding * to %2A
+			if ( path.contains( "*" ) ) //$NON-NLS-1$
+			{
+				path = path.replaceAll( "\\*", "%2A" ); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			return path;
         }
         catch ( UnsupportedEncodingException ex )
         {


### PR DESCRIPTION


Fixed this issue by adding encoding for '*'.
   