### PR TITLE
Fix Maven warnings

### DIFF
--- a/UI/org.eclipse.birt.report.debug.core/pom.xml
+++ b/UI/org.eclipse.birt.report.debug.core/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.debug.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.debug.ui/pom.xml
+++ b/UI/org.eclipse.birt.report.debug.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.debug.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.core/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.core/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.samplereports/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.samplereports/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.samplereports</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.tests/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.cubebuilder/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.cubebuilder/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.cubebuilder</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.data/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.data/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.data</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.editor.script/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editor.script/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editor.script</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.editor.xml.wtp/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editor.xml.wtp/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editor.xml.wtp</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.editors.schematic/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editors.schematic/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editors.schematic</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.editors/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.editors/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editors</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.ide/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.ide/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.lib.explorer/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.lib.explorer/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.lib.explorer</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.lib/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.lib/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.lib</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.preview.static_html/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.static_html/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview.static_html</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.preview.test/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.test/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview.test</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.preview.web/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.web/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview.web</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.preview/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.preview/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.rcp/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.rcp</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.samples.ide/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.samples.ide/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.samples.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.samples.rcp/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.samples.rcp/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.samples.rcp</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.samplesview/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.samplesview/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.samplesview</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui.views/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui.views/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.views</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/org.eclipse.birt.report.designer.ui/pom.xml
+++ b/UI/org.eclipse.birt.report.designer.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/UI/pom.xml
+++ b/UI/pom.xml
@@ -10,7 +10,6 @@
 
 	<groupId>org.eclipse.birt.UI</groupId>
 	<artifactId>org.eclipse.birt.UI-parent</artifactId>
-	<version>4.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/build/birt-packages/birt-report-all-in-one/pom.xml
+++ b/build/birt-packages/birt-report-all-in-one/pom.xml
@@ -60,7 +60,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho.version}</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/build/birt-packages/birt-report-rcp/pom.xml
+++ b/build/birt-packages/birt-report-rcp/pom.xml
@@ -52,7 +52,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho.version}</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/build/birt-packages/birt-runtime/pom.xml
+++ b/build/birt-packages/birt-runtime/pom.xml
@@ -28,7 +28,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho.version}</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/build/org.eclipse.birt.api/pom.xml
+++ b/build/org.eclipse.birt.api/pom.xml
@@ -23,7 +23,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-packaging-plugin</artifactId>
-        <version>${tycho.version}</version>
         <executions>
           <execution>
             <phase>process-resources</phase>

--- a/build/org.eclipse.birt.build/pom.xml
+++ b/build/org.eclipse.birt.build/pom.xml
@@ -7,7 +7,6 @@
     <version>4.8.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
-  <groupId>org.eclipse.birt</groupId>
   <artifactId>org.eclipse.birt.build</artifactId>
   <packaging>eclipse-plugin</packaging>
   <build>

--- a/build/org.eclipse.birt.example/pom.xml
+++ b/build/org.eclipse.birt.example/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.example</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/build/org.eclipse.birt/pom.xml
+++ b/build/org.eclipse.birt/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.device.extension/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.extension/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.device.extension</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.device.pdf/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.pdf/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.device.pdf</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	

--- a/chart/org.eclipse.birt.chart.device.svg/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.svg/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.device.svg</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.device.swt/pom.xml
+++ b/chart/org.eclipse.birt.chart.device.swt/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.device.swt</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.engine.extension/pom.xml
+++ b/chart/org.eclipse.birt.chart.engine.extension/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.engine.extension</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.engine/pom.xml
+++ b/chart/org.eclipse.birt.chart.engine/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.engine</artifactId>
 	<packaging>eclipse-plugin</packaging>
   <build>

--- a/chart/org.eclipse.birt.chart.examples.core/pom.xml
+++ b/chart/org.eclipse.birt.chart.examples.core/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.examples.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/chart/org.eclipse.birt.chart.examples/pom.xml
+++ b/chart/org.eclipse.birt.chart.examples/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.examples</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.integration.wtp.ui/pom.xml
+++ b/chart/org.eclipse.birt.chart.integration.wtp.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.integration.wtp.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.reportitem.ui/pom.xml
+++ b/chart/org.eclipse.birt.chart.reportitem.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.reportitem.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.reportitem/pom.xml
+++ b/chart/org.eclipse.birt.chart.reportitem/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.reportitem</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/chart/org.eclipse.birt.chart.tests/pom.xml
+++ b/chart/org.eclipse.birt.chart.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/chart/org.eclipse.birt.chart.ui.extension/pom.xml
+++ b/chart/org.eclipse.birt.chart.ui.extension/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.ui.extension</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.ui/pom.xml
+++ b/chart/org.eclipse.birt.chart.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/chart/org.eclipse.birt.chart.viewer/pom.xml
+++ b/chart/org.eclipse.birt.chart.viewer/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.viewer</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/common/org.apache.batik.ext.awt.extension/pom.xml
+++ b/common/org.apache.batik.ext.awt.extension/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.apache.batik.ext.awt.extension</artifactId>
 	<version>1.7.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>

--- a/common/org.w3c.dom.svg.extension/pom.xml
+++ b/common/org.w3c.dom.svg.extension/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.w3c.dom.svg.extension</artifactId>
 	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>

--- a/common/org.w3c.sac/pom.xml
+++ b/common/org.w3c.sac/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.w3c.sac</artifactId>
 	<version>1.3.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>

--- a/core/org.eclipse.birt.core.testhelper/pom.xml
+++ b/core/org.eclipse.birt.core.testhelper/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.core.testhelper</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/core/org.eclipse.birt.core.tests/pom.xml
+++ b/core/org.eclipse.birt.core.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.core.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/core/org.eclipse.birt.core.ui/pom.xml
+++ b/core/org.eclipse.birt.core.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.core.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.core.script.function/pom.xml
+++ b/data/org.eclipse.birt.core.script.function/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.core.script.function</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.data.aggregation/pom.xml
+++ b/data/org.eclipse.birt.data.aggregation/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data.aggregation</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/data/org.eclipse.birt.data.oda.mongodb.ui/pom.xml
+++ b/data/org.eclipse.birt.data.oda.mongodb.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data.oda.mongodb.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.data.oda.mongodb/pom.xml
+++ b/data/org.eclipse.birt.data.oda.mongodb/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data.oda.mongodb</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.data.oda.pojo.tests/pom.xml
+++ b/data/org.eclipse.birt.data.oda.pojo.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data.oda.pojo.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.data.oda.pojo.ui/pom.xml
+++ b/data/org.eclipse.birt.data.oda.pojo.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data.oda.pojo.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.data.oda.pojo/pom.xml
+++ b/data/org.eclipse.birt.data.oda.pojo/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data.oda.pojo</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.data.tests/pom.xml
+++ b/data/org.eclipse.birt.data.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/data/org.eclipse.birt.data/pom.xml
+++ b/data/org.eclipse.birt.data/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.data</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/data/org.eclipse.birt.me.prettyprint.hector/pom.xml
+++ b/data/org.eclipse.birt.me.prettyprint.hector/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.me.prettyprint.hector</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<dependencies>

--- a/data/org.eclipse.birt.report.data.adapter/pom.xml
+++ b/data/org.eclipse.birt.report.data.adapter/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.adapter</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/data/org.eclipse.birt.report.data.bidi.utils.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.bidi.utils.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.bidi.utils.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.bidi.utils/pom.xml
+++ b/data/org.eclipse.birt.report.data.bidi.utils/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.bidi.utils</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.excel.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.excel.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.excel.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.excel/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.excel/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.excel</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.hive.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.hive.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.hive.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.hive/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.hive/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.hive</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile/META-INF/MANIFEST.MF
@@ -3,8 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.birt.report.data.oda.jdbc.dbprofile;singleton:=true
 Bundle-Version: 4.8.0.qualifier
-Bundle-ClassPath: .,
- src
+Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.birt.report.data.oda.jdbc.dbprofile.Activator
 Bundle-Vendor: Eclipse BIRT Project
 Bundle-Localization: plugin

--- a/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.dbprofile/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.tests/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.jdbc.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.jdbc/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.sampledb.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.sampledb.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.sampledb.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.sampledb/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.sampledb/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.sampledb</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.xml.ui/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.xml.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.xml.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.data.oda.xml/pom.xml
+++ b/data/org.eclipse.birt.report.data.oda.xml/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.xml</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/data/org.eclipse.birt.report.engine.script.javascript/pom.xml
+++ b/data/org.eclipse.birt.report.engine.script.javascript/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.script.javascript</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/docs/org.eclipse.birt.chart.cshelp/pom.xml
+++ b/docs/org.eclipse.birt.chart.cshelp/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.cshelp</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/docs/org.eclipse.birt.chart.doc.isv/pom.xml
+++ b/docs/org.eclipse.birt.chart.doc.isv/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.chart.doc.isv</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/docs/org.eclipse.birt.cshelp/pom.xml
+++ b/docs/org.eclipse.birt.cshelp/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.cshelp</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/docs/org.eclipse.birt.doc.isv/pom.xml
+++ b/docs/org.eclipse.birt.doc.isv/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.doc.isv</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/docs/org.eclipse.birt.doc/pom.xml
+++ b/docs/org.eclipse.birt.doc/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.doc</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.dataextraction.csv.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.dataextraction.csv/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.dataextraction.csv/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.dataextraction.csv</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.dataextraction/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.dataextraction/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.dataextraction</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.docx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.docx/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.docx</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.excel/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.excel/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.excel</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.html/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.html/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.html</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.odp/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.odp/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.odp</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.ods/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.ods/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.ods</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.odt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.odt/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.odt</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.pdf/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.pdf/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.pdf</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.postscript/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.postscript/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.postscript</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.ppt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.ppt/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.ppt</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.pptx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.pptx/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.pptx</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config.wpml/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config.wpml/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.wpml</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.config/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.config/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine.emitter.docx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.docx/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.docx</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.html.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.html.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.html.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine.emitter.html/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.html</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.odp/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.odp/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.odp</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.ods/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.ods/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.ods</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.odt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.odt/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.odt</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.pdf.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.pdf</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.postscript.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.postscript.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.postscript.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine.emitter.postscript/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.postscript/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.postscript</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.ppt/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.ppt/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.ppt</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.pptx.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.pptx</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.prototype.excel.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.prototype.excel.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.prototype.excel.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine.emitter.prototype.excel/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.prototype.excel/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.prototype.excel</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.wpml</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.fonts/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.fonts/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.fonts</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.odf/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.odf/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.odf</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.ooxml/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.ooxml/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.ooxml</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.testhelper/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.testhelper/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.testhelper</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/engine/org.eclipse.birt.report.engine.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/engine/org.eclipse.birt.report.engine/pom.xml
+++ b/engine/org.eclipse.birt.report.engine/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.engine</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/engine/uk.co.spudsoft.birt.emitters.excel.tests/pom.xml
+++ b/engine/uk.co.spudsoft.birt.emitters.excel.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>uk.co.spudsoft.birt.emitters.excel.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/engine/uk.co.spudsoft.birt.emitters.excel/pom.xml
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>uk.co.spudsoft.birt.emitters.excel</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/features/org.eclipse.birt.chart.feature/pom.xml
+++ b/features/org.eclipse.birt.chart.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,13 +14,11 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.chart.integration.wtp.feature/pom.xml
+++ b/features/org.eclipse.birt.chart.integration.wtp.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.integration.wtp</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,13 +14,11 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.chart.osgi.runtime.sdk/pom.xml
+++ b/features/org.eclipse.birt.chart.osgi.runtime.sdk/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.osgi.runtime.sdk</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.birt.chart.osgi.runtime/pom.xml
+++ b/features/org.eclipse.birt.chart.osgi.runtime/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.chart.osgi.runtime</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,7 +14,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
 				<configuration>
 					<excludes>
 						<plugin id="org.apache.axis"/>
@@ -33,8 +31,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.engine.runtime/pom.xml
+++ b/features/org.eclipse.birt.engine.runtime/pom.xml
@@ -8,7 +8,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.engine.runtime</artifactId>
 	<packaging>eclipse-feature</packaging>
 
@@ -17,13 +16,11 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.integration.wtp.feature/pom.xml
+++ b/features/org.eclipse.birt.integration.wtp.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.integration.wtp</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,13 +14,11 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.integration.wtp.sdk.feature/pom.xml
+++ b/features/org.eclipse.birt.integration.wtp.sdk.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.integration.wtp.sdk</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.birt.nl.feature/pom.xml
+++ b/features/org.eclipse.birt.nl.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.nl</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.birt.osgi.runtime.sdk/pom.xml
+++ b/features/org.eclipse.birt.osgi.runtime.sdk/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.osgi.runtime.sdk</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.birt.osgi.runtime/pom.xml
+++ b/features/org.eclipse.birt.osgi.runtime/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.osgi.runtime</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,13 +14,11 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.rcp.feature/pom.xml
+++ b/features/org.eclipse.birt.rcp.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.rcp</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.birt.rcp.nl.feature/pom.xml
+++ b/features/org.eclipse.birt.rcp.nl.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.rcp.nl</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.birt.report.designer.editor.xml.wtp.feature/pom.xml
+++ b/features/org.eclipse.birt.report.designer.editor.xml.wtp.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.report.designer.editor.xml.wtp</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,13 +14,11 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.sdk.feature/pom.xml
+++ b/features/org.eclipse.birt.sdk.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.sdk</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.birt.testhelper.feature/pom.xml
+++ b/features/org.eclipse.birt.testhelper.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.testhelper</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,8 +14,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.tests.feature/pom.xml
+++ b/features/org.eclipse.birt.tests.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.tests</artifactId>
 	<packaging>eclipse-feature</packaging>
 	<build>
@@ -15,8 +14,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/org.eclipse.birt.wtp.nl.feature/pom.xml
+++ b/features/org.eclipse.birt.wtp.nl.feature/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.features</groupId>
 	<artifactId>org.eclipse.birt.wtp.nl</artifactId>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/model/org.eclipse.birt.report.model.adapter.oda.tests/pom.xml
+++ b/model/org.eclipse.birt.report.model.adapter.oda.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.model.adapter.oda.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/model/org.eclipse.birt.report.model.adapter.oda/pom.xml
+++ b/model/org.eclipse.birt.report.model.adapter.oda/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.model.adapter.oda</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/model/org.eclipse.birt.report.model.testhelper/pom.xml
+++ b/model/org.eclipse.birt.report.model.testhelper/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.model.testhelper</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/model/org.eclipse.birt.report.model.testresources/pom.xml
+++ b/model/org.eclipse.birt.report.model.testresources/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.model.testresources</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/model/org.eclipse.birt.report.model.tests/pom.xml
+++ b/model/org.eclipse.birt.report.model.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.model.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/model/org.eclipse.birt.report.modelextension.tests/pom.xml
+++ b/model/org.eclipse.birt.report.modelextension.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.modelextension.tests</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/model/org.eclipse.birt.resources/pom.xml
+++ b/model/org.eclipse.birt.resources/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.resources</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.device.extension.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.device.extension.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.device.extension.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.device.svg.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.device.svg.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.device.svg.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.device.swt.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.device.swt.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.device.swt.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.engine.extension.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.engine.extension.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.engine.extension.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.engine.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.engine.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.engine.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.examples.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.examples.core.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.examples.core.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.examples.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.examples.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.examples.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.integration.wtp.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.integration.wtp.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.integration.wtp.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.reportitem.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.reportitem.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.reportitem.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.reportitem.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.reportitem.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.reportitem.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.ui.extension.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.ui.extension.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.ui.extension.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.chart.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.chart.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.chart.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.core.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.core.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.core.script.function.nl/pom.xml
+++ b/nl/org.eclipse.birt.core.script.function.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.core.script.function.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.core.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.core.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.core.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.data.aggregation.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.aggregation.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.aggregation.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.data.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.data.oda.mongodb.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.mongodb.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.mongodb.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.data.oda.mongodb.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.mongodb.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.mongodb.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.data.oda.pojo.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.pojo.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.pojo.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.data.oda.pojo.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.data.oda.pojo.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.data.oda.pojo.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.integration.wtp.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.integration.wtp.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.integration.wtp.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.adapter.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.adapter.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.adapter.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.bidi.utils.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.bidi.utils.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.bidi.utils.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.excel.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.excel.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.excel.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.excel.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.excel.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.excel.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.hive.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.hive.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.hive.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.hive.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.hive.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.hive.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.sampledb.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.dbprofile.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.jdbc.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.jdbc.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.jdbc.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.sampledb.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.sampledb.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.sampledb.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.sampledb.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.sampledb.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.sampledb.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.xml.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.xml.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.xml.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.data.oda.xml.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.data.oda.xml.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.data.oda.xml.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.debug.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.debug.core.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.debug.core.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.debug.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.debug.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.debug.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.core.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.core.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.cubebuilder.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.cubebuilder.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.cubebuilder.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.editor.script.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editor.script.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editor.script.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.editor.xml.wtp.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editor.xml.wtp.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editor.xml.wtp.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.editors.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editors.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editors.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.editors.schematic.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.editors.schematic.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.editors.schematic.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.ide.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.ide.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.ide.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.lib.explorer.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.lib.explorer.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.lib.explorer.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.lib.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.lib.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.lib.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.preview.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.preview.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.preview.web.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.preview.web.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.preview.web.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.rcp.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.rcp.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.rcp.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.samples.ide.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.samples.ide.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.samples.ide.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.samplesview.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.samplesview.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.samplesview.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.designer.ui.views.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.designer.ui.views.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.designer.ui.views.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.dataextraction.csv.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.dataextraction.csv.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.dataextraction.csv.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.dataextraction.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.dataextraction.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.dataextraction.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.docx.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.docx.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.docx.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.excel.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.excel.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.excel.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.html.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.html.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.html.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.pdf.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.pdf.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.pdf.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.postscript.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.postscript.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.postscript.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.ppt.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.ppt.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.ppt.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.pptx.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.pptx.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.pptx.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.emitter.config.wpml.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.emitter.config.wpml.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.emitter.config.wpml.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.engine.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.engine.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.engine.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.item.crosstab.core.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.item.crosstab.core.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.item.crosstab.core.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.item.crosstab.ui.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.item.crosstab.ui.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.item.crosstab.ui.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.model.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.model.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.model.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.report.viewer.nl/pom.xml
+++ b/nl/org.eclipse.birt.report.viewer.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.report.viewers.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/org.eclipse.birt.resources.nl/pom.xml
+++ b/nl/org.eclipse.birt.resources.nl/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt.nl</groupId>
 	<artifactId>org.eclipse.birt.resources.nl1</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/nl/pom.xml
+++ b/nl/pom.xml
@@ -166,8 +166,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.8</version>
-			</plugin>
+				</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -585,7 +585,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho.version}</version>
 				<configuration>
 					<additionalFileSets>
 						<fileSet>

--- a/testsuites/org.eclipse.birt.report.tests.chart/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.chart/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.tests.chart</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/testsuites/org.eclipse.birt.report.tests.engine.emitter.html/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.engine.emitter.html/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.tests.engine.emitter.html</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/testsuites/org.eclipse.birt.report.tests.model/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.model/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.tests.model</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/testsuites/org.eclipse.birt.tests.core/pom.xml
+++ b/testsuites/org.eclipse.birt.tests.core/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.tests.core</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/testsuites/org.eclipse.birt.tests.data/pom.xml
+++ b/testsuites/org.eclipse.birt.tests.data/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.tests.data</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/viewer/org.eclipse.birt.axis.overlay/pom.xml
+++ b/viewer/org.eclipse.birt.axis.overlay/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.axis.overlay</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/viewer/org.eclipse.birt.integration.wtp.ui/pom.xml
+++ b/viewer/org.eclipse.birt.integration.wtp.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.integration.wtp.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/viewer/org.eclipse.birt.jetty.overlay/pom.xml
+++ b/viewer/org.eclipse.birt.jetty.overlay/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.jetty.overlay</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/viewer/org.eclipse.birt.report.viewer.tests/pom.xml
+++ b/viewer/org.eclipse.birt.report.viewer.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.viewer.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/viewer/org.eclipse.birt.report.viewer/pom.xml
+++ b/viewer/org.eclipse.birt.report.viewer/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.viewer</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<profiles>

--- a/xtab/org.eclipse.birt.report.item.crosstab.core.tests/pom.xml
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core.tests/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.item.crosstab.core.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/xtab/org.eclipse.birt.report.item.crosstab.core/pom.xml
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.item.crosstab.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<build>

--- a/xtab/org.eclipse.birt.report.item.crosstab.ui/pom.xml
+++ b/xtab/org.eclipse.birt.report.item.crosstab.ui/pom.xml
@@ -7,7 +7,6 @@
 		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
-	<groupId>org.eclipse.birt</groupId>
 	<artifactId>org.eclipse.birt.report.item.crosstab.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
This pr fixes:
* groupId can be inherited from parent, so it doesn't need to be specified in each pom
* when importing the maven projects into Eclipse, a projects fails to import with error message "'src' already present on build path", this is caused by '.' and 'src' both being specified as 'Bundle-Classpath' where '.' already includes 'src'
