### PR TITLE
Fixed plugin.xml warnings (missing unbounded in extension point schema)

### DIFF
--- a/chart/org.eclipse.birt.chart.engine/schema/aggregatefunctions.exsd
+++ b/chart/org.eclipse.birt.chart.engine/schema/aggregatefunctions.exsd
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="org.eclipse.birt.chart.engine">
+<schema targetNamespace="org.eclipse.birt.chart.engine" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
          <meta.schema plugin="org.eclipse.birt.chart.engine" id="aggregatefunctions" name="BIRT Chart Library Aggregate Function Extension"/>
@@ -11,8 +11,13 @@
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="aggregateFunction"/>
          </sequence>
          <attribute name="point" type="string" use="required">

--- a/chart/org.eclipse.birt.chart.engine/schema/charttypes.exsd
+++ b/chart/org.eclipse.birt.chart.engine/schema/charttypes.exsd
@@ -17,7 +17,7 @@
          </appInfo>
       </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="chartType"/>
          </sequence>
          <attribute name="point" type="string" use="required">

--- a/chart/org.eclipse.birt.chart.engine/schema/datapointdefinitions.exsd
+++ b/chart/org.eclipse.birt.chart.engine/schema/datapointdefinitions.exsd
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="org.eclipse.birt.chart.engine">
+<schema targetNamespace="org.eclipse.birt.chart.engine" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
          <meta.schema plugin="org.eclipse.birt.chart.engine" id="datapointdefinitions" name="Contains definitions of Data Point Display"/>
@@ -11,8 +11,13 @@
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="datapointDefinition"/>
          </sequence>
          <attribute name="point" type="string" use="required">
@@ -80,7 +85,7 @@
          <meta.section type="examples"/>
       </appInfo>
       <documentation>
-            &lt;extension
+         &lt;extension
          point=&quot;org.eclipse.birt.chart.engine.datapointdefinitions&quot;&gt;
       &lt;datapointDefinition
             definition=&quot;org.eclipse.birt.chart.datafeed.BubbleDataPointDefinition&quot;

--- a/chart/org.eclipse.birt.chart.engine/schema/datasetprocessors.exsd
+++ b/chart/org.eclipse.birt.chart.engine/schema/datasetprocessors.exsd
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="org.eclipse.birt.chart.engine">
+<schema targetNamespace="org.eclipse.birt.chart.engine" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
          <meta.schema plugin="org.eclipse.birt.chart.engine" id="datasetprocessors" name="Contains definition of chart DataSet processors"/>
@@ -11,8 +11,13 @@
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="datasetProcessor"/>
          </sequence>
          <attribute name="point" type="string" use="required">

--- a/chart/org.eclipse.birt.chart.engine/schema/devicerenderers.exsd
+++ b/chart/org.eclipse.birt.chart.engine/schema/devicerenderers.exsd
@@ -2,9 +2,9 @@
 <!-- Schema file written by PDE -->
 <schema targetNamespace="org.eclipse.birt.chart.engine" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appinfo>
+      <appInfo>
          <meta.schema plugin="org.eclipse.birt.chart.engine" id="devicerenderers" name="Contains definition of chart device renderers"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          The DeviceRenderer extension point allows custom implementations of device renderers to be plugged into the chart library to generate charts in new output formats.
       </documentation>
@@ -12,12 +12,12 @@
 
    <element name="extension">
       <annotation>
-         <appinfo>
+         <appInfo>
             <meta.element />
-         </appinfo>
+         </appInfo>
       </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="deviceRenderer"/>
          </sequence>
          <attribute name="point" type="string" use="required">
@@ -63,9 +63,9 @@
                <documentation>
                   The device attribute corresponds to the fully qualified class name that represents the implementing device renderer class. An example of the fully qualified device renderer class name is &apos;org.eclipse.birt.chart.device.swt.SwtRendererImpl&apos;
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute kind="java"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
          <attribute name="format" type="string">
@@ -87,27 +87,27 @@
                <documentation>
                   @Since 2.5. This is used to display name of device renderer in UI. If it&apos;s blank, display name could be &quot;format&quot; attribute value.
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute translatable="true"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
       </complexType>
    </element>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="since"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          1.0.0
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="examples"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          &lt;extension
          point=&quot;org.eclipse.birt.chart.engine.devicerenderers&quot;&gt;
@@ -145,27 +145,27 @@
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="apiInfo"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          Please refer to the javadocs for IDeviceRenderer in the &lt;i&gt;org.eclipse.birt.chart.device&lt;/i&gt; package.
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="implementation"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          The &lt;i&gt;org.eclipse.birt.chart.device.extension&lt;/i&gt; plug-in provides device renderers for default supported output devices.
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="copyright"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          Copyright (c) 2004-2005 Actuate Corporation.
 All rights reserved. This program and the accompanying materials are made available under the  terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html

--- a/chart/org.eclipse.birt.chart.engine/schema/displayservers.exsd
+++ b/chart/org.eclipse.birt.chart.engine/schema/displayservers.exsd
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="org.eclipse.birt.chart.engine">
+<schema targetNamespace="org.eclipse.birt.chart.engine" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
          <meta.schema plugin="org.eclipse.birt.chart.engine" id="xservers" name="Contains definition of chart XServers"/>
@@ -11,8 +11,13 @@
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="displayserver"/>
          </sequence>
          <attribute name="point" type="string" use="required">

--- a/chart/org.eclipse.birt.chart.engine/schema/modelrenderers.exsd
+++ b/chart/org.eclipse.birt.chart.engine/schema/modelrenderers.exsd
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="org.eclipse.birt.chart.engine">
+<schema targetNamespace="org.eclipse.birt.chart.engine" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
          <meta.schema plugin="org.eclipse.birt.chart.engine" id="renderers" name="Contains definition of registered chart model renderers"/>
@@ -11,8 +11,13 @@
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="modelRenderer"/>
          </sequence>
          <attribute name="point" type="string" use="required">


### PR DESCRIPTION
Some of the extensions specified by BIRT itself did not match the extension point schema -> updated the schemas -> resolved warnings