### PR TITLE
Fix for XSS vulnerability Bug 546816

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/utility/ParameterAccessor.java
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/utility/ParameterAccessor.java
@@ -2104,7 +2104,7 @@ public class ParameterAccessor
 			{
 			}
 		}
-		return request.getParameter( parameterName );
+		return htmlEncode( request.getParameter( parameterName ) );
 	}
 
 	/**
@@ -2258,7 +2258,7 @@ public class ParameterAccessor
 		{
 			return null;
 		}
-
+		filePath = htmlDecode( filePath );
 		if ( isEncodedPaths( request ) )
 		{
 			return decodeBase64( filePath );


### PR DESCRIPTION
Reflected XSS vulnerability in the __format URL parameter
It should also take care of the other parameters.
It make sure all parameter are escape to avoid attack.
tested with associate unit test.


Signed-off-by: shiheng guan <guans@opentext.com>