### PR TITLE
Broken image icon is not displaying in Mozilla, but it is displaying in

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
@@ -321,7 +321,8 @@ public class HTMLReportEmitter extends ContentEmitterAdapter
 	protected int browserVersion;
 	// The browser supports the inline-block or not. The default state is true;
 	protected boolean browserSupportsInlineBlock = true;
-	
+	// The browser supports the broken image icon.
+		protected boolean browserSupportsBrokenImageIcon = false;	
 	protected int imageDpi = -1;
 	
 	protected HTMLEmitter htmlEmitter;
@@ -448,6 +449,13 @@ public class HTMLReportEmitter extends ContentEmitterAdapter
 					|| browserVersion == HTMLEmitterUtil.BROWSER_FIREFOX2 )
 			{
 				browserSupportsInlineBlock = false;
+			}
+//  Single Metric: Dont provide alt attribute to the img element in single metric			
+			if(browserVersion==HTMLEmitterUtil.BROWSER_FIREFOX
+			 ||browserVersion==HTMLEmitterUtil.BROWSER_FIREFOX1
+			 ||browserVersion==HTMLEmitterUtil.BROWSER_FIREFOX2)
+			{
+				browserSupportsBrokenImageIcon=true;
 			}
 		}
 	}
@@ -3122,7 +3130,11 @@ public class HTMLReportEmitter extends ContentEmitterAdapter
 			String altText = image.getAltText( );
 			if ( altText == null )
 			{
+//				#BIRT-3336 : Single Metric: Dont provide alt attribute to the img element in single metric
+				if(!browserSupportsBrokenImageIcon)
+				{
 				writer.attributeAllowEmpty( HTMLTags.ATTR_ALT, "" );
+				}
 			}
 			else
 			{

--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/util/HTMLEmitterUtil.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/util/HTMLEmitterUtil.java
@@ -234,6 +234,7 @@ public class HTMLEmitterUtil
 	}
 	
 	public static int BROWSER_UNKNOW = -1;
+	public static int BROWSER_FIREFOX = 10;
 	public static int BROWSER_FIREFOX1 = 11;
 	public static int BROWSER_FIREFOX2 = 12;
 	public static int BROWSER_FIREFOX3 = 13;
@@ -266,6 +267,10 @@ public class HTMLEmitterUtil
 		else if ( userAgent.contains( "Firefox/2" ) )
 		{
 			return BROWSER_FIREFOX2;
+		}
+		else if ( userAgent.contains( "Firefox" ) )
+		{
+			return BROWSER_FIREFOX;
 		}
 		else
 			return BROWSER_UNKNOW;


### PR DESCRIPTION
Chrome
Dont provide alt attribute to the img element in single metric.

Signed-off-by: rvasanth <rvasanth@RVASANTHBZ44NV1.opentext.net>