### PR TITLE
Bugfix for issue 636 - NPE with test report from eclipse bug 562873

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableLayout.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableLayout.java
@@ -618,16 +618,6 @@ public class TableLayout {
 		return false;
 	}
 
-	private boolean isEmptyRow(RowArea rowArea) {
-		for (int i = startCol; i <= endCol; i++) {
-			CellArea cell = rowArea.getCell(i);
-			if (cell != null && cell.getChildrenCount() > 0) {
-				return false;
-			}
-		}
-		return true;
-	}
-
 	/**
 	 * 1) Creates row wrapper. 2) For the null cell in the row wrapper, fills the
 	 * relevant position with dummy cell or empty cell. 3) Updates the height of the
@@ -652,8 +642,7 @@ public class TableLayout {
 			lastRow = (RowArea) rows.getCurrent();
 		}
 		currentRow = rowArea;
-		// Do not use specified height if row is empty to avoid endless page break
-		int sheight = isEmptyRow(rowArea) ? 0 : rowArea.getSpecifiedHeight();
+		int sheight = rowArea.getSpecifiedHeight();
 		int height = sheight;
 		/*
 		 * In this case, the row should be the first row of new page. 1. this row is the


### PR DESCRIPTION
The commit https://github.com/eclipse/birt/commit/f84d0f812a72ba8e54f6caf641e16442d480594c caused severe issues.
In older releases of BIRT up to 4.6.0, the output was wrong (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=562873).
Newer releases (starting from 4.7.0) caused a NullPointerException when running the example report.
As a solution, removed the changes from that commit.