### PR TITLE
BIRT getMessage("key") call does not take the defined locale in Preview settings but the default en_US

### DIFF
--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/ModuleOption.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/ModuleOption.java
@@ -313,8 +313,8 @@ public class ModuleOption implements IModuleOption
 
 	private boolean isPrimitiveType( Object obj )
 	{
-		// check if class name is like java.lang.String,Integer,Long
-		return obj == null
+		// check if instance of ULocale or class name is like java.lang.String,Integer,Long
+		return obj == null || (obj instanceof ULocale)
 				|| obj.getClass( ).getName( ).startsWith( "java.lang." ); //$NON-NLS-1$
 	}
 


### PR DESCRIPTION
…o remove Locale.

Signed-off-by: Ravikiran Katneni <rkatneni@opentext.com>