### PR TITLE
update crosstabUtil to properly handle special characters

### DIFF
--- a/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/util/CrosstabUtil.java
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/util/CrosstabUtil.java
@@ -1116,6 +1116,10 @@ public final class CrosstabUtil implements ICrosstabConstants
 		{
 			columnName = "[^\\]]+";
 		}
+		else
+		{
+			columnName = Pattern.quote( columnName );
+		}
 		
 		ExpressionHandle expr = column
 				.getExpressionProperty( ComputedColumn.EXPRESSION_MEMBER );		


### PR DESCRIPTION
crosstabUtil does not properly handle special characters for column names. This leads to corner case issue when the column name is like "[asasas]][", "?12", etc
Properly update the utility when column name contains special characters