### PR TITLE
Fixed warnings in MANIFESTs

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.data/META-INF/MANIFEST.MF
+++ b/UI/org.eclipse.birt.report.designer.ui.data/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Export-Package: org.eclipse.birt.report.designer.data.ui.actions,
  org.eclipse.birt.report.designer.data.ui.datasource,
  org.eclipse.birt.report.designer.data.ui.providers,
  org.eclipse.birt.report.designer.data.ui.util
-Bundle-ClassPath: library.jar,
- .
+Bundle-ClassPath: .
+Automatic-Module-Name: org.eclipse.birt.report.designer.ui.data

--- a/engine/uk.co.spudsoft.birt.emitters.excel.tests/META-INF/MANIFEST.MF
+++ b/engine/uk.co.spudsoft.birt.emitters.excel.tests/META-INF/MANIFEST.MF
@@ -16,9 +16,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  lib/commons-codec-1.5.jar,
  lib/dom4j-1.6.1.jar,
- lib/stax-api-1.0.1.jar,
  lib/xmlbeans-2.3.0.jar,
- lib/poi-3.9-20121203.jar,
  lib/poi-ooxml-3.9-20121203.jar,
  lib/poi-ooxml-schemas-3.9-20121203.jar
 Import-Package: uk.co.spudsoft.birt.emitters.excel

--- a/testsuites/org.eclipse.birt.report.tests.chart/META-INF/MANIFEST.MF
+++ b/testsuites/org.eclipse.birt.report.tests.chart/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Require-Bundle: org.junit;resolution:=optional,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: com.ibm.icu.util
 Bundle-Vendor: Eclipse BIRT Project
+Automatic-Module-Name: org.eclipse.birt.report.tests.chart


### PR DESCRIPTION
- removed non-existing 'library.jar's from classpath
- removed jars from classpath that are now imported from bundles
- added missing Automatic-Module-Name