### PR TITLE
Fixing Bug 472025 - Wrong assert statement in SimpleResultSet

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/transform/SimpleResultSet.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/transform/SimpleResultSet.java
@@ -533,7 +533,7 @@ public class SimpleResultSet implements IResultIterator
 	public void doSave( StreamWrapper streamsWrapper, boolean isSubQuery )
 			throws DataException
 	{
-		assert streamsWrapper == null;
+		assert streamsWrapper != null;
 		this.streamsWrapper = streamsWrapper;
 		this.auxiliaryIndexCreators = streamsWrapper.getAuxiliaryIndexCreators( );
 		this.groupCalculator.doSave( streamsWrapper.getStreamManager( ) );


### PR DESCRIPTION
Fixed the inverted / wrong-way-round assertion reported in bug [472025 ](https://bugs.eclipse.org/bugs/show_bug.cgi?id=472025) and [512004](https://bugs.eclipse.org/bugs/show_bug.cgi?id=512004).