### PR TITLE
Raised ReqExecEnv because of API use

### DIFF
--- a/chart/org.eclipse.birt.chart.tests/META-INF/MANIFEST.MF
+++ b/chart/org.eclipse.birt.chart.tests/META-INF/MANIFEST.MF
@@ -40,6 +40,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.batik.transcoder,
  org.apache.xerces;bundle-version="[2.8.0,3.0.0)";resolution:=optional
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.ibm.icu.text;version="3.4.4",
  com.ibm.icu.util;version="3.4.4"

--- a/data/org.eclipse.birt.report.data.oda.jdbc.tests/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.report.data.oda.jdbc.tests/META-INF/MANIFEST.MF
@@ -12,5 +12,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.datatools.connectivity.oda,
  org.apache.derby
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse BIRT Project


### PR DESCRIPTION
org.eclipse.birt.chart.tests and org.eclipse.birt.report.data.oda.jdbc.tests both use APIs from JavaSE-1.7 -> update RequiredExecutionEnvironment