### PR TITLE
Avoid writing password into report design in case where Connection profile is used as data source

### DIFF
--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/writer/ModuleWriterImpl.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/writer/ModuleWriterImpl.java
@@ -751,6 +751,17 @@ abstract class ModuleWriterImpl extends ElementVisitor
 	{
 		PropertyDefn propDefn = obj.getPropertyDefn( propName );
 
+		// if connection profile is used as data source then
+		// do not write the password into report design
+		Object valueCP = obj.getLocalProperty( getModule( ),
+				"OdaConnProfileStorePath" );
+		if ( propName.equalsIgnoreCase( "password" ) && valueCP != null )
+		{
+			String xmlCP = propDefn.getXmlValue( getModule( ), valueCP );
+			if ( xmlCP != null )
+				return;
+		}
+
 		// The style property is not available for all elements.
 
 		if ( propDefn == null )


### PR DESCRIPTION
Avoid writing password into report design in case where Connection profile is used as data source