### PR TITLE
XLSX tab naming can cause IllegalArgumentException #641

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Build with Maven
-      run: mvn clean install --no-transfer-progress -U -fn
+      run: mvn clean install --no-transfer-progress -U -DskipTests
     - name: Test Model
       run: mvn -B -pl :org.eclipse.birt.report.model.tests integration-test
     - name: Test Charts
@@ -56,4 +56,3 @@ jobs:
       run: mvn -B -pl :org.eclipse.birt.report.tests.engine integration-test
     - name: Test Core
       run: mvn -B -pl :org.eclipse.birt.core.tests integration-test
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Build with Maven
-      run: mvn clean install --no-transfer-progress -U -DskipTests
+      run: mvn clean install --no-transfer-progress -U -fn
     - name: Test Model
       run: mvn -B -pl :org.eclipse.birt.report.model.tests integration-test
     - name: Test Charts

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://eclipse.org/birt
 [![Build Status](https://github.com/eclipse/birt/workflows/CI/badge.svg)](https://github.com/eclipse/birt/actions)
 
 ## Building BIRT
-BIRT is built with [Apache Maven](http://maven.apache.org) through [Tycho](https://github.com/eclipse/tycho).
+BIRT is built with [Apache Maven](http://maven.apache.org).
 
 To build BIRT with the latest Eclipse platform, run:
 
@@ -22,12 +22,9 @@ To build BIRT with Eclipse Oxygen, run:
     mvn package -Poxygen -DskipTests
     
 ### Building environment
-* JDK 11
+* JDK 1.8
 * Maven 3.6.3
 * Internet access
-
-## Latest snapshot repository towards 4.9.0
+* 
+## Download latest snapshot towards 4.9.0
 https://download.eclipse.org/birt/update-site/snapshot/
-
-## Latest designer download towards 4.9.0
-https://ci.eclipse.org/birt/job/birt-master/lastSuccessfulBuild/artifact/build/birt-packages/birt-report-all-in-one/target/products/

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableLayout.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableLayout.java
@@ -618,6 +618,16 @@ public class TableLayout {
 		return false;
 	}
 
+	private boolean isEmptyRow(RowArea rowArea) {
+		for (int i = startCol; i <= endCol; i++) {
+			CellArea cell = rowArea.getCell(i);
+			if (cell != null && cell.getChildrenCount() > 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	/**
 	 * 1) Creates row wrapper. 2) For the null cell in the row wrapper, fills the
 	 * relevant position with dummy cell or empty cell. 3) Updates the height of the
@@ -642,7 +652,8 @@ public class TableLayout {
 			lastRow = (RowArea) rows.getCurrent();
 		}
 		currentRow = rowArea;
-		int sheight = rowArea.getSpecifiedHeight();
+		// Do not use specified height if row is empty to avoid endless page break
+		int sheight = isEmptyRow(rowArea) ? 0 : rowArea.getSpecifiedHeight();
 		int height = sheight;
 		/*
 		 * In this case, the row should be the first row of new page. 1. this row is the

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.api.IRenderOption;
 import org.eclipse.birt.report.engine.api.ReportEngine;
 import org.eclipse.birt.report.engine.emitter.IContentEmitter;
@@ -287,5 +288,85 @@ public class HandlerState {
 			}
 		}
 		return 0;
+	}
+
+	/**
+	 * Maximum number of characters that Excel will accept for a sheet name.
+	 */
+	public static final int MAX_SHEET_NAME_LENGTH = 31;
+	/**
+	 * Characters that Excel will not accept in a sheet name.
+	 */
+	public static final String[] ILLEGAL_SHEET_NAME_CHARACTERS = new String[] { "\\", //$NON-NLS-1$
+			"/", //$NON-NLS-1$
+			"*", //$NON-NLS-1$
+			"[", //$NON-NLS-1$
+			"]", //$NON-NLS-1$
+			":", //$NON-NLS-1$
+			"?" //$NON-NLS-1$
+	};
+
+	/**
+	 * Remove illegal characters from the sheet name and make sure it's not too
+	 * long.
+	 *
+	 * @param sheetName
+	 * @return corrected sheet name
+	 */
+	public String correctSheetName(final String sheetName) {
+		// https://www.accountingweb.com/technology/excel/seven-characters-you-cant-use-in-worksheet-names
+		if (sheetName == null) {
+			return null;
+		}
+		String correctedSheetName = sheetName;
+		for (String illegalChar : ILLEGAL_SHEET_NAME_CHARACTERS) {
+			correctedSheetName = correctedSheetName.replace(illegalChar, ""); //$NON-NLS-1$
+		}
+		if ("history".equalsIgnoreCase(correctedSheetName)) { //$NON-NLS-1$
+			return "history-sheet"; //$NON-NLS-1$
+		}
+		if (correctedSheetName.length() > MAX_SHEET_NAME_LENGTH) {
+			correctedSheetName = correctedSheetName.substring(0, MAX_SHEET_NAME_LENGTH);
+		}
+		return correctedSheetName;
+	}
+
+	/**
+	 * Add an index to the end of the sheet name if necessary. Shorten the sheet
+	 * name if necessary. The sheet name is assumed to not be too long to start
+	 * with.
+	 *
+	 * @return the prepared sheet name
+	 * @throws BirtException
+	 */
+	public String prepareSheetName() throws BirtException {
+		String sheetName = this.sheetName;
+		if (sheetName == null) {
+			return null;
+		}
+		String preparedName = sheetName;
+		Integer previousNameCount = 1;
+		while (true) {
+			Integer nameCount = this.sheetNames.get(sheetName);
+			if (nameCount == null) {
+				this.sheetNames.put(sheetName, previousNameCount);
+				return preparedName;
+			}
+			++nameCount;
+			preparedName = sheetName + " " + nameCount; //$NON-NLS-1$
+			int correction = preparedName.length() - MAX_SHEET_NAME_LENGTH;
+			if (correction <= 0) {
+				this.sheetNames.put(sheetName, nameCount);
+				return preparedName;
+			}
+			if (correction > sheetName.length()) {
+				throw new BirtException(EmitterServices.getPluginName(),
+						"Unable to fit sheet name into the maximum allowed length", //$NON-NLS-1$
+						null);
+			}
+			sheetName = sheetName.substring(0, sheetName.length() - correction);
+			preparedName = sheetName + " " + nameCount; //$NON-NLS-1$
+			previousNameCount = nameCount;
+		}
 	}
 }

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.api.IRenderOption;
 import org.eclipse.birt.report.engine.api.ReportEngine;
 import org.eclipse.birt.report.engine.emitter.IContentEmitter;
@@ -288,85 +287,5 @@ public class HandlerState {
 			}
 		}
 		return 0;
-	}
-
-	/**
-	 * Maximum number of characters that Excel will accept for a sheet name.
-	 */
-	public static final int MAX_SHEET_NAME_LENGTH = 31;
-	/**
-	 * Characters that Excel will not accept in a sheet name.
-	 */
-	public static final String[] ILLEGAL_SHEET_NAME_CHARACTERS = new String[] { "\\", //$NON-NLS-1$
-			"/", //$NON-NLS-1$
-			"*", //$NON-NLS-1$
-			"[", //$NON-NLS-1$
-			"]", //$NON-NLS-1$
-			":", //$NON-NLS-1$
-			"?" //$NON-NLS-1$
-	};
-
-	/**
-	 * Remove illegal characters from the sheet name and make sure it's not too
-	 * long.
-	 *
-	 * @param sheetName
-	 * @return corrected sheet name
-	 */
-	public String correctSheetName(final String sheetName) {
-		// https://www.accountingweb.com/technology/excel/seven-characters-you-cant-use-in-worksheet-names
-		if (sheetName == null) {
-			return null;
-		}
-		String correctedSheetName = sheetName;
-		for (String illegalChar : ILLEGAL_SHEET_NAME_CHARACTERS) {
-			correctedSheetName = correctedSheetName.replace(illegalChar, ""); //$NON-NLS-1$
-		}
-		if ("history".equalsIgnoreCase(correctedSheetName)) { //$NON-NLS-1$
-			return "history-sheet"; //$NON-NLS-1$
-		}
-		if (correctedSheetName.length() > MAX_SHEET_NAME_LENGTH) {
-			correctedSheetName = correctedSheetName.substring(0, MAX_SHEET_NAME_LENGTH);
-		}
-		return correctedSheetName;
-	}
-
-	/**
-	 * Add an index to the end of the sheet name if necessary. Shorten the sheet
-	 * name if necessary. The sheet name is assumed to not be too long to start
-	 * with.
-	 *
-	 * @return the prepared sheet name
-	 * @throws BirtException
-	 */
-	public String prepareSheetName() throws BirtException {
-		String sheetName = this.sheetName;
-		if (sheetName == null) {
-			return null;
-		}
-		String preparedName = sheetName;
-		Integer previousNameCount = 1;
-		while (true) {
-			Integer nameCount = this.sheetNames.get(sheetName);
-			if (nameCount == null) {
-				this.sheetNames.put(sheetName, previousNameCount);
-				return preparedName;
-			}
-			++nameCount;
-			preparedName = sheetName + " " + nameCount; //$NON-NLS-1$
-			int correction = preparedName.length() - MAX_SHEET_NAME_LENGTH;
-			if (correction <= 0) {
-				this.sheetNames.put(sheetName, nameCount);
-				return preparedName;
-			}
-			if (correction > sheetName.length()) {
-				throw new BirtException(EmitterServices.getPluginName(),
-						"Unable to fit sheet name into the maximum allowed length", //$NON-NLS-1$
-						null);
-			}
-			sheetName = sheetName.substring(0, sheetName.length() - correction);
-			preparedName = sheetName + " " + nameCount; //$NON-NLS-1$
-			previousNameCount = nameCount;
-		}
 	}
 }

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import org.eclipse.birt.report.model.api.elements.ReportDesignConstants;
 import org.eclipse.birt.report.model.api.metadata.IArgumentInfo;
 import org.eclipse.birt.report.model.api.metadata.IElementDefn;
-import org.eclipse.birt.report.model.api.metadata.IElementPropertyDefn;
 import org.eclipse.birt.report.model.api.metadata.IMethodInfo;
 import org.eclipse.birt.report.model.api.metadata.IPredefinedStyle;
 import org.eclipse.birt.report.model.api.metadata.IPropertyType;
@@ -113,15 +112,8 @@ public class ElementDefnTest extends AbstractMetaTest {
 		assertNotNull(elemDefn);
 
 		System.out.println("elemDefn name = " + elemDefn.getName());
-		System.out.println("  displayName = " + elemDefn.getDisplayName());
-		System.out.println("  properties:");
-		for(IElementPropertyDefn property : elemDefn.getProperties()) {
-			System.out.println("    " + property.getName());
-		}
+
 		List groupNames = elemDefn.getGroupNames();
-		
-		System.out.println("  groupNames = " + groupNames);
-		
 		assertEquals(6, groupNames.size());
 	}
 

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
@@ -18,6 +18,9 @@ import org.eclipse.birt.report.model.api.elements.ReportDesignConstants;
 import org.eclipse.birt.report.model.api.metadata.IArgumentInfo;
 import org.eclipse.birt.report.model.api.metadata.IElementDefn;
 import org.eclipse.birt.report.model.api.metadata.IMethodInfo;
+import org.eclipse.birt.report.model.api.metadata.IPredefinedStyle;
+import org.eclipse.birt.report.model.api.metadata.IPropertyType;
+import org.eclipse.birt.report.model.api.metadata.IStructureDefn;
 import org.eclipse.birt.report.model.api.metadata.MetaDataConstants;
 import org.eclipse.birt.report.model.core.DesignElement;
 import org.eclipse.birt.report.model.elements.OdaDataSet;
@@ -77,8 +80,38 @@ public class ElementDefnTest extends AbstractMetaTest {
 	 */
 	public void testGetGroupNames() {
 		ThreadResources.setLocale(ULocale.ENGLISH);
-		IElementDefn elemDefn = MetaDataDictionary.getInstance().getElement(MetaDataConstants.STYLE_NAME);
+
+		MetaDataDictionary dict = MetaDataDictionary.getInstance();
+		System.out.println("dict = " + dict);
+		System.out.println("  elements:");
+		for (IElementDefn ed : dict.getElements()) {
+			System.out.println("    " + ed.getName());
+		}
+		System.out.println("  extensions:");
+		for (IElementDefn ed : dict.getExtensions()) {
+			System.out.println("    " + ed.getName());
+		}
+		dict.getFunctions();
+		System.out.println("  functions:");
+		for(IMethodInfo methodInfo : dict.getFunctions()) {
+			System.out.println("    " + methodInfo.getName());
+		}
+		System.out.println("  predefined styles:");
+		for(IPredefinedStyle predefinedStyle : dict.getPredefinedStyles()) {
+			System.out.println("    " + predefinedStyle.getName());
+		}
+		System.out.println("  property types:");
+		for(IPropertyType propertyType : dict.getPropertyTypes()) {
+			System.out.println("    " + propertyType.getName());
+		}
+		System.out.println("  structures:");
+		for(IStructureDefn structure : dict.getStructures()) {
+			System.out.println("    " + structure.getName());
+		}
+		IElementDefn elemDefn = dict.getElement(MetaDataConstants.STYLE_NAME);
 		assertNotNull(elemDefn);
+
+		System.out.println("elemDefn name = " + elemDefn.getName());
 
 		List groupNames = elemDefn.getGroupNames();
 		assertEquals(6, groupNames.size());

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.birt.report.model.api.elements.ReportDesignConstants;
 import org.eclipse.birt.report.model.api.metadata.IArgumentInfo;
 import org.eclipse.birt.report.model.api.metadata.IElementDefn;
+import org.eclipse.birt.report.model.api.metadata.IElementPropertyDefn;
 import org.eclipse.birt.report.model.api.metadata.IMethodInfo;
 import org.eclipse.birt.report.model.api.metadata.IPredefinedStyle;
 import org.eclipse.birt.report.model.api.metadata.IPropertyType;
@@ -112,8 +113,14 @@ public class ElementDefnTest extends AbstractMetaTest {
 		assertNotNull(elemDefn);
 
 		System.out.println("elemDefn name = " + elemDefn.getName());
-
+		System.out.println("  properties:");
+		for(IElementPropertyDefn propDefn : elemDefn.getProperties()) {
+			System.out.println("    " + propDefn.getName());
+		}
+		
 		List groupNames = elemDefn.getGroupNames();
+		System.out.println("  groupNames = " + groupNames);
+
 		assertEquals(6, groupNames.size());
 	}
 

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
@@ -120,6 +120,11 @@ public class ElementDefnTest extends AbstractMetaTest {
 		
 		List groupNames = elemDefn.getGroupNames();
 		System.out.println("  groupNames = " + groupNames);
+		if(groupNames.isEmpty()) {
+			// this is where it's failing
+			IElementDefn reportDesignDefn = dict.getElement("ReportDesign");
+			System.out.println("  reportDesign = " + reportDesignDefn.getContents());
+		}
 
 		assertEquals(6, groupNames.size());
 	}

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/metadata/ElementDefnTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.birt.report.model.api.elements.ReportDesignConstants;
 import org.eclipse.birt.report.model.api.metadata.IArgumentInfo;
 import org.eclipse.birt.report.model.api.metadata.IElementDefn;
+import org.eclipse.birt.report.model.api.metadata.IElementPropertyDefn;
 import org.eclipse.birt.report.model.api.metadata.IMethodInfo;
 import org.eclipse.birt.report.model.api.metadata.IPredefinedStyle;
 import org.eclipse.birt.report.model.api.metadata.IPropertyType;
@@ -112,8 +113,15 @@ public class ElementDefnTest extends AbstractMetaTest {
 		assertNotNull(elemDefn);
 
 		System.out.println("elemDefn name = " + elemDefn.getName());
-
+		System.out.println("  displayName = " + elemDefn.getDisplayName());
+		System.out.println("  properties:");
+		for(IElementPropertyDefn property : elemDefn.getProperties()) {
+			System.out.println("    " + property.getName());
+		}
 		List groupNames = elemDefn.getGroupNames();
+		
+		System.out.println("  groupNames = " + groupNames);
+		
 		assertEquals(6, groupNames.size());
 	}
 

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/util/BaseTestCase.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/util/BaseTestCase.java
@@ -143,6 +143,7 @@ public abstract class BaseTestCase extends TestCase {
 		ThreadResources.setLocale(ULocale.ENGLISH);
 
 		if (engine == null) {
+			MetaDataDictionary.reset(); // will force MetaDataDictionary to initialize
 			engine = new DesignEngine(new DesignConfig());
 		}
 	}

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
@@ -529,7 +529,7 @@ public final class MetaDataDictionary implements IMetaDataDictionary {
 		}
 
 		System.out.println("initializing MetaDataDictionary from " + ROM_DEF_FILE_NAME);
-		Thread.dumpStack();
+		// Thread.dumpStack();
 		try {
 			InputStream input = (ReportDesign.class.getResourceAsStream(ROM_DEF_FILE_NAME));
 			MetaDataReader.read(input);

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
@@ -492,6 +492,7 @@ public final class MetaDataDictionary implements IMetaDataDictionary {
 	 */
 
 	public synchronized static void reset() {
+		System.out.println("resetting MetaDataDictionary");
 		instance = new MetaDataDictionary();
 		ExtensionManager.releaseInstance();
 		initialized = false;
@@ -527,6 +528,7 @@ public final class MetaDataDictionary implements IMetaDataDictionary {
 			return;
 		}
 
+		System.out.println("initializing MetaDataDictionary from " + ROM_DEF_FILE_NAME);
 		try {
 			InputStream input = (ReportDesign.class.getResourceAsStream(ROM_DEF_FILE_NAME));
 			MetaDataReader.read(input);
@@ -551,6 +553,7 @@ public final class MetaDataDictionary implements IMetaDataDictionary {
 
 	void addElementDefn(ElementDefn type) throws MetaDataException {
 		String name = type.getName();
+		System.out.println("adding ElementDefn '" + name + "' to MetaDataDictionary");
 		if (StringUtil.isBlank(name))
 			throw new MetaDataException(MetaDataException.DESIGN_EXCEPTION_MISSING_ELEMENT_NAME);
 		if (elementNameMap.containsKey(name))

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
@@ -527,14 +527,11 @@ public final class MetaDataDictionary implements IMetaDataDictionary {
 			return;
 		}
 
-		System.out.println("initializing MetaDataDictionary");
 		try {
 			InputStream input = (ReportDesign.class.getResourceAsStream(ROM_DEF_FILE_NAME));
 			MetaDataReader.read(input);
 			ExtensionManager.getInstance().initialize();
 		} catch (MetaDataParserException e) {
-			System.out.println("caught MetaDataDictionary initialization exception");
-			e.printStackTrace();
 			// we provide logger, so do not assert.
 		} finally {
 			initialized = true;

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
@@ -527,11 +527,14 @@ public final class MetaDataDictionary implements IMetaDataDictionary {
 			return;
 		}
 
+		System.out.println("initializing MetaDataDictionary");
 		try {
 			InputStream input = (ReportDesign.class.getResourceAsStream(ROM_DEF_FILE_NAME));
 			MetaDataReader.read(input);
 			ExtensionManager.getInstance().initialize();
 		} catch (MetaDataParserException e) {
+			System.out.println("caught MetaDataDictionary initialization exception");
+			e.printStackTrace();
 			// we provide logger, so do not assert.
 		} finally {
 			initialized = true;

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/MetaDataDictionary.java
@@ -529,6 +529,7 @@ public final class MetaDataDictionary implements IMetaDataDictionary {
 		}
 
 		System.out.println("initializing MetaDataDictionary from " + ROM_DEF_FILE_NAME);
+		Thread.dumpStack();
 		try {
 			InputStream input = (ReportDesign.class.getResourceAsStream(ROM_DEF_FILE_NAME));
 			MetaDataReader.read(input);

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/web.xml
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/web.xml
@@ -247,6 +247,16 @@ Automatically created by Apache Tomcat JspC.
 
 
     <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-class>
     </servlet>
@@ -254,6 +264,11 @@ Automatically created by Apache Tomcat JspC.
     <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.CancelTask_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -267,28 +282,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.CancelTask_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -297,8 +292,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.HiddenParameterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.HiddenParameterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -312,18 +307,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.HiddenParameterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.HiddenParameterFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -332,8 +317,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -342,18 +337,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -362,8 +347,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -372,18 +362,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -397,8 +387,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -407,18 +402,43 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.index_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.index_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.index_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.index_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-class>
     </servlet>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/common/Locale.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/common/processing.jsp</url-pattern>
+    </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/common/Error.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/RadioButtonParameterFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
+        <url-pattern>/CancelTask.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -432,33 +452,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/common/processing.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/common/Locale.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
-        <url-pattern>/CancelTask.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/RadioButtonParameterFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/parameter/ComboBoxParameterFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/CheckboxParameterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -467,8 +462,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/TextBoxParameterFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.HiddenParameterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/HiddenParameterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -482,18 +477,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/RequesterFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.HiddenParameterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/HiddenParameterFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/RunFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/CheckboxParameterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -502,8 +487,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/TextBoxParameterFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/layout/SidebarFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/RequesterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -512,18 +507,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/TocFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/ProgressBarFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/NavigationbarFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/RunFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -532,8 +517,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/PrintReportDialogFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/ProgressBarFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/TocFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -542,18 +532,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/PrintReportDialogFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/NavigationbarFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/dialog/ExceptionDialogFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/ParameterDialogFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/ExportDataDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -567,8 +557,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/PrintReportServerDialogFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/ExportDataDialogFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/ParameterDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -577,13 +572,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.index_jsp</servlet-name>
+        <url-pattern>/index.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.index_jsp</servlet-name>
-        <url-pattern>/index.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/PrintReportServerDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
 <!--

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/web.xml
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/web.xml
@@ -247,28 +247,13 @@ Automatically created by Apache Tomcat JspC.
 
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.CancelTask_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -282,13 +267,23 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.CancelTask_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.DocumentFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.DocumentFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -302,28 +297,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -332,8 +312,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.DocumentFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.DocumentFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -342,13 +327,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.FramesetFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.FramesetFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -357,13 +347,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -372,8 +357,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -382,8 +367,23 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.FramesetFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.FramesetFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -392,8 +392,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -406,39 +416,14 @@ Automatically created by Apache Tomcat JspC.
         <servlet-class>org.apache.jsp.index_jsp</servlet-class>
     </servlet>
 
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/common/Locale.jsp</url-pattern>
-    </servlet-mapping>
-
     <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/common/processing.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/common/Error.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/parameter/RadioButtonParameterFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
-        <url-pattern>/CancelTask.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -452,13 +437,23 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/ComboBoxParameterFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
+        <url-pattern>/CancelTask.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.DocumentFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/DocumentFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/common/Error.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/common/Locale.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ComboBoxParameterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/ComboBoxParameterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -472,28 +467,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/ReportContentFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.CheckboxParameterFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/parameter/CheckboxParameterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/ReportDialogFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/TextBoxParameterFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/SidebarFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/ReportContentFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -502,8 +482,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/ReportFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.DocumentFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/DocumentFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/TextBoxParameterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -512,13 +497,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.FramesetFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/FramesetFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/ReportFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/ProgressBarFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/ReportDialogFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/SidebarFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -527,13 +517,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/ToolbarFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/PrintReportDialogFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/ProgressBarFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -542,8 +527,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/ExceptionDialogFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/PrintReportDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -552,8 +537,23 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/DialogContainerFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/ParameterDialogFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.FramesetFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/FramesetFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/ToolbarFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/PrintReportServerDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -562,8 +562,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ParameterDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/ParameterDialogFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExceptionDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/ExceptionDialogFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/DialogContainerFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -574,16 +584,6 @@ Automatically created by Apache Tomcat JspC.
     <servlet-mapping>
         <servlet-name>org.apache.jsp.index_jsp</servlet-name>
         <url-pattern>/index.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/PrintReportServerDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
 <!--


### PR DESCRIPTION
The spudsoft emitter uses the table of contents entries for tab naming. POI and/or Excel has some restrictions on what characters can comprise a tab name, and this can lead errors that can be data-dependent. Additionally there is a size limit on the name but the emitter code doesn't take that into account when searching for duplicate names, which can also lead to errors.

Signed-off-by: Steve Schafer <sschafer@innoventsolutions.com>