### PR TITLE
Fixing Bug 347479 - Bar chart with study layout and negative value

### DIFF
--- a/chart/org.eclipse.birt.chart.engine.extension/src/org/eclipse/birt/chart/extension/render/Bar.java
+++ b/chart/org.eclipse.birt.chart.engine.extension/src/org/eclipse/birt/chart/extension/render/Bar.java
@@ -737,6 +737,7 @@ public final class Bar extends AxesRenderer
 									ChartException.RENDERING,
 									ex );
 						}
+						dBaseLocation = dZeroLocation;
 						dY = au.getLastPosition( dValue );
 					}
 				}


### PR DESCRIPTION
When we have a Bar chart with study layout and negative value the bars are not rendered properly because of  "bad" dBaseLocation calculation.