### PR TITLE
Span tag was running properly on 4.2, it required BIDI flag to be true

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.config.pptx/src/org/eclipse/birt/report/engine/emitter/config/pptx/PPTXEmitterDescriptor.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.pptx/src/org/eclipse/birt/report/engine/emitter/config/pptx/PPTXEmitterDescriptor.java
@@ -49,11 +49,10 @@ public class PPTXEmitterDescriptor extends AbstractEmitterDescriptor
 		bidiProcessing.setDataType( IConfigurableOption.DataType.BOOLEAN );
 		bidiProcessing
 				.setDisplayType( IConfigurableOption.DisplayType.CHECKBOX );
-		bidiProcessing.setDefaultValue( Boolean.FALSE );
+		bidiProcessing.setDefaultValue( Boolean.TRUE );
 		bidiProcessing.setToolTip( null );
 		bidiProcessing
 				.setDescription( getMessage( "OptionDescription.BidiProcessing" ) ); //$NON-NLS-1$
-		bidiProcessing.setEnabled( false );
 		
 		// Initializes the option for TextWrapping.
 		ConfigurableOption textWrapping = new ConfigurableOption( TEXT_WRAPPING );

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/PPTXRender.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/PPTXRender.java
@@ -38,7 +38,6 @@ import org.eclipse.birt.report.engine.nLayout.area.ITextArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.BlockTextArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.ContainerArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.ImageBlockContainer;
-import org.eclipse.birt.report.engine.nLayout.area.impl.LineArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.PageArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.TableArea;
 import org.eclipse.birt.report.engine.nLayout.area.style.TextStyle;
@@ -79,7 +78,6 @@ public class PPTXRender extends PageDeviceRender
 	private boolean editMode;
 	private boolean isRTL = false;
 	private boolean isTextWrap = true;
-	private int currentLineAreaX = 0;
 
 	public PPTXRender( IEmitterServices services ) throws EngineException
 	{
@@ -207,10 +205,6 @@ public class PPTXRender extends PageDeviceRender
 	@Override
 	public void visitContainer( IContainerArea container )
 	{
-		if ( container instanceof LineArea )
-		{
-			currentLineAreaX = 0;
-		}
 		if ( container instanceof PageArea )
 		{
 			if( editMode )
@@ -314,7 +308,6 @@ public class PPTXRender extends PageDeviceRender
 		if ( editMode )
 		{
 			int x = currentX + getX( text );
-			x = Math.max( x, currentLineAreaX );
 			int y = currentY + getY( text );
 			int width = getWidth( text );
 			int height = getHeight( text );
@@ -322,7 +315,6 @@ public class PPTXRender extends PageDeviceRender
 			tw.setLink( PPTUtil.getHyperlink( text, services, reportRunnable,
 					context ) );
 			tw.writeTextBlock( x, y, width, height, text );
-			currentLineAreaX = x + width;
 		}
 		else
 		{


### PR DESCRIPTION
Revert configuration option commit:
824345a6e3d1ff2b9b8ba8e0948412e95a3ca82b

and revert new change commit: 7d46aaaf5730dc312915c84492f60ce62eb5fbbe

The function reorderVisually runs inside that flag that put the proper
layout of multiple boxes when it is in a line area.  We removed it for a smaller issue



Signed-off-by: sguan <sguan@actuate.com>