### PR TITLE
revert api change to prevent cascading effect

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/IContentEmitter.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/IContentEmitter.java
@@ -123,12 +123,4 @@ public interface IContentEmitter
 	void startListGroup( IListGroupContent group ) throws BirtException;
 
 	void endListGroup( IListGroupContent group ) throws BirtException;
-
-	/**
-	 * Indicates if multiple page is enabled in current emitter.
-	 * 
-	 * @since 4.7
-	 * @return true means multiple page is enabled
-	 */
-	boolean isMultiplePagesEnabled( );
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/html/HTMLTableLayoutEmitter.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/html/HTMLTableLayoutEmitter.java
@@ -51,7 +51,7 @@ public class HTMLTableLayoutEmitter extends ContentEmitterAdapter
 	/**
 	 * the emitter used to output the table content
 	 */
-	protected final IContentEmitter emitter;
+	protected IContentEmitter emitter;
 
 	/**
 	 * the current table layout
@@ -632,7 +632,11 @@ public class HTMLTableLayoutEmitter extends ContentEmitterAdapter
 				if ( hasDropCell( ) )
 				{
 					// Page break only if multiple page is enabled and cache exceed max limit
-					if ( emitter.isMultiplePagesEnabled( ) && layout.exceedMaxCache( ) )
+					if ( emitter instanceof ContentEmitterAdapter && !((ContentEmitterAdapter)emitter).isMultiplePagesEnabled( ) )
+					{
+						return;
+					}
+					if ( layout.exceedMaxCache( ) )
 					{
 						context.softRowBreak = true;
 					}

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/ExcelEmitter.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/ExcelEmitter.java
@@ -442,11 +442,6 @@ public abstract class ExcelEmitter implements IContentEmitter {
 		handlerState.getHandler().endListGroup(handlerState,group);
 		log.removePrefix( 'G' );
 	}
-
-	@Override
-	public boolean isMultiplePagesEnabled() {
-		return true;
-	}
 	
 	
 	


### PR DESCRIPTION
Revert the function addition at the IContentEmitter interface as there are other classes that implement this interface directly.  Keep the function at ContentEmitterAdapter and only check emitters that extend from this class