### PR TITLE
Multiple data engine unit tests failed due to older Derby

### DIFF
--- a/data/org.eclipse.birt.data.tests/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.data.tests/META-INF/MANIFEST.MF
@@ -12,5 +12,5 @@ Require-Bundle: org.eclipse.birt.data,
  org.eclipse.datatools.connectivity.oda.flatfile,
  org.junit;bundle-version="4.8.1"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse BIRT Project


### PR DESCRIPTION
Bumped up required execution environment version for data engine tests.
Older Derby 10.8 used by the test was incompatible with newer 10.11 test
db format, which caused multiple test failires.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>