### PR TITLE
Space is encoded in dataset parameter #623

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/utility/ParameterAccessor.java
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/utility/ParameterAccessor.java
@@ -2104,7 +2104,7 @@ public class ParameterAccessor
 			{
 			}
 		}
-		return htmlEncode( request.getParameter( parameterName ) );
+		return request.getParameter( parameterName );
 	}
 
 	/**

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/common/Attributes.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/common/Attributes.jsp
@@ -13,7 +13,7 @@
 	{
 		Constants.request = {};
 	}
-	Constants.request.format = '<%= ParameterAccessor.getFormat(request) %>';
+	Constants.request.format = '<%= ParameterAccessor.htmlEncode(ParameterAccessor.getFormat(request)) %>';
 	Constants.request.rtl = <%= ParameterAccessor.isRtl( request ) %>;
 	Constants.request.isDesigner = <%= ParameterAccessor.isDesigner() %>;
 	Constants.request.servletPath = "<%= request.getAttribute( "ServletPath" ) %>".substr(1);


### PR DESCRIPTION
Redo fix to bug 456816 (CVE-2019-11776) to html-encode format parameter in the jsp rather than encoding all parameters which was causing problems in prepared queries.

Signed-off-by: Steve Schafer <sschafer@innoventsolutions.com>