### PR TITLE
Use the generated image for the development environment creation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To build BIRT with Eclipse Oxygen, run:
 
 ## Create an Eclipse Development Environment
 
-[![Create Eclipse Development Environment for Eclipse BIRT](https://img.shields.io/static/v1?logo=eclipseide&label=Create%20Development%20Environment&message=Eclipse%20BIRT&style=for-the-badge&logoColor=white&labelColor=darkorange&color=gray)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse/birt/master/build/org.eclipse.birt.releng/BIRTConfiguration.setup&show=true "Click to open Eclipse-Installer Auto Launch or drag into your running installer")
+[![Create Eclipse Development Environment for Eclipse BIRT](https://download.eclipse.org/oomph/www/setups/svg/birt.svg)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse/birt/master/build/org.eclipse.birt.releng/BIRTConfiguration.setup&show=true "Click to open Eclipse-Installer Auto Launch or drag into your running installer")
 
 ## Latest snapshot repository towards 4.9.0
 https://download.eclipse.org/birt/update-site/snapshot/


### PR DESCRIPTION
This ensures that all the projects will use a consistent image style for their buttons now and in the future should we want to make central style changes...

It looks like this:

![image](https://user-images.githubusercontent.com/208716/141292879-8ee9b624-107e-466e-a864-b0072db399cf.png)