### PR TITLE
Add unit test for CoreJavaScriptWrapper and create test suites for entire core package

### DIFF
--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/AllTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/AllTests.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core;
+
+import org.eclipse.birt.core.script.AllScriptTests;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Tests cases run in the build script.
+ */
+
+public class AllTests
+{
+
+	/**
+	 * @return test run in build script
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+		test.addTest( AllScriptTests.suite( ) );
+
+		return test;
+	}
+
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/AllArchiveTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/AllArchiveTests.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.archive;
+
+import org.eclipse.birt.core.archive.cache.FileCacheManagerTest;
+import org.eclipse.birt.core.archive.compound.ArchiveEntryInputStreamTest;
+import org.eclipse.birt.core.archive.compound.ArchiveFileFactoryTest;
+import org.eclipse.birt.core.archive.compound.ArchiveFileTest;
+import org.eclipse.birt.core.archive.compound.ArchivePerformanceTest;
+import org.eclipse.birt.core.archive.compound.ArchiveRemoveTest;
+import org.eclipse.birt.core.archive.compound.ArchiveViewTest;
+import org.eclipse.birt.core.archive.compound.UpgradeArchiveTest;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for archive package
+ */
+
+public class AllArchiveTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( FileCacheManagerTest.class );
+		test.addTestSuite( ArchiveEntryInputStreamTest.class );
+		test.addTestSuite( ArchiveFileFactoryTest.class );
+		test.addTestSuite( ArchiveFileTest.class );
+		test.addTestSuite( ArchivePerformanceTest.class );
+		test.addTestSuite( ArchiveRemoveTest.class );
+		test.addTestSuite( ArchiveViewTest.class );
+		test.addTestSuite( UpgradeArchiveTest.class );
+		test.addTestSuite( ArchiveFileCacheTest.class );
+		test.addTestSuite( ArchiveFileSaveTest.class );
+		test.addTestSuite( ArchiveFlushTest.class );
+		test.addTestSuite( ArchiveUtilTest.class );
+		test.addTestSuite( DocArchiveLockManagerTest.class );
+		test.addTestSuite( DocumentArchiveTest.class );
+		test.addTestSuite( FileArchiveTest.class );
+		test.addTestSuite( FolderArchiveTest.class );
+		test.addTestSuite( FolderToArchiveTest.class );
+		test.addTestSuite( InputStreamRefreshTest.class );
+		test.addTestSuite( SpecialCharacterTest.class );
+		test.addTestSuite( TestBuffer.class );
+		// add all test classes here
+
+		return test;
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveFileCacheTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveFileCacheTest.java
@@ -17,14 +17,11 @@ import java.io.IOException;
 
 import org.eclipse.birt.core.archive.compound.ArchiveEntry;
 import org.eclipse.birt.core.archive.compound.ArchiveFile;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveFileCacheTest
+import junit.framework.TestCase;
+
+public class ArchiveFileCacheTest extends TestCase
 {
 	@Test
     public void testMemoryCache( ) throws IOException

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveFileSaveTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveFileSaveTest.java
@@ -17,14 +17,11 @@ import java.io.RandomAccessFile;
 
 import org.eclipse.birt.core.archive.compound.ArchiveEntry;
 import org.eclipse.birt.core.archive.compound.ArchiveFile;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveFileSaveTest
+import junit.framework.TestCase;
+
+public class ArchiveFileSaveTest extends TestCase
 {
 	@Test
     public void testSave( ) throws IOException

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveFlushTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveFlushTest.java
@@ -11,8 +11,6 @@
 
 package org.eclipse.birt.core.archive;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,13 +23,9 @@ import org.eclipse.birt.core.archive.compound.ArchiveWriter;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
-public class ArchiveFlushTest
+public class ArchiveFlushTest extends TestCase
 {
 
     /**

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveUtilTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/ArchiveUtilTest.java
@@ -14,13 +14,11 @@ package org.eclipse.birt.core.archive;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveUtilTest
+import junit.framework.TestCase;
+
+public class ArchiveUtilTest extends TestCase
 {
 
     static final String ARCHIVE_FILE = "./utest/test.file";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/DocArchiveLockManagerTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/DocArchiveLockManagerTest.java
@@ -13,16 +13,12 @@ package org.eclipse.birt.core.archive;
 
 import java.io.File;
 
-import org.junit.Assert;
 import org.junit.Ignore;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class DocArchiveLockManagerTest
+import junit.framework.TestCase;
+
+public class DocArchiveLockManagerTest extends TestCase
 {
 
     static final String LOCK_FILE_NAME = "./utest/lock.lck";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/DocumentArchiveTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/DocumentArchiveTest.java
@@ -6,12 +6,11 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class DocumentArchiveTest
+import junit.framework.TestCase;
+
+public class DocumentArchiveTest extends TestCase
 {
 
 	static final String ARCHIVE_DOCUMENT_NAME = "org.eclipse.birt.core.archive.archive.zip"; //$NON-NLS-1$

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/FileArchiveTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/FileArchiveTest.java
@@ -18,10 +18,10 @@ import java.io.RandomAccessFile;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class FileArchiveTest
+import junit.framework.TestCase;
+
+public class FileArchiveTest extends TestCase
 {
 
     static final String ARCHIVE_NAME = "./utest/test.archive";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/FolderArchiveTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/FolderArchiveTest.java
@@ -7,10 +7,10 @@ import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class FolderArchiveTest
+import junit.framework.TestCase;
+
+public class FolderArchiveTest extends TestCase
 {
 
     static final String ARCHIVE_NAME = "./utest/test.archive.folder/";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/FolderToArchiveTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/FolderToArchiveTest.java
@@ -1,6 +1,8 @@
 
 package org.eclipse.birt.core.archive;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -8,17 +10,12 @@ import java.util.List;
 import org.eclipse.birt.core.archive.compound.ArchiveEntry;
 import org.eclipse.birt.core.archive.compound.ArchiveFile;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
-public class FolderToArchiveTest
+public class FolderToArchiveTest extends TestCase
 {
 
     @Before

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/InputStreamRefreshTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/InputStreamRefreshTest.java
@@ -16,14 +16,13 @@ import java.io.File;
 import org.eclipse.birt.core.archive.compound.ArchiveFile;
 import org.eclipse.birt.core.archive.compound.ArchiveReader;
 import org.eclipse.birt.core.archive.compound.ArchiveWriter;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class InputStreamRefreshTest
+import junit.framework.TestCase;
+
+public class InputStreamRefreshTest extends TestCase
 {
 
 	static final String ARCHIVE_NAME = "./utest/test.archive";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/SpecialCharacterTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/SpecialCharacterTest.java
@@ -8,17 +8,12 @@ import org.eclipse.birt.core.archive.compound.ArchiveFile;
 import org.eclipse.birt.core.archive.compound.ArchiveReader;
 import org.eclipse.birt.core.archive.compound.ArchiveWriter;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
-public class SpecialCharacterTest
+public class SpecialCharacterTest extends TestCase
 {
 
     /**

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/TestBuffer.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/TestBuffer.java
@@ -19,7 +19,9 @@ import org.eclipse.birt.core.archive.compound.ArchiveFile;
 import org.eclipse.birt.core.archive.compound.ArchiveReader;
 import org.eclipse.birt.core.archive.compound.ArchiveWriter;
 
-public class TestBuffer
+import junit.framework.TestCase;
+
+public class TestBuffer extends TestCase
 {
 
 	static int TEST_COUNT = 1024;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/cache/FileCacheManagerTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/cache/FileCacheManagerTest.java
@@ -1,12 +1,10 @@
 package org.eclipse.birt.core.archive.cache;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class FileCacheManagerTest
+import junit.framework.TestCase;
+
+public class FileCacheManagerTest extends TestCase
 {
 	@Test
     public void testFileCacheManager( )

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveEntryInputStreamTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveEntryInputStreamTest.java
@@ -6,14 +6,11 @@ import java.io.IOException;
 import org.eclipse.birt.core.archive.ArchiveUtil;
 import org.eclipse.birt.core.archive.RAInputStream;
 import org.eclipse.birt.core.archive.RAOutputStream;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveEntryInputStreamTest
+import junit.framework.TestCase;
+
+public class ArchiveEntryInputStreamTest extends TestCase
 {
 
 	long STREAM_SIZE = 40960;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveFileFactoryTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveFileFactoryTest.java
@@ -17,10 +17,10 @@ import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveFileFactoryTest
+import junit.framework.TestCase;
+
+public class ArchiveFileFactoryTest extends TestCase
 {
 
 	static final int TEST_COUNT = 50;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveFileTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveFileTest.java
@@ -7,10 +7,10 @@ import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveFileTest
+import junit.framework.TestCase;
+
+public class ArchiveFileTest extends TestCase
 {
 
 	static final String ARCHIVE_FOLDER = "./utest/";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchivePerformanceTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchivePerformanceTest.java
@@ -6,14 +6,11 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 
 import org.junit.Ignore;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchivePerformanceTest
+import junit.framework.TestCase;
+
+public class ArchivePerformanceTest extends TestCase
 {
 
 	int STREAM_COUNT = 127;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveRemoveTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveRemoveTest.java
@@ -7,10 +7,10 @@ import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveRemoveTest
+import junit.framework.TestCase;
+
+public class ArchiveRemoveTest extends TestCase
 {
 
 	static final String ARCHIVE_FOLDER = "./utest/";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveViewTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/ArchiveViewTest.java
@@ -18,14 +18,13 @@ import java.io.InputStream;
 
 import org.eclipse.birt.core.archive.RAInputStream;
 import org.eclipse.birt.core.archive.RAOutputStream;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ArchiveViewTest
+import junit.framework.TestCase;
+
+public class ArchiveViewTest extends TestCase
 {
 
 	static final String TEST_FOLDER = "./utest/";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/UpgradeArchiveTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/archive/compound/UpgradeArchiveTest.java
@@ -8,14 +8,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.eclipse.birt.core.archive.ArchiveUtil;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class UpgradeArchiveTest
+import junit.framework.TestCase;
+
+public class UpgradeArchiveTest extends TestCase
 {
 	@Before
     public void setUp()

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/AllBTreeTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/AllBTreeTests.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.birt.core.btree;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for btree package
+ */
+
+public class AllBTreeTests
+{
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( BTreeCursorTest.class );
+		test.addTestSuite( BTreeMultipleThreadTest.class );
+		test.addTestSuite( BTreeTest.class );
+		test.addTestSuite( NodeInputStreamTest.class );
+		test.addTestSuite( NodeOutputStreamTest.class );
+
+		return test;
+	}
+
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeCursorTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeCursorTest.java
@@ -14,13 +14,11 @@ package org.eclipse.birt.core.btree;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class BTreeCursorTest
+import junit.framework.TestCase;
+
+public class BTreeCursorTest extends TestCase
 {
 	@Test
     public void testCursor( ) throws Exception

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeMultipleThreadTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeMultipleThreadTest.java
@@ -15,13 +15,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class BTreeMultipleThreadTest
+import junit.framework.TestCase;
+
+public class BTreeMultipleThreadTest extends TestCase
 {
 
 	static int KEY_COUNT = 10000;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeTest.java
@@ -24,12 +24,6 @@ import java.util.Random;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
-
 public class BTreeTest extends BTreeTestCase
 {
 	@Test

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeTestCase.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/BTreeTestCase.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Random;
 
-abstract public class BTreeTestCase
+import junit.framework.TestCase;
+
+abstract public class BTreeTestCase extends TestCase
 {
 
 	static final String BTREE_INPUT_RESOURCE = "org/eclipse/birt/core/btree/btree.input.txt";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/NodeInputStreamTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/NodeInputStreamTest.java
@@ -18,13 +18,11 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class NodeInputStreamTest
+import junit.framework.TestCase;
+
+public class NodeInputStreamTest extends TestCase
 {
 	@Test
     public void testInputStream( ) throws IOException

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/NodeOutputStreamTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/btree/NodeOutputStreamTest.java
@@ -17,13 +17,11 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class NodeOutputStreamTest
+import junit.framework.TestCase;
+
+public class NodeOutputStreamTest extends TestCase
 {
 	@Test
     public void testEmptyOutputStream( ) throws IOException

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/config/AllConfigTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/config/AllConfigTests.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.config;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for config package
+ */
+
+public class AllConfigTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( FileConfigVarManagerTest.class );
+		// add all test classes here
+
+		return test;
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/config/FileConfigVarManagerTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/config/FileConfigVarManagerTest.java
@@ -15,12 +15,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class FileConfigVarManagerTest
+import junit.framework.TestCase;
+
+public class FileConfigVarManagerTest extends TestCase
 {
 	@After
     public void tearDown()

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/AllDataTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/AllDataTests.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.data;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for data package
+ */
+
+public class AllDataTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( DataTypeUtilTest.class );
+		test.addTestSuite( DateUtilTest.class );
+		test.addTestSuite( DateUtilThreadTest.class );
+		test.addTestSuite( ExpressionParserUtilityTest.class );
+		test.addTestSuite( ExpressionUtilTest.class );
+		// add all test classes here
+
+		return test;
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/DataTypeUtilTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/DataTypeUtilTest.java
@@ -19,6 +19,9 @@ import java.util.Locale;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.core.script.BaseScriptable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.Wrapper;
 
@@ -27,17 +30,13 @@ import com.ibm.icu.util.Calendar;
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
 /**
  * 
  * Test case for DataTypeUtil
  */
-public class DataTypeUtilTest
+public class DataTypeUtilTest extends TestCase
 {
 
 	public Object[] testObject;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/DateUtilTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/DateUtilTest.java
@@ -13,20 +13,18 @@ package org.eclipse.birt.core.data;
 
 import java.text.ParseException;
 
+import org.junit.Test;
+
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.util.ULocale;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
 
 /**
  *
  */
-public class DateUtilTest
+public class DateUtilTest extends TestCase
 {
 	/**
 	 * Test DataTypeUtil#checkValid

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/DateUtilThreadTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/DateUtilThreadTest.java
@@ -11,19 +11,17 @@
 
 package org.eclipse.birt.core.data;
 
+import org.junit.Test;
+
 import com.ibm.icu.util.ULocale;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
 /**
  * 
  */
 
-public class DateUtilThreadTest
+public class DateUtilThreadTest extends TestCase
 {
 	@Test
     public void test() throws InterruptedException

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/ExpressionParserUtilityTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/ExpressionParserUtilityTest.java
@@ -4,19 +4,15 @@ package org.eclipse.birt.core.data;
 import java.util.List;
 
 import org.eclipse.birt.core.exception.BirtException;
-import org.eclipse.birt.core.data.IColumnBinding;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+
+import junit.framework.TestCase;
 
 /**
  * test case for expression parser
  *
  */
-public class ExpressionParserUtilityTest
+public class ExpressionParserUtilityTest extends TestCase
 {
 
 	String[] oldExpressions = new String[]{

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/ExpressionUtilTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/ExpressionUtilTest.java
@@ -15,17 +15,14 @@ import java.util.Set;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.core.exception.CoreException;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+
+import junit.framework.TestCase;
 
 /**
  * 
  */
-public class ExpressionUtilTest
+public class ExpressionUtilTest extends TestCase
 {
 	@Test
     public void testToNewExpression( )

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/OlapExpressionCompilerTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/data/OlapExpressionCompilerTest.java
@@ -7,14 +7,11 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.eclipse.birt.core.exception.CoreException;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class OlapExpressionCompilerTest
+import junit.framework.TestCase;
+
+public class OlapExpressionCompilerTest extends TestCase
 {
 	@Test
     public void testGetDimLevels( ) throws CoreException

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/exception/AllExceptionTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/exception/AllExceptionTests.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.exception;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * 
+ */
+
+public class AllExceptionTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( BirtExceptionTest.class );
+		// add all test classes here
+
+		return test;
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/exception/BirtExceptionTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/exception/BirtExceptionTest.java
@@ -13,16 +13,14 @@ package org.eclipse.birt.core.exception;
 import java.util.Enumeration;
 import java.util.ResourceBundle;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+
+import junit.framework.TestCase;
 
 /**
  *
  */
-public class BirtExceptionTest
+public class BirtExceptionTest extends TestCase
 {
 
     private static String FATAL_ERROR_KEY = "Fatal_Error";

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/AllFormatTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/AllFormatTests.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.format;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Test cases in format package
+ */
+
+public class AllFormatTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( DateFormatterTest.class );
+		test.addTestSuite( NumberFormatterTest.class );
+		test.addTestSuite( StringFormatterTest.class );
+
+		return test;
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/DateFormatterTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/DateFormatterTest.java
@@ -17,14 +17,12 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
+import org.junit.Test;
+
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
 /**
  * DateFormatterTest.
@@ -35,7 +33,7 @@ import static org.junit.Assert.*;
  * we add in the subclss.
  * 
  */
-public class DateFormatterTest
+public class DateFormatterTest extends TestCase
 {
 
 	/*

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/NumberFormatterTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/NumberFormatterTest.java
@@ -16,18 +16,16 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import org.junit.Test;
+
 import com.ibm.icu.util.ULocale;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
 /**
  * 
  */
-public class NumberFormatterTest
+public class NumberFormatterTest extends TestCase
 {
 	@Test
     public void testNumericFormat( )

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/StringFormatterTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/format/StringFormatterTest.java
@@ -13,11 +13,9 @@ package org.eclipse.birt.core.format;
 
 import java.text.ParseException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+
+import junit.framework.TestCase;
 
 /**
  * StringFormatterTest.
@@ -26,7 +24,7 @@ import static org.junit.Assert.*;
  * translate the string according to the format string
  * 
  */
-public class StringFormatterTest
+public class StringFormatterTest extends TestCase
 {
 
 	//test function StringFormatter.applyPattern &

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/AllScriptTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/AllScriptTests.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.script;
+
+import org.eclipse.birt.core.script.bre.BirtCompTest;
+import org.eclipse.birt.core.script.bre.BirtDateTimeTest;
+import org.eclipse.birt.core.script.bre.BirtDurationTest;
+import org.eclipse.birt.core.script.bre.BirtMathTest;
+import org.eclipse.birt.core.script.bre.BirtStrTest;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Test cases in script package.
+ */
+
+public class AllScriptTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( CoreJavaScriptWrapperTest.class );
+		test.addTestSuite( NativeDateTimeSpanTest.class );
+		test.addTestSuite( NativeFinanceTest.class );
+		test.addTestSuite( NativeJavaMapTest.class );
+		test.addTestSuite( NativeNamedListTest.class );
+		test.addTestSuite( ScriptableParametersTest.class );
+		test.addTestSuite( ScriptContextTest.class );
+		test.addTestSuite( BirtCompTest.class );
+		test.addTestSuite( BirtDateTimeTest.class );
+		test.addTestSuite( BirtDurationTest.class );
+		test.addTestSuite( BirtMathTest.class );
+		test.addTestSuite( BirtStrTest.class );
+		// add all test classes here
+
+		return test;
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/CoreJavaScriptWrapperTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/CoreJavaScriptWrapperTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Actuate Corporation.
+ * All rights reserved.
+ *******************************************************************************/
+
+package org.eclipse.birt.core.script;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeArray;
+import org.mozilla.javascript.Scriptable;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit test for CoreJavaScriptWrapper class.
+ */
+
+public class CoreJavaScriptWrapperTest extends TestCase
+{
+
+	/**
+	 * Create a Context instance
+	 */
+	Context cx;
+	/**
+	 * Create a Scriptable instance
+	 */
+	Scriptable scope;
+
+	IJavascriptWrapper coreWrapper;
+
+	@Before
+	public void setUp( ) throws Exception
+	{
+		/*
+		 * Creates and enters a Context. The Context stores information about
+		 * the execution environment of a script.
+		 */
+
+		cx = Context.enter( );
+		/*
+		 * Initialize the standard objects (Object, Function, etc.) This must be
+		 * done before scripts can be executed. Returns a scope object that we
+		 * use in later calls.
+		 */
+		scope = cx.initStandardObjects( );
+
+		coreWrapper = new CoreJavaScriptWrapper( );
+	}
+
+	@After
+	public void tearDown( )
+	{
+		Context.exit( );
+	}
+
+	@Test
+	public void testWrap( )
+	{
+		// test nativeArray
+		NativeArray nativeArray = new NativeArray( new Object[]{
+				"one", "two"
+		} );
+		Object object = coreWrapper.wrap( cx, scope, nativeArray, null );
+		assertTrue( object instanceof org.mozilla.javascript.NativeArray );
+
+		// test list
+		List<Integer> list = new ArrayList<>( );
+		object = coreWrapper.wrap( cx, scope, list, null );
+		assertTrue( object instanceof NativeJavaList );
+
+		// test map
+		Map<Integer, Integer> linkedHashMap = new LinkedHashMap<>( );
+		object = coreWrapper.wrap( cx, scope, linkedHashMap, null );
+		assertTrue( object instanceof NativeJavaLinkedHashMap );
+
+		// test BirtHashMap
+		BirtHashMap birtHashMap = new BirtHashMap( );
+		object = coreWrapper.wrap( cx, scope, birtHashMap, null );
+		assertTrue( object instanceof NativeJavaMap );
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeDateTimeSpanTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeDateTimeSpanTest.java
@@ -11,18 +11,19 @@
 
 package org.eclipse.birt.core.script;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Calendar;
 import java.util.Date;
-
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+
+import junit.framework.TestCase;
 
 /**
  * @Created on Dec 27, 2004
@@ -31,7 +32,7 @@ import static org.junit.Assert.*;
  * 
  * This class is the unit test for class NativeDateTimeSpan.
  */
-public class NativeDateTimeSpanTest
+public class NativeDateTimeSpanTest extends TestCase
 {
 
 	/**

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeFinanceTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeFinanceTest.java
@@ -11,15 +11,18 @@
 
 package org.eclipse.birt.core.script;
 
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+
+import junit.framework.TestCase;
 
 /**
  * Created on Nov 12, 2004 NativeFinanceTest.
@@ -49,7 +52,7 @@ import static org.junit.Assert.*;
  *          <li>testIrr()</li>
  *          <li>testMirr()</li>
  */
-public class NativeFinanceTest
+public class NativeFinanceTest extends TestCase
 {
 
 	/**

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeJavaMapTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeJavaMapTest.java
@@ -1,18 +1,20 @@
 
 package org.eclipse.birt.core.script;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
 
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
-public class NativeJavaMapTest
+public class NativeJavaMapTest extends TestCase
 {
 
 	/**

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeNamedListTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/NativeNamedListTest.java
@@ -3,17 +3,16 @@ package org.eclipse.birt.core.script;
 import java.util.Date;
 import java.util.HashMap;
 
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+import junit.framework.TestCase;
 
 
-public class NativeNamedListTest
+public class NativeNamedListTest extends TestCase
 {
 	/**
 	 * Create a Context instance

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/ScriptContextTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/ScriptContextTest.java
@@ -15,17 +15,16 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 
 import org.eclipse.birt.core.exception.BirtException;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+
+import junit.framework.TestCase;
 
 /**
  * 
  */
-public class ScriptContextTest
+public class ScriptContextTest extends TestCase
 {
 
 	ScriptContext context;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/ScriptableParametersTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/ScriptableParametersTest.java
@@ -16,14 +16,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.birt.core.exception.BirtException;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class ScriptableParametersTest
+import junit.framework.TestCase;
+
+public class ScriptableParametersTest extends TestCase
 {
 
 	ScriptContext context;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtCompTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtCompTest.java
@@ -12,20 +12,19 @@ package org.eclipse.birt.core.script.bre;
 
 import org.eclipse.birt.core.script.CoreJavaScriptInitializer;
 import org.eclipse.birt.core.script.functionservice.IScriptFunctionContext;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+import junit.framework.TestCase;
 
 
 /**
  * 
  */
-public class BirtCompTest
+public class BirtCompTest extends TestCase
 {
 	private Context cx;
 	private Scriptable scope;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtDateTimeTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtDateTimeTest.java
@@ -11,9 +11,6 @@
 
 package org.eclipse.birt.core.script.bre;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Calendar;
 import java.util.Date;
 
@@ -28,11 +25,13 @@ import org.mozilla.javascript.Scriptable;
 
 import com.ibm.icu.util.ULocale;
 
+import junit.framework.TestCase;
+
 /**
  *
  */
 
-public class BirtDateTimeTest
+public class BirtDateTimeTest extends TestCase
 {
 
 	private Context cx;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtDurationTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtDurationTest.java
@@ -18,20 +18,19 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 
 import org.eclipse.birt.core.script.CoreJavaScriptInitializer;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+import junit.framework.TestCase;
 
 /**
  * 
  */
 
-public class BirtDurationTest
+public class BirtDurationTest extends TestCase
 {
 	private Context cx;
 	private Scriptable scope;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtMathTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtMathTest.java
@@ -14,22 +14,20 @@ package org.eclipse.birt.core.script.bre;
 import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.birt.core.script.CoreJavaScriptInitializer;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+import junit.framework.TestCase;
 
 
 /**
  * 
  */
 
-public class BirtMathTest
+public class BirtMathTest extends TestCase
 {
 	private Context cx;
 	private Scriptable scope;

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtStrTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/script/bre/BirtStrTest.java
@@ -12,21 +12,20 @@
 package org.eclipse.birt.core.script.bre;
 
 import org.eclipse.birt.core.script.CoreJavaScriptInitializer;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+import junit.framework.TestCase;
 
 
 /**
  * 
  */
 
-public class BirtStrTest
+public class BirtStrTest extends TestCase
 {
 	String str = " I am a test    string";
 	

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/template/AllTemplateTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/template/AllTemplateTests.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.template;
+
+import org.eclipse.birt.core.script.CoreJavaScriptWrapperTest;
+import org.eclipse.birt.core.script.NativeDateTimeSpanTest;
+import org.eclipse.birt.core.script.NativeFinanceTest;
+import org.eclipse.birt.core.script.NativeJavaMapTest;
+import org.eclipse.birt.core.script.NativeNamedListTest;
+import org.eclipse.birt.core.script.ScriptContextTest;
+import org.eclipse.birt.core.script.ScriptableParametersTest;
+import org.eclipse.birt.core.script.bre.BirtCompTest;
+import org.eclipse.birt.core.script.bre.BirtDateTimeTest;
+import org.eclipse.birt.core.script.bre.BirtDurationTest;
+import org.eclipse.birt.core.script.bre.BirtMathTest;
+import org.eclipse.birt.core.script.bre.BirtStrTest;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Tests in template package
+ */
+
+public class AllTemplateTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( CoreJavaScriptWrapperTest.class );
+		test.addTestSuite( NativeDateTimeSpanTest.class );
+		test.addTestSuite( NativeFinanceTest.class );
+		test.addTestSuite( NativeJavaMapTest.class );
+		test.addTestSuite( NativeNamedListTest.class );
+		test.addTestSuite( ScriptableParametersTest.class );
+		test.addTestSuite( ScriptContextTest.class );
+		test.addTestSuite( BirtCompTest.class );
+		test.addTestSuite( BirtDateTimeTest.class );
+		test.addTestSuite( BirtDurationTest.class );
+		test.addTestSuite( BirtMathTest.class );
+		test.addTestSuite( BirtStrTest.class );
+		// add all test classes here
+
+		return test;
+	}
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/template/TemplateParserTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/template/TemplateParserTest.java
@@ -14,14 +14,11 @@ import org.eclipse.birt.core.template.TextTemplate.ExpressionValueNode;
 import org.eclipse.birt.core.template.TextTemplate.ImageNode;
 import org.eclipse.birt.core.template.TextTemplate.TextNode;
 import org.eclipse.birt.core.template.TextTemplate.ValueNode;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
 
-public class TemplateParserTest
+import junit.framework.TestCase;
+
+public class TemplateParserTest extends TestCase
 {
 	@Test
     public void testValueOf( )

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/util/AllUtilTests.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/util/AllUtilTests.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Actuate Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.core.util;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ * Util package test
+ */
+
+public class AllUtilTests
+{
+
+	/**
+	 * @return the test
+	 */
+
+	public static Test suite( )
+	{
+		TestSuite test = new TestSuite( );
+
+		test.addTestSuite( IOUtilTest.class );
+
+		// add all test classes here
+
+		return test;
+	}
+
+}

--- a/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/util/IOUtilTest.java
+++ b/core/org.eclipse.birt.core.tests/test/org/eclipse/birt/core/util/IOUtilTest.java
@@ -14,10 +14,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Time;
@@ -30,23 +27,19 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.birt.core.script.JavascriptEvalUtil;
+import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.IdScriptableObject;
 import org.mozilla.javascript.ImporterTopLevel;
-import org.mozilla.javascript.NativeJavaObject;
 import org.mozilla.javascript.Scriptable;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Ignore;
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
 /**
  * Test case for IOUtil
  * @see org.eclipse.birt.core.util.IOUtil
  */
-public class IOUtilTest
+public class IOUtilTest extends TestCase
 {
 	// test value
 	private Object[] testValues = new Object[]{


### PR DESCRIPTION
1. Create unit test for CoreJavaScriptWrapper
2. Create test suites framework for entire org.eclipse.birt.core package


Signed-off-by: Shijie Zhang <szhang@opentext.com>