### PR TITLE
Fix to resolve the "Get page count failed" error 

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/QueryResults.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/QueryResults.java
@@ -280,12 +280,12 @@ public class QueryResults implements IQueryResults, IQueryService
 			iterator = null;
 		}
 	    
-		queryService.close( );
+		//queryService.close( );
 		queryService = null;
 		logger.logp( Level.FINER,
 				QueryResults.class.getName( ),
 				"close",
-				"QueryResults is closed" );
+				"Iterators associated with QueryResults are closed" );
 	}
 	
 	/**


### PR DESCRIPTION
caused while running a report with chart that is based on Join DS from datadesign

Signed-off-by: Meeta Kapoor <mkapoor@opentext.com>