### PR TITLE
add value check for N for N and Percent aggregation accumulator

### DIFF
--- a/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/rank/NAccumulator.java
+++ b/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/rank/NAccumulator.java
@@ -48,6 +48,6 @@ public abstract class NAccumulator extends BaseTopBottomAccumulator
 	 */
 	protected int adjustNValue( double N )
 	{
-		return (int)N;
+		return (int)( N < 0 ? 0 : N );
 	}
 }

--- a/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/rank/PercentAccumulator.java
+++ b/data/org.eclipse.birt.data.aggregation/src/org/eclipse/birt/data/aggregation/impl/rank/PercentAccumulator.java
@@ -48,6 +48,6 @@ public abstract class PercentAccumulator extends BaseTopBottomAccumulator
 	 */
 	protected int adjustNValue( double N )
 	{
-		return (int)Math.round( N / 100 * cachedValues.size( ) );
+		return (int)( N < 0 ? 0 : Math.round( N / 100 * cachedValues.size( ) ) );
 	}
 }

--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/binding/ComputedColumnTest.java
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/binding/ComputedColumnTest.java
@@ -552,6 +552,129 @@ public class ComputedColumnTest extends APITestCase
 		checkOutputFile();
 		
 	}
+
+	/**
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testTopNAggregationOnComputedColumnWithFilterOnEmptyDataSet( )
+			throws Exception
+	{
+		ccName = new String[]{
+				"cc1"
+		};
+		ccExpr = new String[]{
+				"row.COL0"
+		};
+
+		List argument = new ArrayList( );
+		argument.add( new ScriptExpression( "3" ) );
+		ComputedColumn cc1 = new ComputedColumn( "cc1",
+				"row.COL0",
+				DataType.BOOLEAN_TYPE,
+				"ISTOPN",
+				new ScriptExpression( "!row.cc1" ),
+				argument );
+		( (BaseDataSetDesign) this.dataSet ).addComputedColumn( cc1 );
+
+		String[] bindingNameRow = new String[5];
+		bindingNameRow[0] = "ROW_COL0";
+		bindingNameRow[1] = "ROW_COL1";
+		bindingNameRow[2] = "ROW_COL2";
+		bindingNameRow[3] = "ROW_COL3";
+		bindingNameRow[4] = "ROW_cc1";
+
+		ScriptExpression[] bindingExprRow = new ScriptExpression[]{
+				new ScriptExpression( "dataSetRow." + "COL0", 0 ),
+				new ScriptExpression( "dataSetRow." + "COL1", 0 ),
+				new ScriptExpression( "dataSetRow." + "COL2", 0 ),
+				new ScriptExpression( "dataSetRow." + "COL3", 0 ),
+				new ScriptExpression( "dataSetRow." + ccName[0], 0 )
+		};
+		FilterDefinition filter = new FilterDefinition(
+				new ScriptExpression( "row.cc1" ) );
+		this.dataSet.addFilter( filter );
+
+		IResultIterator resultIt = this.executeQuery( this.createQuery( null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				bindingNameRow,
+				bindingExprRow ) );
+
+		printResult( resultIt, bindingNameRow, bindingExprRow );
+		// assert
+		checkOutputFile( );
+
+	}
+
+	/**
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testTopNPercentAggregationOnComputedColumnWithFilterOnEmptyDataSet( )
+			throws Exception
+	{
+		ccName = new String[]{
+				"cc1"
+		};
+		ccExpr = new String[]{
+				"row.COL0"
+		};
+
+		List argument = new ArrayList( );
+		argument.add( new ScriptExpression( "10" ) );
+		ComputedColumn cc1 = new ComputedColumn( "cc1",
+				"row.COL0",
+				DataType.BOOLEAN_TYPE,
+				"ISTOPNPercent",
+				new ScriptExpression( "!row.cc1" ),
+				argument );
+		( (BaseDataSetDesign) this.dataSet ).addComputedColumn( cc1 );
+
+		String[] bindingNameRow = new String[5];
+		bindingNameRow[0] = "ROW_COL0";
+		bindingNameRow[1] = "ROW_COL1";
+		bindingNameRow[2] = "ROW_COL2";
+		bindingNameRow[3] = "ROW_COL3";
+		bindingNameRow[4] = "ROW_cc1";
+
+		ScriptExpression[] bindingExprRow = new ScriptExpression[]{
+				new ScriptExpression( "dataSetRow." + "COL0", 0 ),
+				new ScriptExpression( "dataSetRow." + "COL1", 0 ),
+				new ScriptExpression( "dataSetRow." + "COL2", 0 ),
+				new ScriptExpression( "dataSetRow." + "COL3", 0 ),
+				new ScriptExpression( "dataSetRow." + ccName[0], 0 )
+		};
+		FilterDefinition filter = new FilterDefinition(
+				new ScriptExpression( "row.cc1" ) );
+		this.dataSet.addFilter( filter );
+
+		IResultIterator resultIt = this.executeQuery( this.createQuery( null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				bindingNameRow,
+				bindingExprRow ) );
+
+		printResult( resultIt, bindingNameRow, bindingExprRow );
+		// assert
+		checkOutputFile( );
+
+	}
+
 	/**
 	 * 
 	 * @throws Exception

--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/binding/golden/ComputedColumnTest.testTopNAggregationOnComputedColumnWithFilterOnEmptyDataSet.txt
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/binding/golden/ComputedColumnTest.testTopNAggregationOnComputedColumnWithFilterOnEmptyDataSet.txt
@@ -1,0 +1,4 @@
+COL0  COL1  COL2  COL3  cc1  
+ 2     0     0     0     <null>    
+ 2     0     0     1     <null>    
+ 2     0     0     2     <null>

--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/binding/golden/ComputedColumnTest.testTopNPercentAggregationOnComputedColumnWithFilterOnEmptyDataSet.txt
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/binding/golden/ComputedColumnTest.testTopNPercentAggregationOnComputedColumnWithFilterOnEmptyDataSet.txt
@@ -1,0 +1,9 @@
+COL0  COL1  COL2  COL3  cc1  
+ 2     0     0     0     <null>    
+ 2     0     0     1     <null>    
+ 2     0     0     2     <null>    
+ 2     0     1     0     <null>    
+ 2     0     1     1     <null>    
+ 2     0     1     2     <null>    
+ 2     0     2     0     <null>    
+ 2     0     2     1     <null>


### PR DESCRIPTION
For TopN/BottomN aggregation BIRT has a NAccumulator that contains a BasicCachedArray which stores all   running N elements. Aggregation is always assuming there is at least 1 element. So when all elements are filtered and aggregation is evaluated on empty input, the default N = -1 falls through to initialized size of BasicCachedArray. 
Add fix to properly evaluate the N value before passing it to initialize BasicCachedArray. The fix is similar for Top percent N aggregation.