### PR TITLE
Fix for Security Issue : https://bugs.eclipse.org/bugs/show_bug.cgi?id=538142

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/Messages.properties
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/Messages.properties
@@ -38,7 +38,7 @@ birt.viewer.error.viewingsessionexpired=The viewing session has expired.
 birt.viewer.error.viewingsessionlocked=The viewing session is locked and can't be terminated.
 birt.viewer.error.viewingsessionmaxreached=The maximum number of viewing sessions has been reached.
 birt.viewer.error.columnrequired=No column is selected, please select at least one column for export.
-
+birt.viewer.error.invalidextfordocumentparam=Invalid extension - "{0}" for the __document parameter.
 birt.viewer.message.taskcanceled=Current operation has been canceled.
 
 ###############################################################################

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/ResourceConstants.java
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/ResourceConstants.java
@@ -35,6 +35,7 @@ public interface ResourceConstants
 	public static final String GENERAL_ERROR_VIEWING_SESSION_EXPIRED = "birt.viewer.error.viewingsessionexpired"; //$NON-NLS-1$
 	public static final String GENERAL_ERROR_VIEWING_SESSION_LOCKED = "birt.viewer.error.viewingsessionlocked"; //$NON-NLS-1$
 	public static final String GENERAL_ERROR_VIEWING_SESSION_MAX_REACHED = "birt.viewer.error.viewingsessionmaxreached"; //$NON-NLS-1$
+	public static final String ERROR_INVALID_EXTENSION_FOR_DOCUMENT_PARAMETER = "birt.viewer.error.invalidextfordocumentparam"; //$NON-NLS-1$
 	
 	// general exception
 	public static final String GENERAL_EXCEPTION_DOCUMENT_FILE_ERROR = "birt.viewer.generalException.DOCUMENT_FILE_ERROR"; //$NON-NLS-1$

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/viewer.properties
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/viewer.properties
@@ -86,9 +86,22 @@ viewer.session.maximumSessionCount=0
 # cleant by this mechanism.
 viewer.session.maximumSessionCountPolicy=1
 
+
+#Restrictions on the __document parameter when used to specify the report document to be generated. These restrictions
+#are only applicable for actions like frameset, document, output which generate a report document. Please note that irrespective
+#of the settting here, when the __document param is expected and not specified, the system uses rptdocument as the extension for the
+#target report document. To maintain consistency, do not specify rptdocument in the black list and if white list is defined, add rptdocument to the list.
+
+#Comma separated white list of extensions for the report document produced by the system. 
+reportdocument.allowed-extensions=
+#Comma separated black list of extensions for the report document produced by the system. The black list takes precedence over the white list.
+reportdocument.disallowed-extensions=jsp
+
+
 # [LOGGERS]
 # "logger."+class=level
 # if no level is specified or the text "DEFAULT",
 # then the default level from the web.xml will be used
 logger.org.eclipse.datatools.connectivity.oda=DEFAULT
 logger.org.eclipse.datatools.enablement.oda=DEFAULT
+


### PR DESCRIPTION
…d=538142

Through Birt Viewer, one can perform operations such as generating a report as a frameset, output the report document in some format, generate a report document and so on. One parameter these operations take is "__document" that represents the report document file to be generated. Using executable extension such as .jsp for the __document parameter and using a specially crafted report, one can access sensitive information about the system or do something nasty on the server by accessing the generated report document. The fix introduces a configurable whitelist and blacklist for the report document extension.