### PR TITLE
commit before closing the connection

### DIFF
--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
@@ -476,6 +476,15 @@ public class Connection implements IConnection
 
 			if ( jdbcConn.isClosed( ) == false )
 			{
+				// if the policy DBConfig.SET_COMMIT_TO_FALSE is used, which sets autocommit to false by default
+				if (!jdbcConn.getAutoCommit() && DBConfig.getInstance().qualifyPolicy(
+						jdbcConn.getMetaData().getDriverName(),
+						DBConfig.SET_COMMIT_TO_FALSE))
+				{
+					// commit leaving no open transactions
+					commit( );
+				}
+
 				jdbcConn.close( );
 				logger.log(Level.FINE, "JDBC connection: " + jdbcConn + " is closed");
 			}


### PR DESCRIPTION
This leaves no open transactions using the postgres driver the default way. As the postgres driver uses the policy DBConfig.SET_COMMIT_TO_FALSE configured in config.xml, which sets autocommit to false by default.

The open transaction was introduced by this commit: eclipse@3936b04

To show the "idle in transaction" open database connection (which is reused, though!) run
SELECT * FROM pg_stat_activity
on the database after generating a report using BIRT with PostgreSQL JNDI.

Signed-off-by: Bernhard Kiselka <bk@wigeogis.com>