### PR TITLE
Fix NotSerializableException with large group by reports

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/transform/group/GroupInfoUpdator.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/transform/group/GroupInfoUpdator.java
@@ -36,8 +36,9 @@ public class GroupInfoUpdator
 		this.level = level;
 		this.originGroups = groups;
 		this.lastIndex = last;
-		this.newGroups = new BasicCachedList( tempDir,
-				DataEngineSession.getCurrentClassLoader( ) );
+		this.newGroups = new CachedList( tempDir,
+				DataEngineSession.getCurrentClassLoader( ),
+				GroupInfo.getCreator( ) );
 		this.aggrUpdator = aggrValues;
 	}
 	


### PR DESCRIPTION
When generating a report with a large amount of data (we hit the issue with over 19,000 rows) and a table with multiple groups. A NotSerializableException followed by an EOFException caused the report to be empty.

I traced it down to the GroupInfoUpdator class using a BasicCachedList instead of a CachedList, as BasicCachedList is unable to write out the GroupInfo objects the list contains.

We had these errors in the log which indicated it as a problem:

```
Mar 28, 2017 5:06:28 AM org.eclipse.birt.data.engine.cache.BasicCachedList saveToDisk
SEVERE: Exception happened when save data to disk in CachedList. Exception message: java.io.NotSerializableException: Not serializable.
Mar 28, 2017 5:06:28 AM org.eclipse.birt.data.engine.cache.BasicCachedList loadFromDisk
SEVERE: Exception happened when load data from disk in CachedList. Exception message: java.io.EOFException
```