### PR TITLE
Add PDE target definition for Photon

### DIFF
--- a/BIRT_photon.target
+++ b/BIRT_photon.target
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="BIRT Photon target platform">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository/"/>
+			<unit id="org.eclipse.orbit.mongodb" version="3.2.2.v20170222-2110"/>
+			<unit id="com.lowagie.text" version="2.1.7.v201004222200"/>
+			<unit id="org.apache.batik.bridge" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.css" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.dom" version="1.7.1.v201505191845"/>
+			<unit id="org.apache.batik.dom.svg" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.ext.awt" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.extension" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.parser" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.svggen" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.swing" version="1.7.0.v201302011158"/>
+			<unit id="org.apache.batik.transcoder" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.util" version="1.7.0.v201011041433"/>
+			<unit id="org.apache.batik.util.gui" version="1.7.0.v200903091627"/>
+			<unit id="org.apache.batik.xml" version="1.7.0.v201011041433"/>
+			<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
+			<unit id="org.apache.poi" version="3.9.0.v201405241750"/>
+			<unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
+			<unit id="org.apache.derby" version="10.11.1.1_v201605202053"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.platform.ide" version="4.8.0.I20180611-0500"/>
+			<unit id="org.eclipse.platform.sdk" version="4.8.0.I20180611-0500"/>
+			<unit id="org.eclipse.sdk.ide" version="4.8.0.I20180611-0500"/>
+			<repository location="http://download.eclipse.org/eclipse/updates/4.8/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.emf.base.feature.group" version="2.16.0.v20181124-0637"/>
+			<unit id="org.eclipse.emf.ecore.feature.group" version="2.16.0.v20181124-0637"/>
+			<unit id="org.eclipse.emf.feature.group" version="2.16.0.v20181206-1055"/>
+			<repository location="http://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="1.14.1.201712071719"/>
+			<unit id="org.eclipse.datatools.connectivity.oda.designer.core.feature.feature.group" version="1.14.1.201712071719"/>
+			<unit id="org.eclipse.datatools.connectivity.oda.designer.feature.feature.group" version="1.14.1.201712071719"/>
+			<unit id="org.eclipse.datatools.connectivity.oda.feature.feature.group" version="1.14.1.201712071719"/>
+			<unit id="org.eclipse.datatools.enablement.apache.derby.feature.feature.group" version="1.14.1.201712071719"/>
+			<unit id="org.eclipse.datatools.enablement.feature.feature.group" version="1.14.1.201712071719"/>
+			<unit id="org.eclipse.datatools.enablement.jdbc.feature.feature.group" version="1.14.1.201712071719"/>
+			<repository location="http://download.eclipse.org/datatools/1.14.1.201712071719/repository/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>
+			<unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
+			<repository location="http://download.eclipse.org/tools/gef/updates/legacy/releases/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.9.3.v201803221418"/>
+			<unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.1.1.v201804042202"/>
+			<repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.5/R-3.9.5-20180409100740/repository/"/>
+			<unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.9.0.v201803221834"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.jetty.bundles.f.feature.group" version="9.4.10.201805070144"/>
+			<repository location="http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.10.v20180503"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.apache.jasper" version="8.5.35"/>
+			<repository location="http://download.eclipse.org/gemini/updates/web/3.0.4"/>
+		</location>
+	</locations>
+</target>

--- a/BIRT_photon.target
+++ b/BIRT_photon.target
@@ -1,37 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="BIRT Photon target platform">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository/"/>
-			<unit id="org.eclipse.orbit.mongodb" version="3.2.2.v20170222-2110"/>
-			<unit id="com.lowagie.text" version="2.1.7.v201004222200"/>
-			<unit id="org.apache.batik.bridge" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.css" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.dom" version="1.7.1.v201505191845"/>
-			<unit id="org.apache.batik.dom.svg" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.ext.awt" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.extension" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.parser" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.svggen" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.swing" version="1.7.0.v201302011158"/>
-			<unit id="org.apache.batik.transcoder" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.util" version="1.7.0.v201011041433"/>
-			<unit id="org.apache.batik.util.gui" version="1.7.0.v200903091627"/>
-			<unit id="org.apache.batik.xml" version="1.7.0.v201011041433"/>
-			<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
-			<unit id="org.apache.poi" version="3.9.0.v201405241750"/>
-			<unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
-			<unit id="org.apache.derby" version="10.11.1.1_v201605202053"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.platform.ide" version="4.8.0.I20180611-0500"/>
 			<unit id="org.eclipse.platform.sdk" version="4.8.0.I20180611-0500"/>
 			<unit id="org.eclipse.sdk.ide" version="4.8.0.I20180611-0500"/>
 			<repository location="http://download.eclipse.org/eclipse/updates/4.8/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.base.feature.group" version="2.16.0.v20181124-0637"/>
-			<unit id="org.eclipse.emf.ecore.feature.group" version="2.16.0.v20181124-0637"/>
-			<unit id="org.eclipse.emf.feature.group" version="2.16.0.v20181206-1055"/>
+			<unit id="org.eclipse.emf.base.feature.group" version="2.17.0.v20181231-1705"/>
+			<unit id="org.eclipse.emf.ecore.feature.group" version="2.17.0.v20181231-1705"/>
+			<unit id="org.eclipse.emf.feature.group" version="2.17.0.v20190109-0952"/>
 			<repository location="http://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -62,6 +40,30 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.apache.jasper" version="8.5.35"/>
 			<repository location="http://download.eclipse.org/gemini/updates/web/3.0.4"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.apache.batik.anim" version="1.9.1.v20181015-1528"/>
+			<unit id="org.apache.batik.bridge" version="1.9.1.v20181015-1528"/>
+			<unit id="org.apache.batik.codec" version="1.9.1.v20180313-1559"/>
+			<unit id="org.apache.batik.dom" version="1.9.1.v20181015-1528"/>
+			<unit id="org.apache.batik.dom.svg" version="1.9.1.v20181015-1528"/>
+			<unit id="org.apache.batik.ext.awt" version="1.9.1.v20180227-1645"/>
+			<unit id="org.apache.batik.extension" version="1.9.1.v20180313-1559"/>
+			<unit id="org.apache.batik.gvt" version="1.9.1.v20180227-1645"/>
+			<unit id="org.apache.batik.parser" version="1.9.1.v20180313-1559"/>
+			<unit id="org.apache.batik.pdf" version="1.9.1.v20180417-1407"/>
+			<unit id="org.apache.batik.script" version="1.9.1.v20180313-1559"/>
+			<unit id="org.apache.batik.svggen" version="1.9.1.v20180313-1559"/>
+			<unit id="org.apache.batik.swing" version="1.9.1.v20181015-1528"/>
+			<unit id="org.apache.batik.transcoder" version="1.9.1.v20181015-1528"/>
+			<unit id="org.apache.batik.util.gui" version="1.9.1.v20180227-1645"/>
+			<unit id="org.apache.batik.xml" version="1.9.1.v20180227-1645"/>
+			<unit id="org.apache.derby" version="10.11.1.1_v201605202053"/>
+			<unit id="org.apache.poi" version="3.9.0.v201405241750"/>
+			<unit id="org.eclipse.orbit.mongodb" version="3.2.2.v20181004-1955"/>
+			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/"/>
+			<unit id="com.lowagie.text" version="2.1.7.v201004222200"/>
+			<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
I created a PDE target definition for the current target platform of the master branch. It resolves all dependencies currently needed by BIRT.

It is almost in sync with the tycho target platform. Only difference is the addition of a recent Apache Jasper version from Gemini as it is required by the Jetty Version currently used by BIRT.

Signed-off-by: Alexander Lehmann <a.lehm@gmx.de>
