### PR TITLE
X-Content-Type-Options: nosniff prevents the client browser from 'mime sniffing' but image does not display in IE

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
@@ -3637,6 +3637,11 @@ public class HTMLReportEmitter extends ContentEmitterAdapter
 				.getDesignHandle( );
 		URL url = design.findResource( uri, IResourceLocator.IMAGE,
 				reportContext.getAppContext( ) );
+		String fileExtension = null;
+		if ( uri != null && uri.contains( "." ) )
+		{
+			fileExtension = uri.substring( uri.lastIndexOf( "." ) + 1 );
+		}
 		if ( url == null )
 		{
 			return uri;
@@ -3661,6 +3666,10 @@ public class HTMLReportEmitter extends ContentEmitterAdapter
 		}
 		image.setReportRunnable( runnable );
 		image.setRenderOption( renderOption );
+		if ( fileExtension != null )
+		{
+			image.setMimeType( "image/" + fileExtension );
+		}
 		String imgUri = null;
 		if ( imageHandler != null )
 		{


### PR DESCRIPTION
X-Content-Type-Options: nosniff prevents the client browser from 'mime sniffing' but image does not display in IE