### PR TITLE
Altering a library causes null pointer when reloading in a report

### DIFF
--- a/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ChartReportItemUIImpl.java
+++ b/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ChartReportItemUIImpl.java
@@ -141,15 +141,18 @@ public class ChartReportItemUIImpl extends ReportItemFigureProvider
 				// Mark this figure need resize to auto fit container if chart
 				// model bounds is empty but handle bounds is default value
 				final Chart cm = (Chart) iri.getProperty( ChartReportItemConstants.PROPERTY_CHART );
-				final Bounds bo = cm.getBlock( ).getBounds( );
-				final NumberFormat nf = ChartUIUtil.getDefaultNumberFormatInstance( );
-				if ( ( bo == null || bo.getWidth( ) == 0 || bo.getHeight( ) == 0 )
-						&& ( nf.format( ChartReportItemConstants.DEFAULT_CHART_BLOCK_WIDTH ) + "pt" ).equals( eih.getWidth( ) //$NON-NLS-1$
-								.getStringValue( ) )
-						&& ( nf.format( ChartReportItemConstants.DEFAULT_CHART_BLOCK_HEIGHT ) + "pt" ).equals( eih.getHeight( ) //$NON-NLS-1$
-								.getStringValue( ) ) )
+				if(cm !=null)
 				{
-					dr.needFitContainer = true;
+					final Bounds bo = cm.getBlock( ).getBounds( );
+					final NumberFormat nf = ChartUIUtil.getDefaultNumberFormatInstance( );
+					if ( ( bo == null || bo.getWidth( ) == 0 || bo.getHeight( ) == 0 )
+							&& ( nf.format( ChartReportItemConstants.DEFAULT_CHART_BLOCK_WIDTH ) + "pt" ).equals( eih.getWidth( ) //$NON-NLS-1$
+									.getStringValue( ) )
+							&& ( nf.format( ChartReportItemConstants.DEFAULT_CHART_BLOCK_HEIGHT ) + "pt" ).equals( eih.getHeight( ) //$NON-NLS-1$
+									.getStringValue( ) ) )
+					{
+						dr.needFitContainer = true;
+					}
 				}
 			}
 


### PR DESCRIPTION
-Description of Issue: 
when a chartItem present in a library is modifed then NPE is thrown once
we refresh the library or if we open the reportdesing is reopened.

-Description of Resolution: 
Added not null check.


Signed-off-by: rrimmana <rrimmana@RRIMMANA4J5LX52.opentext.net>