### PR TITLE
BIRT-3744 Spark: wrong output results in xtab in measures for some aggregate functions in report run in AJC

### DIFF
--- a/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/re/CrosstabQueryUtil.java
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/re/CrosstabQueryUtil.java
@@ -337,7 +337,7 @@ public class CrosstabQueryUtil implements ICrosstabConstants
 		if( measureBindingName != null )
 		{
 			IMeasureDefinition mDef = cubeQuery.createMeasure( measureBindingName );
-			mDef.setAggrFunction( DataAdapterUtil.getRollUpAggregationName( aggrFunc ) );
+			mDef.setAggrFunction(  aggrFunc  );
 		}
 	}
 	


### PR DESCRIPTION
Cross tab using data model measure with aggregate function COUNT is automatically getting converted into SUM.