### PR TITLE
Maven 3.5+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ To build BIRT with Eclipse Mars, run:
     
 ### Building environment
 * JDK 1.8
-* Maven 3.3.1 or 3.3.3
+* Maven 3.5+
 

--- a/UI/org.eclipse.birt.report.debug.core/pom.xml
+++ b/UI/org.eclipse.birt.report.debug.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.debug.ui/pom.xml
+++ b/UI/org.eclipse.birt.report.debug.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.core/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.samplereports/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.samplereports/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.tests/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.cubebuilder/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.cubebuilder/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.data/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.data/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.editor.script/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editor.script/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.editor.xml.wtp/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editor.xml.wtp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.editors.schematic/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editors.schematic/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.editors/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editors/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.ide/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.ide/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.lib.explorer/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.lib.explorer/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.lib/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.lib/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.preview.static_html/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.static_html/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.preview.test/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.preview.web/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.web/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.preview/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.rcp/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.samples.ide/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.samples.ide/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.samples.rcp/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.samples.rcp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.samplesview/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.samplesview/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui.views/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.views/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/org.eclipse.birt.report.designer.ui/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/UI/pom.xml
+++ b/UI/pom.xml
@@ -4,13 +4,12 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.UI</groupId>
 	<artifactId>org.eclipse.birt.UI-parent</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>4.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/build/birt-packages/birt-charts/ChartRuntime/pom.xml
+++ b/build/birt-packages/birt-charts/ChartRuntime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/build/birt-packages/birt-charts/ChartSDK/pom.xml
+++ b/build/birt-packages/birt-charts/ChartSDK/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/build/birt-packages/birt-charts/DeploymentRuntime/pom.xml
+++ b/build/birt-packages/birt-charts/DeploymentRuntime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/build/birt-packages/birt-charts/pom.xml
+++ b/build/birt-packages/birt-charts/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt.birt-packages.birt-charts</groupId>
 	<artifactId>birt-charts</artifactId>

--- a/build/birt-packages/birt-epp/pom.xml
+++ b/build/birt-packages/birt-epp/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-epp</artifactId>

--- a/build/birt-packages/birt-integration-test/pom.xml
+++ b/build/birt-packages/birt-integration-test/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-integration-test</artifactId>

--- a/build/birt-packages/birt-nl/birt-charts/pom.xml
+++ b/build/birt-packages/birt-nl/birt-charts/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package.nl</groupId>
 		<artifactId>org.eclipse.birt.build.package.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>NLpack1-birt-charts</artifactId>

--- a/build/birt-packages/birt-nl/birt-rcp-report-designer/pom.xml
+++ b/build/birt-packages/birt-nl/birt-rcp-report-designer/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package.nl</groupId>
 		<artifactId>org.eclipse.birt.build.package.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>NLpack1-birt-rcp-report-designer</artifactId>

--- a/build/birt-packages/birt-nl/birt-report-designer-all-in-one/pom.xml
+++ b/build/birt-packages/birt-nl/birt-report-designer-all-in-one/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package.nl</groupId>
 		<artifactId>org.eclipse.birt.build.package.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>NLpack1-birt-report-designer-all-in-one</artifactId>

--- a/build/birt-packages/birt-nl/birt-report-framework/pom.xml
+++ b/build/birt-packages/birt-nl/birt-report-framework/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package.nl</groupId>
 		<artifactId>org.eclipse.birt.build.package.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>NLpack1-birt-report-framework</artifactId>

--- a/build/birt-packages/birt-nl/birt-runtime/pom.xml
+++ b/build/birt-packages/birt-nl/birt-runtime/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package.nl</groupId>
 		<artifactId>org.eclipse.birt.build.package.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>NLpack1-birt-runtime</artifactId>

--- a/build/birt-packages/birt-nl/pom.xml
+++ b/build/birt-packages/birt-nl/pom.xml
@@ -8,8 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.build.package.nl</groupId>

--- a/build/birt-packages/birt-publish/pom.xml
+++ b/build/birt-packages/birt-publish/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-publish</artifactId>

--- a/build/birt-packages/birt-report-all-in-one/pom.xml
+++ b/build/birt-packages/birt-report-all-in-one/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-report-all-in-one</artifactId>

--- a/build/birt-packages/birt-report-framework-sdk/pom.xml
+++ b/build/birt-packages/birt-report-framework-sdk/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt</groupId>

--- a/build/birt-packages/birt-report-framework/pom.xml
+++ b/build/birt-packages/birt-report-framework/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt</groupId>

--- a/build/birt-packages/birt-report-rcp/pom.xml
+++ b/build/birt-packages/birt-report-rcp/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-report-rcp</artifactId>

--- a/build/birt-packages/birt-runtime-osgi/pom.xml
+++ b/build/birt-packages/birt-runtime-osgi/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-runtime-osgi</artifactId>

--- a/build/birt-packages/birt-runtime-test/pom.xml
+++ b/build/birt-packages/birt-runtime-test/pom.xml
@@ -4,8 +4,7 @@
   <parent>
     <groupId>org.eclipse.birt.build.package</groupId>
     <artifactId>org.eclipse.birt.build.package-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.birt</groupId>
   <artifactId>birt-runtime-test</artifactId>

--- a/build/birt-packages/birt-runtime/pom.xml
+++ b/build/birt-packages/birt-runtime/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-runtime</artifactId>

--- a/build/birt-packages/birt-sample-plugins/pom.xml
+++ b/build/birt-packages/birt-sample-plugins/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-sample-plugins</artifactId>

--- a/build/birt-packages/birt-source/pom.xml
+++ b/build/birt-packages/birt-source/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt</groupId>

--- a/build/birt-packages/birt-tests-suite/pom.xml
+++ b/build/birt-packages/birt-tests-suite/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>birt-tests-suite</artifactId>

--- a/build/birt-packages/birt-wtp-integration-sdk/pom.xml
+++ b/build/birt-packages/birt-wtp-integration-sdk/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build.package</groupId>
 		<artifactId>org.eclipse.birt.build.package-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt</groupId>

--- a/build/birt-packages/pom.xml
+++ b/build/birt-packages/pom.xml
@@ -11,8 +11,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build</groupId>
 		<artifactId>org.eclipse.birt.build-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.build.package</groupId>

--- a/build/org.eclipse.birt.api/pom.xml
+++ b/build/org.eclipse.birt.api/pom.xml
@@ -4,8 +4,7 @@
   <parent>
     <groupId>org.eclipse.birt.build</groupId>
     <artifactId>org.eclipse.birt.build-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.birt</groupId>
   <artifactId>org.eclipse.birt.api</artifactId>

--- a/build/org.eclipse.birt.build/pom.xml
+++ b/build/org.eclipse.birt.build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.birt</groupId>
     <artifactId>org.eclipse.birt-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.birt</groupId>

--- a/build/org.eclipse.birt.chart/pom.xml
+++ b/build/org.eclipse.birt.chart/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/build/org.eclipse.birt.example/pom.xml
+++ b/build/org.eclipse.birt.example/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/build/org.eclipse.birt.p2updatesite/pom.xml
+++ b/build/org.eclipse.birt.p2updatesite/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build</groupId>
 		<artifactId>org.eclipse.birt.build-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt</groupId>

--- a/build/org.eclipse.birt.releng.birtbuilder/extras/pom.xml
+++ b/build/org.eclipse.birt.releng.birtbuilder/extras/pom.xml
@@ -5,11 +5,10 @@
   <parent>
     <groupId>org.eclipse.birt</groupId>
     <artifactId>org.eclipse.birt-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.eclipse.birt</groupId>
   <artifactId>extras</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>eclipse-update-site</packaging>
 </project>

--- a/build/org.eclipse.birt.sdk/pom.xml
+++ b/build/org.eclipse.birt.sdk/pom.xml
@@ -6,8 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.birt.build</groupId>
 		<artifactId>org.eclipse.birt.build-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.eclipse.birt</groupId>

--- a/build/org.eclipse.birt/pom.xml
+++ b/build/org.eclipse.birt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.build</groupId>

--- a/chart/org.eclipse.birt.chart.device.extension/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.extension/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.device.pdf/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.pdf/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.device.svg/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.svg/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.device.swt/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.swt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.engine.extension/pom.xml
+++ b/chart/org.eclipse.birt.chart.engine.extension/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.engine/pom.xml
+++ b/chart/org.eclipse.birt.chart.engine/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.examples.core/pom.xml
+++ b/chart/org.eclipse.birt.chart.examples.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.examples/pom.xml
+++ b/chart/org.eclipse.birt.chart.examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.integration.wtp.ui/pom.xml
+++ b/chart/org.eclipse.birt.chart.integration.wtp.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.reportitem.ui/pom.xml
+++ b/chart/org.eclipse.birt.chart.reportitem.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.reportitem/pom.xml
+++ b/chart/org.eclipse.birt.chart.reportitem/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.tests/pom.xml
+++ b/chart/org.eclipse.birt.chart.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.ui.extension/pom.xml
+++ b/chart/org.eclipse.birt.chart.ui.extension/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.ui/pom.xml
+++ b/chart/org.eclipse.birt.chart.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/org.eclipse.birt.chart.viewer/pom.xml
+++ b/chart/org.eclipse.birt.chart.viewer/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/chart/pom.xml
+++ b/chart/pom.xml
@@ -5,8 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.chart</groupId>

--- a/common/org.apache.batik.ext.awt.extension/pom.xml
+++ b/common/org.apache.batik.ext.awt.extension/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/common/org.apache.derby.core/pom.xml
+++ b/common/org.apache.derby.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/common/org.w3c.dom.svg.extension/pom.xml
+++ b/common/org.w3c.dom.svg.extension/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/common/org.w3c.sac/pom.xml
+++ b/common/org.w3c.sac/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.common</groupId>

--- a/core/org.eclipse.birt.core.testhelper/pom.xml
+++ b/core/org.eclipse.birt.core.testhelper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/core/org.eclipse.birt.core.tests/pom.xml
+++ b/core/org.eclipse.birt.core.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/core/org.eclipse.birt.core.ui/pom.xml
+++ b/core/org.eclipse.birt.core.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/core/org.eclipse.birt.core/pom.xml
+++ b/core/org.eclipse.birt.core/pom.xml
@@ -4,8 +4,7 @@
   <parent>
     <groupId>org.eclipse.birt.core</groupId>
     <artifactId>org.eclipse.birt.core-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <relativePath>../</relativePath>
+    <version>4.8.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.birt</groupId>
   <artifactId>org.eclipse.birt.core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.core</groupId>

--- a/data/org.eclipse.birt.core.script.function/pom.xml
+++ b/data/org.eclipse.birt.core.script.function/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data.aggregation/pom.xml
+++ b/data/org.eclipse.birt.data.aggregation/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data.oda.mongodb.ui/pom.xml
+++ b/data/org.eclipse.birt.data.oda.mongodb.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data.oda.mongodb/pom.xml
+++ b/data/org.eclipse.birt.data.oda.mongodb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data.oda.pojo.tests/pom.xml
+++ b/data/org.eclipse.birt.data.oda.pojo.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data.oda.pojo.ui/pom.xml
+++ b/data/org.eclipse.birt.data.oda.pojo.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data.oda.pojo/pom.xml
+++ b/data/org.eclipse.birt.data.oda.pojo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data.tests/pom.xml
+++ b/data/org.eclipse.birt.data.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.data/pom.xml
+++ b/data/org.eclipse.birt.data/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.me.prettyprint.hector/pom.xml
+++ b/data/org.eclipse.birt.me.prettyprint.hector/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.adapter/pom.xml
+++ b/data/org.eclipse.birt.report.data.adapter/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.bidi.utils.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.bidi.utils.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.bidi.utils/pom.xml
+++ b/data/org.eclipse.birt.report.data.bidi.utils/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.excel.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.excel.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.excel/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.excel/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.hive.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.hive.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.hive/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.hive/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.tests/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.jdbc/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.sampledb.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.sampledb.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.sampledb/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.sampledb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.xml.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.xml.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.data.oda.xml/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.xml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/org.eclipse.birt.report.engine.script.javascript/pom.xml
+++ b/data/org.eclipse.birt.report.engine.script.javascript/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.data</groupId>

--- a/docs/org.eclipse.birt.chart.cshelp/pom.xml
+++ b/docs/org.eclipse.birt.chart.cshelp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/docs/org.eclipse.birt.chart.doc.isv/pom.xml
+++ b/docs/org.eclipse.birt.chart.doc.isv/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/docs/org.eclipse.birt.cshelp/pom.xml
+++ b/docs/org.eclipse.birt.cshelp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/docs/org.eclipse.birt.doc.isv/pom.xml
+++ b/docs/org.eclipse.birt.doc.isv/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/docs/org.eclipse.birt.doc/pom.xml
+++ b/docs/org.eclipse.birt.doc/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.docs</groupId>

--- a/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.dataextraction.csv/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.dataextraction.csv/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.dataextraction/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.dataextraction/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.docx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.docx/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.excel/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.excel/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.html/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.html/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.odp/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.odp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.ods/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.ods/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.odt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.odt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.pdf/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.pdf/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.postscript/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.postscript/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.ppt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.ppt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.pptx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.pptx/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.wpml/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.wpml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.config/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.docx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.docx/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.html.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.html.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.html/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.odp/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.odp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.ods/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.ods/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.odt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.odt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.postscript.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.postscript.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.postscript/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.postscript/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.ppt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.ppt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.prototype.excel.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.prototype.excel.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.prototype.excel/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.prototype.excel/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.fonts/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.fonts/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.odf/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.odf/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.ooxml/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.ooxml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.testhelper/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.testhelper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/org.eclipse.birt.report.engine/pom.xml
+++ b/engine/org.eclipse.birt.report.engine/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.engine</groupId>

--- a/engine/uk.co.spudsoft.birt.emitters.excel.tests/pom.xml
+++ b/engine/uk.co.spudsoft.birt.emitters.excel.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/engine/uk.co.spudsoft.birt.emitters.excel/pom.xml
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/features/org.eclipse.birt.chart.cshelp.feature/pom.xml
+++ b/features/org.eclipse.birt.chart.cshelp.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.cshelp</artifactId>

--- a/features/org.eclipse.birt.chart.doc.isv.feature/pom.xml
+++ b/features/org.eclipse.birt.chart.doc.isv.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.doc.isv</artifactId>

--- a/features/org.eclipse.birt.chart.feature/pom.xml
+++ b/features/org.eclipse.birt.chart.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart</artifactId>

--- a/features/org.eclipse.birt.chart.integration.wtp.feature/pom.xml
+++ b/features/org.eclipse.birt.chart.integration.wtp.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.integration.wtp</artifactId>

--- a/features/org.eclipse.birt.chart.osgi.runtime.sdk/pom.xml
+++ b/features/org.eclipse.birt.chart.osgi.runtime.sdk/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.osgi.runtime.sdk</artifactId>

--- a/features/org.eclipse.birt.chart.osgi.runtime/pom.xml
+++ b/features/org.eclipse.birt.chart.osgi.runtime/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.osgi.runtime</artifactId>

--- a/features/org.eclipse.birt.chart.viewer.feature/pom.xml
+++ b/features/org.eclipse.birt.chart.viewer.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.viewer</artifactId>

--- a/features/org.eclipse.birt.cshelp.feature/pom.xml
+++ b/features/org.eclipse.birt.cshelp.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.cshelp</artifactId>

--- a/features/org.eclipse.birt.doc.feature/pom.xml
+++ b/features/org.eclipse.birt.doc.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.doc</artifactId>

--- a/features/org.eclipse.birt.doc.isv.feature/pom.xml
+++ b/features/org.eclipse.birt.doc.isv.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.doc.isv</artifactId>

--- a/features/org.eclipse.birt.engine.runtime/pom.xml
+++ b/features/org.eclipse.birt.engine.runtime/pom.xml
@@ -5,8 +5,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.engine.runtime</artifactId>

--- a/features/org.eclipse.birt.example.feature/pom.xml
+++ b/features/org.eclipse.birt.example.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.example</artifactId>

--- a/features/org.eclipse.birt.feature/pom.xml
+++ b/features/org.eclipse.birt.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt</artifactId>

--- a/features/org.eclipse.birt.integration.wtp.feature/pom.xml
+++ b/features/org.eclipse.birt.integration.wtp.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.integration.wtp</artifactId>

--- a/features/org.eclipse.birt.integration.wtp.sdk.feature/pom.xml
+++ b/features/org.eclipse.birt.integration.wtp.sdk.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.integration.wtp.sdk</artifactId>

--- a/features/org.eclipse.birt.nl.feature/pom.xml
+++ b/features/org.eclipse.birt.nl.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.nl</artifactId>

--- a/features/org.eclipse.birt.osgi.runtime.sdk/pom.xml
+++ b/features/org.eclipse.birt.osgi.runtime.sdk/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.osgi.runtime.sdk</artifactId>

--- a/features/org.eclipse.birt.osgi.runtime/pom.xml
+++ b/features/org.eclipse.birt.osgi.runtime/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.osgi.runtime</artifactId>

--- a/features/org.eclipse.birt.rcp.feature/pom.xml
+++ b/features/org.eclipse.birt.rcp.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.rcp</artifactId>

--- a/features/org.eclipse.birt.rcp.nl.feature/pom.xml
+++ b/features/org.eclipse.birt.rcp.nl.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.rcp.nl</artifactId>

--- a/features/org.eclipse.birt.report.designer.editor.xml.wtp.feature/pom.xml
+++ b/features/org.eclipse.birt.report.designer.editor.xml.wtp.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.report.designer.editor.xml.wtp</artifactId>

--- a/features/org.eclipse.birt.sdk.feature/pom.xml
+++ b/features/org.eclipse.birt.sdk.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.sdk</artifactId>

--- a/features/org.eclipse.birt.testhelper.feature/pom.xml
+++ b/features/org.eclipse.birt.testhelper.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.testhelper</artifactId>

--- a/features/org.eclipse.birt.tests.feature/pom.xml
+++ b/features/org.eclipse.birt.tests.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.tests</artifactId>

--- a/features/org.eclipse.birt.wtp.nl.feature/pom.xml
+++ b/features/org.eclipse.birt.wtp.nl.feature/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.features</groupId>
 		<artifactId>org.eclipse.birt.features-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.wtp.nl</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.features</groupId>

--- a/model/org.eclipse.birt.report.model.adapter.oda.tests/pom.xml
+++ b/model/org.eclipse.birt.report.model.adapter.oda.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/model/org.eclipse.birt.report.model.adapter.oda/pom.xml
+++ b/model/org.eclipse.birt.report.model.adapter.oda/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/model/org.eclipse.birt.report.model.testhelper/pom.xml
+++ b/model/org.eclipse.birt.report.model.testhelper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/model/org.eclipse.birt.report.model.testresources/pom.xml
+++ b/model/org.eclipse.birt.report.model.testresources/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/model/org.eclipse.birt.report.model.tests/pom.xml
+++ b/model/org.eclipse.birt.report.model.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/model/org.eclipse.birt.report.model/pom.xml
+++ b/model/org.eclipse.birt.report.model/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.model</groupId>
 		<artifactId>org.eclipse.birt.model-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.model</artifactId>

--- a/model/org.eclipse.birt.report.modelextension.tests/pom.xml
+++ b/model/org.eclipse.birt.report.modelextension.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/model/org.eclipse.birt.resources/pom.xml
+++ b/model/org.eclipse.birt.resources/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.model</groupId>

--- a/nl/org.eclipse.birt.chart.device.extension.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.device.extension.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.device.extension.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.device.svg.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.device.svg.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.device.svg.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.device.swt.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.device.swt.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.device.swt.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.engine.extension.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.engine.extension.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.engine.extension.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.engine.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.engine.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.engine.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.examples.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.examples.core.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.examples.core.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.examples.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.examples.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.examples.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.integration.wtp.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.integration.wtp.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.integration.wtp.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.reportitem.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.reportitem.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.reportitem.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.reportitem.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.reportitem.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.reportitem.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.ui.extension.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.ui.extension.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.ui.extension.nl1</artifactId>

--- a/nl/org.eclipse.birt.chart.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.core.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.core.nl1</artifactId>

--- a/nl/org.eclipse.birt.core.script.function.nl/pom.xml
+++ b/nl/org.eclipse.birt.core.script.function.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.core.script.function.nl1</artifactId>

--- a/nl/org.eclipse.birt.core.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.core.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.core.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.data.aggregation.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.aggregation.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.aggregation.nl1</artifactId>

--- a/nl/org.eclipse.birt.data.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.nl1</artifactId>

--- a/nl/org.eclipse.birt.data.oda.mongodb.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.mongodb.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.mongodb.nl1</artifactId>

--- a/nl/org.eclipse.birt.data.oda.mongodb.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.mongodb.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.mongodb.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.data.oda.pojo.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.pojo.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.pojo.nl1</artifactId>

--- a/nl/org.eclipse.birt.data.oda.pojo.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.pojo.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.pojo.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.integration.wtp.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.integration.wtp.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.integration.wtp.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.adapter.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.adapter.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.adapter.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.bidi.utils.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.bidi.utils.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.bidi.utils.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.excel.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.excel.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.excel.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.excel.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.excel.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.excel.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.hive.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.hive.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.hive.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.hive.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.hive.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.hive.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.sampledb.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.sampledb.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.sampledb.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.sampledb.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.sampledb.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.sampledb.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.xml.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.xml.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.xml.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.data.oda.xml.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.xml.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.xml.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.debug.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.debug.core.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.debug.core.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.debug.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.debug.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.debug.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.core.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.core.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.cubebuilder.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.cubebuilder.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.cubebuilder.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.editor.script.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editor.script.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editor.script.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.editor.xml.wtp.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editor.xml.wtp.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editor.xml.wtp.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.editors.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editors.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editors.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.editors.schematic.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editors.schematic.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editors.schematic.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.ide.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.ide.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.ide.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.lib.explorer.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.lib.explorer.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.lib.explorer.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.lib.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.lib.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.lib.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.preview.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.preview.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.preview.web.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.preview.web.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview.web.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.rcp.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.rcp.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.rcp.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.samples.ide.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.samples.ide.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.samples.ide.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.samplesview.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.samplesview.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.samplesview.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.designer.ui.views.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.views.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.views.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.dataextraction.csv.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.dataextraction.csv.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.dataextraction.csv.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.dataextraction.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.dataextraction.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.dataextraction.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.docx.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.docx.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.docx.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.excel.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.excel.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.excel.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.html.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.html.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.html.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.pdf.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.pdf.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.pdf.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.postscript.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.postscript.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.postscript.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.ppt.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.ppt.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.ppt.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.pptx.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.pptx.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.pptx.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.wpml.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.wpml.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.wpml.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.engine.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.item.crosstab.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.item.crosstab.core.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.item.crosstab.core.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.item.crosstab.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.item.crosstab.ui.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.item.crosstab.ui.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.model.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.model.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.model.nl1</artifactId>

--- a/nl/org.eclipse.birt.report.viewer.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.viewer.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.viewers.nl1</artifactId>

--- a/nl/org.eclipse.birt.resources.nl/pom.xml
+++ b/nl/org.eclipse.birt.resources.nl/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.nl</groupId>
 		<artifactId>org.eclipse.birt.nl-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.resources.nl1</artifactId>

--- a/nl/pom.xml
+++ b/nl/pom.xml
@@ -5,8 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.nl</groupId>

--- a/testsuites/org.eclipse.birt.report.tests.chart/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.chart/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/testsuites/org.eclipse.birt.report.tests.engine.emitter.html/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.engine.emitter.html/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/testsuites/org.eclipse.birt.report.tests.engine/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.engine/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.eclipse.birt.testsuites</groupId>
 		<artifactId>org.eclipse.birt.testsuites-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
+
 	</parent>
 	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.tests.engine</artifactId>

--- a/testsuites/org.eclipse.birt.report.tests.model/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/testsuites/org.eclipse.birt.tests.core/pom.xml
+++ b/testsuites/org.eclipse.birt.tests.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/testsuites/org.eclipse.birt.tests.data/pom.xml
+++ b/testsuites/org.eclipse.birt.tests.data/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/testsuites/org.eclipse.birt.tests/pom.xml
+++ b/testsuites/org.eclipse.birt.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/testsuites/pom.xml
+++ b/testsuites/pom.xml
@@ -5,8 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.testsuites</groupId>

--- a/tutorial/extension-tutorial-1/pom.xml
+++ b/tutorial/extension-tutorial-1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/tutorial/extension-tutorial-2/pom.xml
+++ b/tutorial/extension-tutorial-2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/viewer/org.eclipse.birt.axis.overlay/pom.xml
+++ b/viewer/org.eclipse.birt.axis.overlay/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/viewer/org.eclipse.birt.integration.wtp.ui/pom.xml
+++ b/viewer/org.eclipse.birt.integration.wtp.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/viewer/org.eclipse.birt.jetty.overlay/pom.xml
+++ b/viewer/org.eclipse.birt.jetty.overlay/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/viewer/org.eclipse.birt.report.viewer.tests/pom.xml
+++ b/viewer/org.eclipse.birt.report.viewer.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/viewer/org.eclipse.birt.report.viewer/pom.xml
+++ b/viewer/org.eclipse.birt.report.viewer/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.viewer</groupId>

--- a/xtab/org.eclipse.birt.report.item.crosstab.core.tests/pom.xml
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/xtab/org.eclipse.birt.report.item.crosstab.core/pom.xml
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/xtab/org.eclipse.birt.report.item.crosstab.ui/pom.xml
+++ b/xtab/org.eclipse.birt.report.item.crosstab.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<groupId>org.eclipse.birt</groupId>

--- a/xtab/pom.xml
+++ b/xtab/pom.xml
@@ -4,8 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.birt</groupId>
 		<artifactId>org.eclipse.birt-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<version>4.8.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.birt.xtab</groupId>


### PR DESCRIPTION
Hi,
We have been using BIRT for a long time. So, mb it is a time to contribute a bit to our beloved project. 
I have tried recently to build BIRT from sources and figured out that recent maven version is not supported.

This patch should fix build for 3.5+ Maven.
At same time it should not break compatibility with previously supported Maven versions.

Main changes:
1) <version>4.8.0-SNAPSHOT</version> is everywhere. If you are using Tycho set version for release, you will not notice any difference.
2) Remove relativePath like '..' or '../', it is already default and there is no need to provide it everytime.
3) Update Readme about maven version

