### PR TITLE
Fixed emitter output to more than one page when hitting cache limit

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/ContentEmitterAdapter.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/ContentEmitterAdapter.java
@@ -207,4 +207,8 @@ public class ContentEmitterAdapter implements IContentEmitter
 		startGroup(group);
 	}
 
+	public boolean isMultiplePagesEnabled( )
+	{
+		return true;
+	}
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/IContentEmitter.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/IContentEmitter.java
@@ -123,4 +123,12 @@ public interface IContentEmitter
 	void startListGroup( IListGroupContent group ) throws BirtException;
 
 	void endListGroup( IListGroupContent group ) throws BirtException;
+
+	/**
+	 * Indicates if multiple page is enabled in current emitter.
+	 * 
+	 * @since 4.7
+	 * @return true means multiple page is enabled
+	 */
+	boolean isMultiplePagesEnabled( );
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/html/HTMLTableLayoutEmitter.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/html/HTMLTableLayoutEmitter.java
@@ -51,7 +51,7 @@ public class HTMLTableLayoutEmitter extends ContentEmitterAdapter
 	/**
 	 * the emitter used to output the table content
 	 */
-	protected IContentEmitter emitter;
+	protected final IContentEmitter emitter;
 
 	/**
 	 * the current table layout
@@ -631,7 +631,8 @@ public class HTMLTableLayoutEmitter extends ContentEmitterAdapter
 				hasDropCell = layout.hasDropCell( );
 				if ( hasDropCell( ) )
 				{
-					if ( layout.exceedMaxCache( ) )
+					// Page break only if multiple page is enabled and cache exceed max limit
+					if ( emitter.isMultiplePagesEnabled( ) && layout.exceedMaxCache( ) )
 					{
 						context.softRowBreak = true;
 					}


### PR DESCRIPTION
Description of Issue: emitter with "multiple page" option disabled does not export content into single page due to hitting table cache limit

Description of Resolution: Add an emitter trigger function at the API layer.  Cache limit check is skipped when the emitter disables multiple sheet