### PR TITLE
Changes made for masterpage in properties corrupted in layout page

### DIFF
--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/rom.def
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/rom.def
@@ -2547,10 +2547,12 @@
     <Property displayNameID="Element.SimpleMasterPage.headerHeight" name="headerHeight" since="1.0" type="dimension" validator="NonNegativeValueValidator">
     	<DefaultUnit>in</DefaultUnit>
     	<Default>0.5</Default>
+    	<AllowedUnits>in,cm,mm,pt,pc,em,ex,px</AllowedUnits>    	
     </Property>
 	<Property displayNameID="Element.SimpleMasterPage.footerHeight" name="footerHeight" since="1.0" type="dimension" validator="NonNegativeValueValidator">
 		<DefaultUnit>in</DefaultUnit>	  
-		<Default>0.5</Default>	    
+		<Default>0.5</Default>
+		<AllowedUnits>in,cm,mm,pt,pc,em,ex,px</AllowedUnits>			    
 	</Property>	
   	<PropertyVisibility name="floatingFooter" visibility="hide"/>    	    
 	<Slot displayNameID="Element.SimpleMasterPage.slot.pageHeader" multipleCardinality="false" name="pageHeader" xmlName="page-header">

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/ElementDefn.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/ElementDefn.java
@@ -1281,7 +1281,7 @@ public class ElementDefn extends ObjectDefn implements IElementDefn
 		// Ted 43511
 		if ( hasStyle( ) )
 		{
-			if ( cachedProperties.get( IStyleModel.HEIGHT_PROP ) != null )
+			if ( cachedProperties.get( IStyleModel.HEIGHT_PROP ) != null && !this.getName( ).equalsIgnoreCase( IStyleModel.MASTER_PAGE_PROP ) )
 			{
 				IPropertyDefn sourcePropertyDefn = cachedProperties.get( IStyleModel.HEIGHT_PROP );
 				if ( sourcePropertyDefn instanceof IElementPropertyDefn
@@ -1296,7 +1296,7 @@ public class ElementDefn extends ObjectDefn implements IElementDefn
 					}
 				}
 			}
-			if ( cachedProperties.get( IStyleModel.WIDTH_PROP ) != null )
+			if ( cachedProperties.get( IStyleModel.WIDTH_PROP ) != null && !this.getName( ).equalsIgnoreCase( IStyleModel.MASTER_PAGE_PROP ) )
 			{			
 				IPropertyDefn sourcePropertyDefn = cachedProperties.get( IStyleModel.WIDTH_PROP );
 				if ( sourcePropertyDefn instanceof IElementPropertyDefn


### PR DESCRIPTION
1. Element MasterPage has its own height and width property, during ElementDefn.buildCachedPropertyDefns( ), height and
width from style will over write the original property, and hence lose
those original properties.
2. define allowed units for simpleMasterPage footer and header


Signed-off-by: Shijie Zhang <szhang@opentext.com>