### PR TITLE
update jetty configuration to use GzipHandler

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty.xml
+++ b/viewer/org.eclipse.birt.report.viewer/jettyhome/etc/jetty.xml
@@ -83,7 +83,21 @@
       </Call>
     </Call>
 -->
-
+	<Call name="insertHandler">
+		<Arg>
+		  <New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
+			<Set name="minGzipSize"><Property name="jetty.gzip.minGzipSize" deprecated="gzip.minGzipSize" default="2048"/></Set>
+			<Set name="checkGzExists"><Property name="jetty.gzip.checkGzExists" deprecated="gzip.checkGzExists" default="false"/></Set>
+			<Set name="compressionLevel"><Property name="jetty.gzip.compressionLevel" deprecated="gzip.compressionLevel" default="-1"/></Set>
+			<Set name="syncFlush"><Property name="jetty.gzip.syncFlush" default="false" /></Set>
+			<Set name="excludedAgentPatterns">
+			  <Array type="String">
+				<Item><Property name="jetty.gzip.excludedUserAgent" deprecated="gzip.excludedUserAgent" default=".*MSIE.6\.0.*"/></Item>
+			  </Array>
+			</Set>
+		  </New>
+		</Arg>
+	</Call>
     <Call class="java.lang.System" name="setProperty">
       <Arg>java.naming.factory.initial</Arg>
       <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>


### PR DESCRIPTION
upgraded jetty 9.3.9 uses GzipHandler to compress files, GZipFilter is deprecated 