### PR TITLE
Cross tab using data model measure with aggregate function COUNT is automatically getting converted into SUM.

### DIFF
--- a/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/re/CrosstabQueryUtil.java
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/re/CrosstabQueryUtil.java
@@ -337,7 +337,7 @@ public class CrosstabQueryUtil implements ICrosstabConstants
 		if( measureBindingName != null )
 		{
 			IMeasureDefinition mDef = cubeQuery.createMeasure( measureBindingName );
-			mDef.setAggrFunction( DataAdapterUtil.getRollUpAggregationName( aggrFunc ) );
+			mDef.setAggrFunction(  aggrFunc  );
 		}
 	}
 	


### PR DESCRIPTION
We found that at runtime, aggregate function count is getting converted to sum for crosstab queries for data model. 