### PR TITLE
Fix FileNotFoundException thrown on workspace startup

### DIFF
--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb/src/org/eclipse/birt/report/data/oda/jdbc/dbprofile/sampledb/internal/impl/SampleDbFactory.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb/src/org/eclipse/birt/report/data/oda/jdbc/dbprofile/sampledb/internal/impl/SampleDbFactory.java
@@ -179,10 +179,15 @@ public class SampleDbFactory implements IExecutableExtension
             File entryFile = new File( dbDir, entry.getName() );
             if ( entry.isDirectory() )
             {
-                entryFile.mkdir();
+                entryFile.mkdirs();
             }
             else
             {
+                File parent = entryFile.getParentFile();
+                if (parent != null)
+                {
+                    parent.mkdirs();
+                }
                 // Copy zip entry to local file
                 OutputStream os = new FileOutputStream( entryFile );
                 byte[] buf = new byte[4000];


### PR DESCRIPTION
There is an exception thrown on start of a workspace (birt-4.7/eclipse 4.7/windows 10/jdk8-64). 
---

java.io.FileNotFoundException: C:\src\ws\ws-debug-tbs-43\.metadata\.plugins\org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb\db\META-INF\MANIFEST.MF (The system cannot find the path specified)
	at java.io.FileOutputStream.open0(Native Method)
	at java.io.FileOutputStream.open(Unknown Source)
	at java.io.FileOutputStream.<init>(Unknown Source)
	at java.io.FileOutputStream.<init>(Unknown Source)
	at org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.internal.impl.SampleDbFactory.initSampleDb(SampleDbFactory.java:187)
	at org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.internal.impl.SampleDbFactory.setInitializationData(SampleDbFactory.java:88)


Issue description:
===========
One of the BIRT's contributions tries to unpack the sample db located in: plugins\org.eclipse.birt.report.data.oda.sampledb_4.7.0.v201706222054\db\BirtSample.jar
into: .metadata\.plugins\org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb\db 
folder and creates FileOutputStreams for the entries without checking if intermediate directories exist.

The problem was also reported and described here:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=515537
and also here:
https://www-01.ibm.com/support/docview.wss?uid=swg21996034
