### PR TITLE
Upgrade Jetty to 9.4.1

### DIFF
--- a/build/birt-packages/birt-integration-test/pom.xml
+++ b/build/birt-packages/birt-integration-test/pom.xml
@@ -99,7 +99,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.3.8.v20160314</version>
+				<version>${jetty.version}</version>
 				<configuration>					
 					<war>${birtpackages.basedir}/birt-runtime-osgi/target/package/birt.war</war> 					
 					<scanIntervalSeconds>10</scanIntervalSeconds>

--- a/data/org.eclipse.birt.data.oda.mongodb.ui/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.data.oda.mongodb.ui/META-INF/MANIFEST.MF
@@ -12,4 +12,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.birt.data.oda.mongodb.ui.Activator
-Import-Package: com.mongodb;version="2.10.1"
+Import-Package: com.mongodb;version="[2.10.1,3.0.0)"

--- a/data/org.eclipse.birt.data.oda.mongodb/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.data.oda.mongodb/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.datatools.connectivity.oda.profile;bundle-version="[3.2.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
-Import-Package: com.mongodb;version="2.10.1",
- com.mongodb.util;version="2.10.1",
+Import-Package: com.mongodb;version="[2.10.1,3.0.0)",
+ com.mongodb.util;version="[2.10.1,3.0.0)",
  org.bson;version="2.10.1",
  org.bson.types;version="2.10.1"

--- a/pom.xml
+++ b/pom.xml
@@ -24,19 +24,19 @@
             </activation>            
             <properties>
                 <eclipse.release.name>oxygen</eclipse.release.name>
-                <tycho.version>0.25.0</tycho.version>
+                <tycho.version>1.0.0</tycho.version>
                 <eclipse.repo.url>http://download.eclipse.org/eclipse/updates/4.7milestones/</eclipse.repo.url>
                 <emf.repo.url>http://download.eclipse.org/modeling/emf/emf/updates/2.13milestones/</emf.repo.url>
                 <gef.repo.url>http://download.eclipse.org/tools/gef/updates/releases/</gef.repo.url>
                 <!-- https://wiki.eclipse.org/WTP_FAQ#How_do_I_install_WTP.3F -->
                 <wtp.repo.url>http://download.eclipse.org/webtools/repository/oxygen/</wtp.repo.url>
                 <!-- http://download.eclipse.org/tools/orbit/downloads/ -->
-                <orbit.repo.url>http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/</orbit.repo.url>
+                <orbit.repo.url>http://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository/</orbit.repo.url>
                 <!-- https://eclipse.org/datatools/downloads.php  -->
                 <dtp.repo.url>http://download.eclipse.org/datatools/updates/1.13/1.13.0.201603142002/repository</dtp.repo.url>
-                <!-- http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/ -->
-                <!-- <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/</jetty.repo.url> -->
-                <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.2.13.v20150730</jetty.repo.url>
+                <jetty.version>9.4.1.v20170120</jetty.version>
+                <!-- jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/</jetty.repo.url -->
+                <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/${jetty.version}</jetty.repo.url>
             </properties>
         </profile>	
 	    <profile>
@@ -53,9 +53,9 @@
                 <orbit.repo.url>http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/</orbit.repo.url>
                 <!-- https://eclipse.org/datatools/downloads.php  -->
                 <dtp.repo.url>http://download.eclipse.org/datatools/updates/1.13/1.13.0.201603142002/repository</dtp.repo.url>
-                <!-- http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/ -->
-                <!-- <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/</jetty.repo.url> -->
-                <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.2.13.v20150730</jetty.repo.url>
+                <jetty.version>9.2.13.v20150730</jetty.version>
+                <!--jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/</jetty.repo.url-->
+                <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/${jetty.version}</jetty.repo.url>
             </properties>
         </profile>
         <profile>
@@ -69,9 +69,10 @@
                 <gef.repo.url>http://download.eclipse.org/tools/gef/updates/releases/</gef.repo.url>
                 <orbit.repo.url>http://download.eclipse.org/tools/orbit/downloads/drops/R20150821153341/repository/</orbit.repo.url>
                 <dtp.repo.url>http://download.eclipse.org/datatools/updates/1.12</dtp.repo.url>
-                <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.2.9.v20150224</jetty.repo.url>
-	    </properties>
-	</profile>
+				<jetty.version>9.2.9.v20150224</jetty.version>
+                <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/${jetty.version}</jetty.repo.url>
+            </properties>
+        </profile>
 		<profile>
 			<id>localdeps</id>
 			<properties>
@@ -325,6 +326,100 @@
 							<arch>x86_64</arch>
 						</environment>
 					</environments>
+					<filters>
+						<!-- restrict Jetty bundles to specific version only -->
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.continuation</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.deploy</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.http</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.io</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.jndi</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.osgi.boot</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.plus</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.security</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.server</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.servlet</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.util</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.webapp</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.jetty.xml</id>
+							<restrictTo>
+								<version>${jetty.version}</version>
+							</restrictTo>
+						</filter>
+					</filters>
 				</configuration>
 			</plugin>
 

--- a/viewer/org.eclipse.birt.jetty.overlay/META-INF/MANIFEST.MF
+++ b/viewer/org.eclipse.birt.jetty.overlay/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.eclipse.birt.jetty.overlay;singleton:=true
 Bundle-Version: 4.7.0.qualifier
 Fragment-Host: system.bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Export-Package: org.eclipse.jetty.util;version="8.1.3",
+Export-Package: org.eclipse.jetty.util,
  org.mortbay.util;version="6.1.23"
 Bundle-Vendor: Eclipse BIRT Project

--- a/viewer/org.eclipse.birt.report.viewer/META-INF/MANIFEST.MF
+++ b/viewer/org.eclipse.birt.report.viewer/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-ClassPath: ., viewer.jar,
 Bundle-Activator: org.eclipse.birt.report.viewer.ViewerPlugin
 Bundle-Vendor: Eclipse BIRT Project
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: javax.servlet;version="2.4.0",
  javax.servlet.http;version="2.4.0",
  javax.servlet.jsp;version="2.0.0",
@@ -45,12 +45,18 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.apache.xerces;bundle-version="[2.8.0,3.0.0)";resolution:=optional,
  org.eclipse.birt.report.item.crosstab.core;bundle-version="[2.2.0,5.0.0)";resolution:=optional,
  org.eclipse.birt.report.designer.core,
- org.eclipse.jetty.osgi.boot;bundle-version="9.2.9",
- org.eclipse.jetty.server;bundle-version="9.2.9",
- org.eclipse.jetty.util;bundle-version="9.2.9",
- org.eclipse.jetty.webapp;bundle-version="9.2.9",
- org.eclipse.jetty.servlet;bundle-version="9.2.9",
+ org.eclipse.jetty.osgi.boot,
+ org.eclipse.jetty.server,
+ org.eclipse.jetty.util,
+ org.eclipse.jetty.webapp,
+ org.eclipse.jetty.plus,
+ org.eclipse.jetty.servlet,
+ org.eclipse.jetty.http,
  org.apache.jasper.glassfish;bundle-version="2.2.2"
 Eclipse-LazyStart: true
 Eclipse-BuddyPolicy: registered
 Eclipse-BundleShape: dir
+Jetty-WarFolderPath: birt
+Jetty-WarResourcePath: birt
+Web-ContextPath: /viewer
+managedServerName: org.eclipse.birt.report.viewer.server

--- a/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty-selector.xml
+++ b/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty-selector.xml
@@ -21,8 +21,8 @@
                 </Item>
               </Array>
              </Arg>
-            <Set name="host"><Property name="jetty.host" /></Set>
-            <Set name="port"><Property name="jetty.port" default="8080"/></Set>
+            <Set name="host"><Property name="jetty.http.host" /></Set>
+            <Set name="port"><Property name="jetty.http.port" default="8080"/></Set>
             <Set name="idleTimeout">300000</Set>
           </New>
       </Arg>

--- a/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty.xml
+++ b/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty.xml
@@ -65,6 +65,11 @@
     <!-- =========================================================== -->
     <!-- jetty-jndi by default                                       -->
     <!-- =========================================================== -->
+<!-- There is no need in modifying the default configuration sequence since
+     it already includes those items. The following section is commented out
+     and kept here for hystorical and testing reasons since it was used with
+     Jetty 9.2. -->
+<!--
     <Call class="org.eclipse.jetty.webapp.Configuration$ClassList" name="setServerDefault">
       <Arg><Ref refid="Server" /></Arg>
       <Call name="addAfter">
@@ -73,11 +78,11 @@
           <Array type="String">
             <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
             <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
-            <Item>org.eclipse.jetty.annotations.AnnotationConfiguration</Item>
           </Array>
         </Arg>
       </Call>
     </Call>
+-->
 
     <Call class="java.lang.System" name="setProperty">
       <Arg>java.naming.factory.initial</Arg>

--- a/viewer/org.eclipse.birt.report.viewer/pom.xml
+++ b/viewer/org.eclipse.birt.report.viewer/pom.xml
@@ -10,6 +10,33 @@
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.viewer</artifactId>
 	<packaging>eclipse-plugin</packaging>
+	<profiles>
+        <profile>
+       	    <id>mars</id>
+            <!-- Jetty server connector property 'jetty.host' and 'jetty.port' was replaced by 'jetty.http.host' and 'jetty.http.port' in Jetty 9.3+ -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-resources</phase>
+                                <configuration>
+                                    <tasks>
+                                        <replace token="jetty.http.host" value="jetty.host" file="jettyhome/etc/jetty-selector.xml"/>
+                                        <replace token="jetty.http.port" value="jetty.port" file="jettyhome/etc/jetty-selector.xml"/>
+                                    </tasks>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+	</profiles>
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
* Jetty 9.4+ is now required for Oxygen, so upgraded Jetty to 9.4.1.
This fixes the report preview issue.
* Restricted Jetty to specific version for each profile. This is
required for suporting three different profiles for three different
releases. This also allowed to remove its version from build files.
* Upgraded Tycho to version 1.0.0 due to a Tycho 0.25.0 bug, which broke
the BIRT build when usign the latest Eclipse Oxygen milestones.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>