### PR TITLE
-Description of Issue: chart legend string contains an '=' symbol, it will get truncated

### DIFF
--- a/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/internal/datafeed/DataProcessor.java
+++ b/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/internal/datafeed/DataProcessor.java
@@ -1004,9 +1004,22 @@ public class DataProcessor
 						if ( sExpression == null )
 							sExpression = IConstants.UNDEFINED_STRING;
 						// TODO format the group key.
-						seOrthogonalRuntimeSeries.setSeriesIdentifier( rsw.getGroupKey( k,
+						Object seriesIdentifier = rsw.getGroupKey( k,
 								sExpression,
-								aggExp ) );
+								aggExp );
+						if ( seriesIdentifier instanceof String )
+						{
+							String prefixedWithSeperator = ChartUtil
+									.prefixExternalizeSeperator(
+											(String) seriesIdentifier );
+							seOrthogonalRuntimeSeries.setSeriesIdentifier(
+									prefixedWithSeperator );
+						}
+						else
+						{
+							seOrthogonalRuntimeSeries
+									.setSeriesIdentifier( seriesIdentifier );
+						}
 						sdOrthogonal.getSeries( )
 								.add( seOrthogonalRuntimeSeries );
 

--- a/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/util/ChartUtil.java
+++ b/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/util/ChartUtil.java
@@ -114,6 +114,7 @@ public class ChartUtil
 	 * represent the value of chart max row number.
 	 */
 	public static final String CHART_MAX_ROW = "CHART_MAX_ROW"; //$NON-NLS-1$	
+	public static final String SEPARATOR = "=";
 	
 	private static final NumberFormat DEFAULT_NUMBER_FORMAT = initDefaultNumberFormat( );
 	
@@ -2807,5 +2808,16 @@ public class ChartUtil
 				av.setLabel( l );
 			}
 		}
+	}
+	
+	public static String prefixExternalizeSeperator( String sCurrentValue )
+	{
+
+		if ( sCurrentValue != null && sCurrentValue.contains( SEPARATOR ) )
+		{
+			return SEPARATOR + sCurrentValue;
+		}
+
+		return sCurrentValue;
 	}
 }

--- a/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/composites/ExternalizedTextEditorComposite.java
+++ b/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/composites/ExternalizedTextEditorComposite.java
@@ -17,6 +17,7 @@ import org.eclipse.birt.chart.ui.extension.i18n.Messages;
 import org.eclipse.birt.chart.ui.swt.interfaces.IUIServiceProvider;
 import org.eclipse.birt.chart.ui.util.ChartUIUtil;
 import org.eclipse.birt.chart.ui.util.UIHelper;
+import org.eclipse.birt.chart.util.ChartUtil;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
@@ -168,13 +169,9 @@ public class ExternalizedTextEditorComposite extends Canvas implements Selection
 		{
 			return sKey + ExternalizedTextEditorComposite.SEPARATOR + sCurrent;
 		}
-    	else if ( sCurrent.contains( ExternalizedTextEditorComposite.SEPARATOR ) )
-		{
-			return ExternalizedTextEditorComposite.SEPARATOR + sCurrent;
-		}
     	else
 		{
-			return sCurrent;
+    		return ChartUtil.prefixExternalizeSeperator( sCurrent );
 		}
     }
 


### PR DESCRIPTION
If the chart legend string contains an '=' symbol, it will truncate.

-Description of Resolution:
For y optional generateed series name with having “=” to be rendered
correctly we had prefixed '='.


Signed-off-by: rrimmana <rrimmana@RRIMMANA4J5LX52.opentext.net>