### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
-  - openjdk11
+  - openjdk8
+
 cache:
   directories:
     - ~/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - openjdk8
-
 cache:
   directories:
     - ~/.m2

--- a/travis-maven-toolchain.xml
+++ b/travis-maven-toolchain.xml
@@ -7,7 +7,7 @@
 	  <id>JavaSE-1.8</id>
     </provides>
     <configuration>
-      <jdkHome>/usr/lib/jvm/java-8-oracle/</jdkHome>
+      <jdkHome>/usr/lib/jvm/java-1.8.0-openjdk-amd64</jdkHome>
     </configuration>
   </toolchain>
   <toolchain>


### PR DESCRIPTION
Travis has updated the default linux distribution from trusty to xenial. On xenial, OracleJDK 8 is not supported anymore. My solution: use OpenJDK 8 on xenial. Alternative solutions: use OracleJDK 8 on trusty or update to Oracle/OpenJDK 11 on xenial.