### PR TITLE
Add resource filters to parent projects #699

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557404762</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/UI/.project
+++ b/UI/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557325867</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/build/.project
+++ b/build/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636556913298</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/build/birt-packages/.project
+++ b/build/birt-packages/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636556878486</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/build/birt-packages/birt-charts/.project
+++ b/build/birt-packages/birt-charts/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636556755514</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/build/birt-packages/birt-nl/.project
+++ b/build/birt-packages/birt-nl/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636556798571</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chart/.project
+++ b/chart/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636556943267</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/common/.project
+++ b/common/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636556983132</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/core/.project
+++ b/core/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557069315</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/data/.project
+++ b/data/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557129331</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/docs/.project
+++ b/docs/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557166372</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/engine/.project
+++ b/engine/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557217451</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/features/.project
+++ b/features/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557252596</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/model/.project
+++ b/model/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557273275</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/nl/.project
+++ b/nl/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636556732304</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/testsuites/.project
+++ b/testsuites/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557300480</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/viewer/.project
+++ b/viewer/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557352307</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/xtab/.project
+++ b/xtab/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1636557384778</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-[^.].*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
In general, for projects that contain nested projects, filter the
folders corresponding to such nested projects such that the nested
contents of those folders are not shown in the resource tree, although
the folder itself is shown.  Of course when the nested contents are not
in the resource tree, they are not shown in any explorers.

Note that this filtering is designed not to apply for folders starting
with a '.', e.g,. .settings folders.  These folders are hidden by
default in the explorers anyway but need must be present in order to
store project-specific preferences.