### PR TITLE
Fix for BIRT-4688 : Data Set "Needs Cache for Data-Engine" property n…

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/EngineExecutionHints.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/EngineExecutionHints.java
@@ -71,9 +71,6 @@ public class EngineExecutionHints implements IEngineExecutionHints
 					{
 						IBaseDataSetDesign design = dataEngine.getDataSetDesign( dataSetName );
 
-						if( design instanceof IScriptDataSetDesign)
-							continue;
-
 						if( design instanceof ICacheable  )
 							DataSetDesignHelper.populateDataSetNames( dataEngine.getDataSetDesign( dataSetName ), dataEngine, temp2 );
 												


### PR DESCRIPTION
Fix for Data Set "Needs Cache for Data-Engine" property no longer caches data for Scripted data sets. If multiple report items on a report have the same Dataset as the source and if "Needs cache for data-engine" property is set to true, then DataSet generation should happen only once.