### PR TITLE
Add core tests to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ jdk:
 cache:
   directories:
     - ~/.m2
-  timeout: 1000
 
 install: true
 script: mvn -q -B --global-toolchains travis-maven-toolchain.xml clean install -DskipTests &&
         mvn -B --global-toolchains travis-maven-toolchain.xml -pl :org.eclipse.birt.core.tests integration-test
-before_cache: rm -r ~/.m2/repository/org/eclipse/birt
+before_cache:
+  - rm -r ~/.m2/repository/org/eclipse/birt
+  - rm -r ~/.m2/repository/.cache/tycho

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
 cache:
   directories:
     - ~/.m2
-script: mvn -B --global-toolchains travis-maven-toolchain.xml clean package -DskipTests
-install:
-  -
+  timeout: 1000
+
+install: true
+script: mvn -q -B --global-toolchains travis-maven-toolchain.xml clean install -DskipTests &&
+        mvn -B --global-toolchains travis-maven-toolchain.xml -pl :org.eclipse.birt.core.tests integration-test
+before_cache: rm -r ~/.m2/repository/org/eclipse/birt


### PR DESCRIPTION
This enables core tests on travis builds. In order for the travis build to pass, #510 has to be merged first.