### PR TITLE
allow not empty text area to have word break, renaming and correcting pdf option hyphenation to word break

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.config.pdf/src/org/eclipse/birt/report/engine/emitter/config/pdf/PDFEmitterDescriptor.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.pdf/src/org/eclipse/birt/report/engine/emitter/config/pdf/PDFEmitterDescriptor.java
@@ -32,7 +32,7 @@ public class PDFEmitterDescriptor extends AbstractEmitterDescriptor
 	private static final String FONT_SUBSTITUTION = "pdfRenderOption.fontSubstitution";
 	private static final String BIDI_PROCESSING = "pdfRenderOption.bidiProcessing";
 	private static final String TEXT_WRAPPING = "pdfRenderOption.textWrapping";
-	private static final String TEXT_HYPHENATION = "pdfRenderOption.hyphenation";
+	private static final String TEXT_WORDBREAK = "pdfRenderOption.wordBreak";
 	private static final String EMBEDDED_FONT = "pdfRenderOption.embeddedFonts";
 	private static final String CHART_DPI = "ChartDpi";
 	private static final String RENDER_CHART_IN_SVG = "RenderChartInSVG";
@@ -57,15 +57,15 @@ public class PDFEmitterDescriptor extends AbstractEmitterDescriptor
 				.setDescription( getMessage( "OptionDescription.BidiProcessing" ) ); //$NON-NLS-1$
 		
 		// Initializes the option for TextHyphenation.
-		ConfigurableOption textHyphenation = new ConfigurableOption(
-				TEXT_HYPHENATION );
-		textHyphenation
-				.setDisplayName( getMessage( "OptionDisplayValue.TextHyphenation" ) ); //$NON-NLS-1$
-		textHyphenation.setDataType( IConfigurableOption.DataType.BOOLEAN );
-		textHyphenation.setDisplayType( IConfigurableOption.DisplayType.CHECKBOX );
-		textHyphenation.setDefaultValue( Boolean.FALSE );
-		textHyphenation.setToolTip( null );
-		textHyphenation
+		ConfigurableOption textWordbreak = new ConfigurableOption(
+				TEXT_WORDBREAK );
+		textWordbreak
+				.setDisplayName( getMessage( "OptionDisplayValue.TextWordbreak" ) ); //$NON-NLS-1$
+		textWordbreak.setDataType( IConfigurableOption.DataType.BOOLEAN );
+		textWordbreak.setDisplayType( IConfigurableOption.DisplayType.CHECKBOX );
+		textWordbreak.setDefaultValue( Boolean.FALSE );
+		textWordbreak.setToolTip( null );
+		textWordbreak
 				.setDescription( getMessage( "OptionDescription.TextHyphenation" ) ); //$NON-NLS-1$
 
 		// Initializes the option for TextWrapping.
@@ -191,7 +191,7 @@ public class PDFEmitterDescriptor extends AbstractEmitterDescriptor
 				.setDescription( getMessage( "OptionDescription.DisablePrint" ) ); //$NON-NLS-1$
 
 		options = new IConfigurableOption[]{bidiProcessing, textWrapping,
-				textHyphenation, fontSubstitution, pageOverFlow, embeddedFont,
+				textWordbreak, fontSubstitution, pageOverFlow, embeddedFont,
 				chartDpi, renderChartInSVG, repaginateForPDF,
 				disableFlashAnimation, disablePrint};
 
@@ -254,9 +254,9 @@ public class PDFEmitterDescriptor extends AbstractEmitterDescriptor
 		{
 			return IPDFRenderOption.PDF_BIDI_PROCESSING;
 		}
-		if ( TEXT_HYPHENATION.equals( name ) )
+		if ( TEXT_WORDBREAK.equals( name ) )
 		{
-			return IPDFRenderOption.PDF_HYPHENATION;
+			return IPDFRenderOption.PDF_WORDBREAK;
 		}
 		if ( FONT_SUBSTITUTION.equals( name ) )
 		{

--- a/engine/org.eclipse.birt.report.engine.emitter.config.pdf/src/org/eclipse/birt/report/engine/emitter/config/pdf/i18n/messages.properties
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.pdf/src/org/eclipse/birt/report/engine/emitter/config/pdf/i18n/messages.properties
@@ -18,7 +18,7 @@ PDFEmitter.DisplayName=PDF
 #Option Display Value
 OptionDisplayValue.BidiProcessing=BIDI processing
 OptionDisplayValue.TextWrapping=Text wrapping
-OptionDisplayValue.TextHyphenation=Text hyphenation
+OptionDisplayValue.TextWordbreak=Text word-break
 OptionDisplayValue.PageOverFlow=Page overflow processing
 OptionDisplayValue.CLIP_CONTENT=Clip the content
 OptionDisplayValue.FIT_TO_PAGE_SIZE=Fit to page size

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/IPDFRenderOption.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/IPDFRenderOption.java
@@ -62,10 +62,10 @@ public interface IPDFRenderOption extends IRenderOption
 	public static final String PDF_TEXT_WRAPPING = "pdfRenderOption.textWrapping";
 	
 	/**
-	 * If it is set to false, no hyphenation is used. 
+	 * If it is set to false, no word break is used. 
 	 * The word longer than the line width will be clipped at the line boundary.
 	 */
-	public static final String PDF_HYPHENATION = "pdfRenderOption.hyphenation";
+	public static final String PDF_WORDBREAK = "pdfRenderOption.wordBreak";
 	
 	/**
 	 * If it is set to false, we needn't check if the character exists in the selected font.

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/impl/EngineTask.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/impl/EngineTask.java
@@ -1855,12 +1855,12 @@ public abstract class EngineTask implements IEngineTask
 						pdfBidiProcessing );
 			}
 
-			Object pdfHyphenation = renderOptions
-					.getOption( IPDFRenderOption.PDF_HYPHENATION );
-			if ( pdfHyphenation != null )
+			Object pdfWordbreak = renderOptions
+					.getOption( IPDFRenderOption.PDF_WORDBREAK );
+			if ( pdfWordbreak != null )
 			{
-				layoutEngine.setOption( IPDFRenderOption.PDF_HYPHENATION,
-						pdfHyphenation );
+				layoutEngine.setOption( IPDFRenderOption.PDF_WORDBREAK,
+						pdfWordbreak );
 			}
 			
 			Object dpi = renderOptions

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/emitter/LayoutEngineContext.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/emitter/LayoutEngineContext.java
@@ -207,16 +207,16 @@ public class LayoutEngineContext
 		return this.bidiProcessing;
 	}
 	
-	protected boolean enableHyphenation = false;
+	protected boolean enableWordbreak = false;
 	
-	public boolean isEnableHyphenation( )
+	public boolean isEnableWordbreak( )
 	{
-		return enableHyphenation;
+		return enableWordbreak;
 	}
 	
-	public void setEnableHyphenation( boolean enableHyphenation )
+	public void setEnableWordbreak( boolean enableWordbreak )
 	{
-		this.enableHyphenation = enableHyphenation;
+		this.enableWordbreak = enableWordbreak;
 	}
 
 	public Locale getLocale( )

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/emitter/PDFLayoutEmitterProxy.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/emitter/PDFLayoutEmitterProxy.java
@@ -184,12 +184,12 @@ public class PDFLayoutEmitterProxy extends LayoutEmitterAdapter
 			// {
 			// context.setBidiProcessing( false );
 			// }
-			Object hyhenation = options.get( IPDFRenderOption.PDF_HYPHENATION );
-			if ( hyhenation != null && hyhenation instanceof Boolean )
+			Object wordbreak = options.get( IPDFRenderOption.PDF_WORDBREAK );
+			if ( wordbreak != null && wordbreak instanceof Boolean )
 			{
-				if ( ( (Boolean) hyhenation ).booleanValue( ) )
+				if ( ( (Boolean) wordbreak ).booleanValue( ) )
 				{
-					context.setEnableHyphenation( true );
+					context.setEnableWordbreak( true );
 				}
 			}
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/emitter/TextAreaLayout.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/emitter/TextAreaLayout.java
@@ -60,7 +60,7 @@ public class TextAreaLayout extends ContainerLayout
 			comp = new TextCompositor( textContent, context.getFontManager( ),
 					context.getBidiProcessing( ),
 					context.getFontSubstitution( ), context.getTextWrapping( ),
-					context.isEnableHyphenation( ), context.getLocale( ) );
+					context.isEnableWordbreak( ), context.getLocale( ) );
 			// checks whether the current line is empty or not.
 			ContainerLayout ancestor = parentLM;
 			do

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/LayoutContext.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/LayoutContext.java
@@ -326,16 +326,16 @@ public class LayoutContext
 		return this.bidiProcessing;
 	}
 	
-	protected boolean enableHyphenation = false;
+	protected boolean enableWordbreak = false;
 	
-	public boolean isEnableHyphenation( )
+	public boolean isEnableWordbreak( )
 	{
-		return enableHyphenation;
+		return enableWordbreak;
 	}
 	
-	public void setEnableHyphenation( boolean enableHyphenation )
+	public void setEnableWordbreak( boolean enableWordbreak )
 	{
-		this.enableHyphenation = enableHyphenation;
+		this.enableWordbreak = enableWordbreak;
 	}
 
 	public Locale getLocale( )

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/LayoutEngine.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/LayoutEngine.java
@@ -264,12 +264,12 @@ public class LayoutEngine extends LayoutEmitterAdapter
 			// {
 			// context.setBidiProcessing( false );
 			// }
-			Object hyhenation = options.get( IPDFRenderOption.PDF_HYPHENATION );
-			if ( hyhenation != null && hyhenation instanceof Boolean )
+			Object wordbreak = options.get( IPDFRenderOption.PDF_WORDBREAK );
+			if ( wordbreak != null && wordbreak instanceof Boolean )
 			{
-				if ( ( (Boolean) hyhenation ).booleanValue( ) )
+				if ( ( (Boolean) wordbreak ).booleanValue( ) )
 				{
-					context.setEnableHyphenation( true );
+					context.setEnableWordbreak( true );
 				}
 			}
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextCompositor.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextCompositor.java
@@ -335,18 +335,16 @@ public class TextCompositor
 				wordVestige = null;
 				insertFirstExceedWord = false;
 			}
-			if ( isNewLine && textArea.isEmpty( ) )
+			if ( isNewLine && context.isEnableWordbreak( ))
 			{
-				if ( context.isEnableHyphenation( ) )
-				{
-					doHyphenation( word.getValue( ), textArea );
-				}
-				else
-				{
-					// If width of a word is larger than the max line width, add
-					// it into the line directly.
-					addWord( textArea, textLength, wordWidth );
-				}
+				doWordBreak( word.getValue( ), textArea );
+			}
+			else if ( isNewLine && textArea.isEmpty( ) )
+			{
+				// If width of a word is larger than the max line width, add
+				// it into the line directly.
+				addWord( textArea, textLength, wordWidth );
+
 			}
 			else
 			{
@@ -359,29 +357,29 @@ public class TextCompositor
 		}
 	}
 
-	private void doHyphenation( String str, TextArea area )
+	private void doWordBreak( String str, TextArea area )
 	{
 		IHyphenationManager hm = new DefaultHyphenationManager( );
-		Hyphenation hyph = hm.getHyphenation( str );
+		Hyphenation wb = hm.getHyphenation( str );
 		FontInfo fi = area.getStyle( ).getFontInfo( );
 		if ( area.getMaxWidth( ) < 0 )
 		{
-			addWordVestige( area, 1, getTextWidth( fi, hyph
+			addWordVestige( area, 1, getTextWidth( fi, wb
 					.getHyphenText( 0, 1 ) ), str.substring( 1, str.length( ) ) );
 			return;
 		}
 		int endHyphenIndex = hyphen( 0, area.getMaxWidth( ) - area.getWidth( ),
-				hyph, fi );
+				wb, fi );
 		// current line can't even place one character. Force to add the first
 		// character into the line.
 		if ( endHyphenIndex == 0 && area.getWidth( ) == 0 )
 		{
-			addWordVestige( area, 1, getTextWidth( fi, hyph
+			addWordVestige( area, 1, getTextWidth( fi, wb
 					.getHyphenText( 0, 1 ) ), str.substring( 1, str.length( ) ) );
 		}
 		else
 		{
-			addWordVestige( area, endHyphenIndex, getTextWidth( fi, hyph
+			addWordVestige( area, endHyphenIndex, getTextWidth( fi, wb
 					.getHyphenText( 0, endHyphenIndex ) )
 					+ textStyle.getLetterSpacing( ) * ( endHyphenIndex - 1 ), str.substring(
 					endHyphenIndex, str.length( ) ) );


### PR DESCRIPTION
a condition is change to allow use of word break even when text area is not empty

also change code naming for better understanding

Signed-off-by: sguan <sguan@actuate.com>