### PR TITLE
Fixed duplicate project names

### DIFF
--- a/features/org.eclipse.birt.engine.runtime/.project
+++ b/features/org.eclipse.birt.engine.runtime/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.birt.osgi.runtime</name>
+	<name>org.eclipse.birt.engine.runtime</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
Importing all BIRT eclipse projects fails because of a duplicate project name. This seems to be a copy-and-paste error.