### PR TITLE
fix regression bug on data set preview fetch row limit

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.data/src/org/eclipse/birt/report/designer/data/ui/dataset/ResultSetPreviewPage.java
+++ b/UI/org.eclipse.birt.report.designer.ui.data/src/org/eclipse/birt/report/designer/data/ui/dataset/ResultSetPreviewPage.java
@@ -250,7 +250,7 @@ public class ResultSetPreviewPage extends AbstractPropertyPage
 			dataSetHandle = ( (DataSetEditor) getContainer( ) ).getHandle( );
 			
 			int maxRow = this.getMaxRowPreference( );
-			if( dataSetHandle.getRowFetchLimit( )<=0 || dataSetHandle.getRowFetchLimit( )> maxRow )
+			if( dataSetHandle.getRowFetchLimit( )<=0 )
 			{
 				ModuleHandle moduleHandle = ( (Module) dataSetHandle.getRoot( )
 						.copy( ) ).getModuleHandle( );


### PR DESCRIPTION
Root cause of the issue:
Regression caused by commits 0b411e2d, 6314f9b7, and 92ceae23
- There are 2 row fetch limit values for data set preview in BDPro. One is the data set preview display limit(default is 500), the other is data set source fetch limit(default is unlimited)
- Original intent of commits is to push down preview display limit(500) to ODA prepared statement when ODA data set fetch limit is default/ unlimited. This is to address accessing Big Data type of data source.
- This causes a regression where the 500 value is hardcoded and data set is always fetching at most 500 rows from data source. 
- The regression causes 2 issues:
1.Data set filters are always applied only on the fetched 500 rows of data rather than the entire data set
2.Customly setting the data source fetch size for size>500 no longer works as preview always fetch 500 rows
