### PR TITLE
Added support for PDF appending. Due to a number of customer requests to

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/META-INF/MANIFEST.MF
@@ -12,9 +12,8 @@ Require-Bundle: org.eclipse.birt.core;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine.fonts;bundle-version="[2.1.0,5.0.0)",
  com.lowagie.text;bundle-version="[1.3.0,3.0.0)",
- org.apache.batik.transcoder;bundle-version="[1.6.0,2.0.0)",
- com.ibm.icu
-Eclipse-LazyStart: true
+ org.apache.batik.transcoder;bundle-version="[1.6.0,2.0.0)"
+Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.birt.report.engine.emitter.pdf.plugin.PDFEmitterPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-ExtensibleAPI: true

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.birt.core;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine.fonts;bundle-version="[2.1.0,5.0.0)",
  com.lowagie.text;bundle-version="[1.3.0,3.0.0)",
- org.apache.batik.transcoder;bundle-version="[1.6.0,2.0.0)"
+ org.apache.batik.transcoder;bundle-version="[1.6.0,2.0.0)",
+ com.ibm.icu
 Eclipse-LazyStart: true
 Bundle-Activator: org.eclipse.birt.report.engine.emitter.pdf.plugin.PDFEmitterPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
@@ -87,6 +87,7 @@ public class PDFPageDevice implements IPageDevice
 	protected final static int MAX_PAGE_WIDTH = 14400000; // 200 inch
 	protected final static int MAX_PAGE_HEIGHT = 14400000; // 200 inch
 	
+	//Property names for list of files to append or prepend to PDF output
 	private static String APPEND_PROPERTY_NAME = "AppendList";
 	private static String PREPEND_PROPERTY_NAME = "PrependList";
 


### PR DESCRIPTION
have the ability to append boiler plate legal documentation or financial
statements to a report, the ability to append PDF files based on a
comma-seperated list or a ArrayList defined in the Report Context has
been added.

This has been tested in actual customer environments and works. To set:
-Create a BIRT Report
-Create a User Property called AppendList.
-Set AppendList under Advanced to a Comma-Seperated list of paths to PDF files to append

-Alternatively, create an ArrayList of String in the report context set in global variable called appendPDF.