### PR TITLE
XLSX tab naming can cause IllegalArgumentException #641

### DIFF
--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/ExcelEmitter.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/ExcelEmitter.java
@@ -229,7 +229,7 @@ public abstract class ExcelEmitter implements IContentEmitter {
 		log.removePrefix('>');
 		log.debug("end:", report);
 
-		String reportTitle = report.getTitle();
+		String reportTitle = handlerState.correctSheetName(report.getTitle());
 		if ((handlerState.getWb().getNumberOfSheets() == 1) && (reportTitle != null)) {
 			handlerState.getWb().setSheetName(0, reportTitle);
 		}

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
@@ -1,12 +1,12 @@
 /*************************************************************************************
  * Copyright (c) 2011, 2012, 2013 James Talbut.
  *  jim-emitters@spudsoft.co.uk
- *  
- * All rights reserved. This program and the accompanying materials 
+ *
+ * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *     James Talbut - Initial implementation.
  ************************************************************************************/
@@ -122,7 +122,7 @@ public class HandlerState {
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param log
 	 * @param smu
 	 * @param wb

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/HandlerState.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.api.IRenderOption;
 import org.eclipse.birt.report.engine.api.ReportEngine;
 import org.eclipse.birt.report.engine.emitter.IContentEmitter;
@@ -287,5 +288,85 @@ public class HandlerState {
 			}
 		}
 		return 0;
+	}
+
+	/**
+	 * Maximum number of characters that Excel will accept for a sheet name.
+	 */
+	public static final int MAX_SHEET_NAME_LENGTH = 31;
+	/**
+	 * Characters that Excel will not accept in a sheet name.
+	 */
+	public static final String[] ILLEGAL_SHEET_NAME_CHARACTERS = new String[] { "\\", //$NON-NLS-1$
+			"/", //$NON-NLS-1$
+			"*", //$NON-NLS-1$
+			"[", //$NON-NLS-1$
+			"]", //$NON-NLS-1$
+			":", //$NON-NLS-1$
+			"?" //$NON-NLS-1$
+	};
+
+	/**
+	 * Remove illegal characters from the sheet name and make sure it's not too
+	 * long.
+	 *
+	 * @param sheetName
+	 * @return corrected sheet name
+	 */
+	public String correctSheetName(final String sheetName) {
+		// https://www.accountingweb.com/technology/excel/seven-characters-you-cant-use-in-worksheet-names
+		if (sheetName == null) {
+			return null;
+		}
+		String correctedSheetName = sheetName;
+		for (String illegalChar : ILLEGAL_SHEET_NAME_CHARACTERS) {
+			correctedSheetName = correctedSheetName.replace(illegalChar, ""); //$NON-NLS-1$
+		}
+		if ("history".equalsIgnoreCase(correctedSheetName)) { //$NON-NLS-1$
+			return "history-sheet"; //$NON-NLS-1$
+		}
+		if (correctedSheetName.length() > MAX_SHEET_NAME_LENGTH) {
+			correctedSheetName = correctedSheetName.substring(0, MAX_SHEET_NAME_LENGTH);
+		}
+		return correctedSheetName;
+	}
+
+	/**
+	 * Add an index to the end of the sheet name if necessary. Shorten the sheet
+	 * name if necessary. The sheet name is assumed to not be too long to start
+	 * with.
+	 *
+	 * @return the prepared sheet name
+	 * @throws BirtException
+	 */
+	public String prepareSheetName() throws BirtException {
+		String sheetName = this.sheetName;
+		if (sheetName == null) {
+			return null;
+		}
+		String preparedName = sheetName;
+		Integer previousNameCount = 1;
+		while (true) {
+			Integer nameCount = this.sheetNames.get(sheetName);
+			if (nameCount == null) {
+				this.sheetNames.put(sheetName, previousNameCount);
+				return preparedName;
+			}
+			++nameCount;
+			preparedName = sheetName + " " + nameCount; //$NON-NLS-1$
+			int correction = preparedName.length() - MAX_SHEET_NAME_LENGTH;
+			if (correction <= 0) {
+				this.sheetNames.put(sheetName, nameCount);
+				return preparedName;
+			}
+			if (correction > sheetName.length()) {
+				throw new BirtException(EmitterServices.getPluginName(),
+						"Unable to fit sheet name into the maximum allowed length", //$NON-NLS-1$
+						null);
+			}
+			sheetName = sheetName.substring(0, sheetName.length() - correction);
+			preparedName = sheetName + " " + nameCount; //$NON-NLS-1$
+			previousNameCount = nameCount;
+		}
 	}
 }

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/FlattenedTableHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/FlattenedTableHandler.java
@@ -36,7 +36,7 @@ public class FlattenedTableHandler extends AbstractHandler {
 	@Override
 	public void startTable(HandlerState state, ITableContent table) throws BirtException {
 		if ((state.sheetName == null) || state.sheetName.isEmpty()) {
-			String name = table.getName();
+			String name = state.correctSheetName(table.getName());
 			if ((name != null) && !name.isEmpty()) {
 				state.sheetName = name;
 			}

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/NestedTableHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/NestedTableHandler.java
@@ -68,7 +68,7 @@ public class NestedTableHandler extends AbstractRealTableHandler {
 		log.debug("startTable called with topLeft = [", topLeft.getRow(), ", ", topLeft.getCol(), "]");
 		super.startTable(state, table);
 		if ((state.sheetName == null) || state.sheetName.isEmpty()) {
-			String name = table.getName();
+			String name = state.correctSheetName(table.getName());
 			if ((name != null) && !name.isEmpty()) {
 				state.sheetName = name;
 			}

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/PageHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/PageHandler.java
@@ -1,12 +1,12 @@
 /*************************************************************************************
  * Copyright (c) 2011, 2012, 2013 James Talbut.
  *  jim-emitters@spudsoft.co.uk
- *  
- * All rights reserved. This program and the accompanying materials 
+ *
+ * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *     James Talbut - Initial implementation.
  ************************************************************************************/
@@ -185,22 +185,6 @@ public class PageHandler extends AbstractHandler {
 		state.getSmu().prepareMarginDimensions(state.currentSheet, page);
 	}
 
-	private String prepareSheetName(HandlerState state) {
-		if (state.sheetName != null) {
-			String preparedName = state.sheetName;
-			Integer nameCount = state.sheetNames.get(preparedName);
-			if (nameCount != null) {
-				++nameCount;
-				state.sheetNames.put(preparedName, nameCount);
-				preparedName = preparedName + " " + nameCount;
-			} else {
-				state.sheetNames.put(preparedName, 1);
-			}
-			return preparedName;
-		}
-		return null;
-	}
-
 	@Override
 	public void endPage(HandlerState state, IPageContent page) throws BirtException {
 
@@ -213,7 +197,7 @@ public class PageHandler extends AbstractHandler {
 			outputStructuredHeaderFooter(state, page.getFooter());
 		}
 
-		String sheetName = prepareSheetName(state);
+		String sheetName = state.prepareSheetName();
 		if (sheetName != null) {
 			log.debug("Attempting to name sheet ", (state.getWb().getNumberOfSheets() - 1), " \"", sheetName, "\" ");
 			int existingSheetIndex = -1;
@@ -275,7 +259,7 @@ public class PageHandler extends AbstractHandler {
 	 * This involves changing the row height as necesssary and determining the
 	 * column spread of the image.
 	 * </p>
-	 * 
+	 *
 	 * @param cellImage The image to be placed on the sheet.
 	 */
 	private void processCellImage(HandlerState state, Drawing<?> drawing, CellImage cellImage) {

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/TopLevelListHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/TopLevelListHandler.java
@@ -47,7 +47,7 @@ public class TopLevelListHandler extends AbstractRealListHandler {
 	public void startList(HandlerState state, IListContent list) throws BirtException {
 		log.debug("Call startList on ", this);
 		super.startList(state, list);
-		String name = list.getName();
+		String name = state.correctSheetName(list.getName());
 		if ((name != null) && !name.isEmpty()) {
 			state.sheetName = name;
 		}
@@ -86,7 +86,7 @@ public class TopLevelListHandler extends AbstractRealListHandler {
 					|| DesignChoiceConstants.PAGE_BREAK_AFTER_ALWAYS_EXCLUDING_LAST
 							.equals(groupDesign.getPageBreakAfter())) {
 				if (group.getTOC() != null) {
-					state.sheetName = group.getTOC().toString();
+					state.sheetName = state.correctSheetName(group.getTOC().toString());
 				}
 			}
 		}

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/TopLevelTableHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/TopLevelTableHandler.java
@@ -40,7 +40,7 @@ public class TopLevelTableHandler extends AbstractRealTableHandler {
 	public void startTable(HandlerState state, ITableContent table) throws BirtException {
 		state.colNum = 0;
 		super.startTable(state, table);
-		String name = table.getName();
+		String name = state.correctSheetName(table.getName());
 		if ((name != null) && !name.isEmpty()) {
 			state.sheetName = name;
 		}
@@ -101,7 +101,7 @@ public class TopLevelTableHandler extends AbstractRealTableHandler {
 					|| DesignChoiceConstants.PAGE_BREAK_AFTER_ALWAYS_EXCLUDING_LAST
 							.equals(groupDesign.getPageBreakAfter())) {
 				if (group.getTOC() != null) {
-					state.sheetName = group.getTOC().toString();
+					state.sheetName = state.correctSheetName(group.getTOC().toString());
 				}
 			}
 		}

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/util/BaseTestCase.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/util/BaseTestCase.java
@@ -143,6 +143,7 @@ public abstract class BaseTestCase extends TestCase {
 		ThreadResources.setLocale(ULocale.ENGLISH);
 
 		if (engine == null) {
+			MetaDataDictionary.reset(); // will force MetaDataDictionary to initialize
 			engine = new DesignEngine(new DesignConfig());
 		}
 	}

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/web.xml
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/web.xml
@@ -247,8 +247,18 @@ Automatically created by Apache Tomcat JspC.
 
 
     <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.CancelTask_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -257,18 +267,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Attributes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Attributes_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ParameterGroupFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.ParameterGroupFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -277,8 +277,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.CancelTask_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.CancelTask_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Attributes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.common.Attributes_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -297,8 +297,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -307,13 +307,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -322,18 +317,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -342,18 +337,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -362,13 +347,38 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
         <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.SimpleExportDataDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.SimpleExportDataDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -382,23 +392,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.SimpleExportDataDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.SimpleExportDataDialogFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -407,8 +402,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -417,28 +417,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/common/Error.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Attributes_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/common/Attributes.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ParameterGroupFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/ParameterGroupFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.common.processing_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/common/processing.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/common/Locale.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Error_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/common/Error.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -449,6 +434,21 @@ Automatically created by Apache Tomcat JspC.
     <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.RadioButtonParameterFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/parameter/RadioButtonParameterFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.ParameterGroupFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/ParameterGroupFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Locale_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/common/Locale.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.common.Attributes_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/common/Attributes.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -467,8 +467,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/parameter/TextBoxParameterFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/ReportContentFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -477,13 +477,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportContentFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/ReportContentFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/RequesterFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.parameter.TextBoxParameterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/parameter/TextBoxParameterFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -492,18 +487,18 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/RunFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/layout/ReportDialogFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.SidebarFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/layout/SidebarFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RequesterFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/RequesterFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.RunFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/RunFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -512,18 +507,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/TocFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ProgressBarFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/control/ProgressBarFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/NavigationbarFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -532,13 +517,38 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/ToolbarFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.layout.ReportDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/layout/ReportDialogFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.NavigationbarFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/NavigationbarFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/DialogContainerFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.TocFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/control/TocFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportDialogFragment_jsp</servlet-name>
         <url-pattern>/webcontent/birt/pages/dialog/PrintReportDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.control.ToolbarFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/control/ToolbarFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.SimpleExportDataDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -552,23 +562,8 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/ExportDataDialogFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.SimpleExportDataDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.DialogContainerFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/DialogContainerFragment.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/PrintReportServerDialogFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -577,8 +572,13 @@ Automatically created by Apache Tomcat JspC.
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportReportDialogFragment_jsp</servlet-name>
-        <url-pattern>/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.ExportDataDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/ExportDataDialogFragment.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.webcontent.birt.pages.dialog.PrintReportServerDialogFragment_jsp</servlet-name>
+        <url-pattern>/webcontent/birt/pages/dialog/PrintReportServerDialogFragment.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>


### PR DESCRIPTION
Truncate sheet names that are too long and filter illegal sheet name characters.

Signed-off-by: Steve Schafer <sschafer@innoventsolutions.com>