### PR TITLE
Updating Jetty, MongoDB and Tycho versions in neon profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,20 +44,20 @@
             <id>neon</id>
             <properties>
                 <eclipse.release.name>neon</eclipse.release.name>
-                <tycho.version>0.25.0</tycho.version>
+                <tycho.version>1.0.0</tycho.version>
                 <eclipse.repo.url>http://download.eclipse.org/eclipse/updates/4.6/</eclipse.repo.url>
                 <emf.repo.url>http://download.eclipse.org/modeling/emf/emf/updates/2.12/</emf.repo.url>
                 <gef.repo.url>http://download.eclipse.org/tools/gef/updates/legacy/releases/</gef.repo.url>
                 <!-- https://wiki.eclipse.org/WTP_FAQ#How_do_I_install_WTP.3F -->
                 <wtp.repo.url>http://download.eclipse.org/webtools/repository/neon/</wtp.repo.url>
                 <!-- http://download.eclipse.org/tools/orbit/downloads/ -->
-                <orbit.repo.url>http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/</orbit.repo.url>
+                <orbit.repo.url>http://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository/</orbit.repo.url>
                 <!-- https://eclipse.org/datatools/downloads.php  -->
                 <dtp.repo.url>http://download.eclipse.org/datatools/updates/1.13/1.13.0.201603142002/repository</dtp.repo.url>
-                <jetty.version>9.2.13.v20150730</jetty.version>
+                <jetty.version>9.3.9.v20160517</jetty.version>
                 <!--jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/</jetty.repo.url-->
                 <jetty.repo.url>http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/${jetty.version}</jetty.repo.url>
-                <mongodb.version>2.10.1.v20130422-1135</mongodb.version>
+                <mongodb.version>3.2.2.v20170222-2110</mongodb.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Updated profile 'neon' with more current Tycho, MongoDB and Jetty versions.

Signed-off-by: Serguei Krivtsov <skrivtsov@actuate.com>