### PR TITLE
Added an overloaded getmessage() to JDBCException

### DIFF
--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/JDBCException.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/JDBCException.java
@@ -164,6 +164,37 @@ public class JDBCException extends OdaException
 		return msg;
 	}
 	
+	public String getMessage( ULocale locale )
+	{
+		JdbcResourceHandle resourceHandle = new JdbcResourceHandle( locale );
+		String msg;
+		if ( argv == null )
+		{
+			msg = resourceHandle.getMessage( errorCode );
+		}
+		else
+		{
+			msg = resourceHandle.getMessage( errorCode, argv );
+		}
+
+		Throwable cause = getCause();
+		if ( cause != null )
+		{
+			String extraMsg;
+			if ( cause instanceof SQLException )
+			{
+				extraMsg = getSQLExceptionMesssage( (SQLException) cause);
+			}
+			else
+			{
+				extraMsg = cause.getLocalizedMessage();
+			}
+			if ( extraMsg != null && extraMsg.length() > 0 )
+				msg += "\n" + extraMsg;
+		}
+		return msg;
+	}
+
 	/**
 	 * Utility function to log a SQLException to provided logger. 
 	 */ 

--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/OdaJdbcDriver.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/OdaJdbcDriver.java
@@ -52,7 +52,7 @@ public class OdaJdbcDriver implements IDriver
 		public static final String DRIVER_INFO_ATTR_NAME = "name";
 		public static final String DRIVER_INFO_ATTR_DRIVERCLASS= "driverClass";
 		public static final String DRIVER_INFO_ATTR_URLTEMPL = "urlTemplate";
-		public static final String DRIVER_INFO_ATTR_SELETORID = "selectorId";
+		public static final String DRIVER_INFO_ATTR_SELECTORID = "selectorId";
 		public static final String DRIVER_INFO_ATTR_CONNFACTORY = "connectionFactory";
 		public static final String DRIVER_INFO_ELEM_JDBCDRIVER = "jdbcDriver";
 		public static final String DRIVER_INFO_ATTR_HIDE = "hide";

--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/utils/JDBCDriverInfoManager.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/utils/JDBCDriverInfoManager.java
@@ -125,7 +125,7 @@ public class JDBCDriverInfoManager
 		driverInfo.setUrlFormat( 
 				configElement.getAttribute( OdaJdbcDriver.Constants.DRIVER_INFO_ATTR_URLTEMPL ) );
 		driverInfo.setSelectorId( 
-				configElement.getAttribute( OdaJdbcDriver.Constants.DRIVER_INFO_ATTR_SELETORID ) );
+				configElement.getAttribute( OdaJdbcDriver.Constants.DRIVER_INFO_ATTR_SELECTORID ) );
 		driverInfo.setHide( configElement.getAttribute( OdaJdbcDriver.Constants.DRIVER_INFO_ATTR_HIDE ) );
 		driverInfo.populateProperties( configElement );
 		return driverInfo;


### PR DESCRIPTION
1)Added an overloaded getmessage() to JDBCException  which now takes locale as an argument and displays the exception message in the locale
2)Also fixed a typo-error
Signed-off-by: Bharadwaj14 <tbharadwaj14@gmail.com>