### PR TITLE
Bookmark is not underline on PDF emitter on spec setting

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/TextStyle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/TextStyle.java
@@ -59,6 +59,7 @@ public class TextStyle  extends AreaConstants
 		this.overLine = style.overLine;
 		this.lineThrough = style.lineThrough;
 		this.direction = style.direction;
+		this.hasHyperlink = style.isHasHyperlink( );
 	}
 
 	


### PR DESCRIPTION
Links are not underlined in pdf output if the links text contain spaces
and is justified when it is more than one line.


Signed-off-by: sguan <sguan@actuate.com>