### PR TITLE
Bug 520124: Add missing ScriptEngineFactory schema file entry

### DIFF
--- a/core/org.eclipse.birt.core/build.properties
+++ b/core/org.eclipse.birt.core/build.properties
@@ -6,6 +6,7 @@ bin.includes = plugin.xml,\
                about.html,\
                META-INF/MANIFEST.MF,\
                schema/FactoryService.exsd,\
+               schema/ScriptEngineFactory.exsd,\
                schema/ScriptFunctionService.exsd
 src.includes = about.html
 jars.extra.classpath = lib/servlet.jar


### PR DESCRIPTION
Hello BIRT Committers,
This pull request adds missing entry for the ScriptEngineFactory.exsd in build.properties.
Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=520124.

I had found this out some days ago and asked for it on the mailing list.
http://dev.eclipse.org/mhonarc/lists/birt-dev/msg10988.html
Please let me know what you think.

Regards,
Zorawar