### PR TITLE
Fixed a bug with IndexOutOfBoundsException when PDF wordbreak option …

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextCompositor.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextCompositor.java
@@ -275,13 +275,14 @@ public class TextCompositor {
 				wordVestige = null;
 				insertFirstExceedWord = false;
 			}
-			if (isNewLine && context.isEnableWordbreak()) {
-				doWordBreak(word.getValue(), textArea);
-			} else if (isNewLine && textArea.isEmpty()) {
-				// If width of a word is larger than the max line width, add
-				// it into the line directly.
-				addWord(textArea, textLength, wordWidth);
-
+			if (isNewLine && textArea.isEmpty()) {
+				if (context.isEnableWordbreak()) {
+					doWordBreak(word.getValue(), textArea);
+				} else {
+					// If width of a word is larger than the max line width,
+					// add it into the line directly.
+					addWord(textArea, textLength, wordWidth);
+				}
 			} else {
 				wordVestige = null;
 				remainWord = word;


### PR DESCRIPTION
…is set and whitespace:nowrap property ist set.

A simple test report with a label containing text "Blablabla BlablaBla BlaBlaBla BlaBlaBla Blablabla" (Arial, 10pt) on a 50mm wide page causes BIRT to crash when

        IPDFRenderOption options = new PDFRenderOption();
        options.setOption("pdfRenderOption.wordBreak", true);

is used and the label has 

            <property name="whiteSpace">nowrap</property>

This PR fixes that bug.