### PR TITLE
UI performance degrades when selecting "many" cells in a grid/table #717

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/internal/ui/views/NonGEFSynchronizerWithTreeView.java
+++ b/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/internal/ui/views/NonGEFSynchronizerWithTreeView.java
@@ -59,7 +59,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.jface.viewers.ISelectionProvider#getSelection()
 	 */
 	public ISelection getSelection() {
@@ -71,20 +71,20 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.jface.viewers.ISelectionProvider#setSelection(org.eclipse
 	 * .jface.viewers.ISelection)
 	 */
 	public void setSelection(ISelection selection) {
 		if (getTreeViewer() != null) {
-			getTreeViewer().setSelection(selection, true);
+			getTreeViewer().setSelection(selection, false);
 		}
 
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.jface.viewers.ISelectionChangedListener#selectionChanged(
 	 * org.eclipse.jface.viewers.SelectionChangedEvent)
 	 */
@@ -94,7 +94,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/**
 	 * select the node
-	 * 
+	 *
 	 * @param event
 	 */
 	protected void treeSelect(SelectionChangedEvent event) {
@@ -103,7 +103,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/**
 	 * Fires a selection changed event.
-	 * 
+	 *
 	 * @param selection the new selection
 	 */
 	protected void fireSelectionChanged(ISelection selection) {
@@ -130,7 +130,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/**
 	 * gets the Tree viewer that hooks on this synchronizer.
-	 * 
+	 *
 	 * @return tree viewer.
 	 */
 	public AbstractTreeViewer getTreeViewer() {
@@ -139,7 +139,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/**
 	 * Hook the tree view need to synchronized
-	 * 
+	 *
 	 * @param viewer
 	 */
 	public void setTreeViewer(AbstractTreeViewer viewer) {
@@ -155,7 +155,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.ui.part.Page#dispose()
 	 */
 	public void dispose() {
@@ -168,7 +168,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.birt.report.designer.core.util.mediator.IColleague#performRequest
 	 * ( org.eclipse.birt.report.designer.core.util.mediator.request.ReportRequest )
@@ -204,7 +204,7 @@ public class NonGEFSynchronizerWithTreeView implements IMediatorColleague {
 
 	/**
 	 * Handles the selection request
-	 * 
+	 *
 	 * @param request
 	 */
 	protected void handleSelectionChange(ReportRequest request) {

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/parts/TableCellKeyDelegate.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/parts/TableCellKeyDelegate.java
@@ -838,20 +838,6 @@ public class TableCellKeyDelegate extends GraphicalViewerKeyHandler {
 			return;
 		}
 
-		boolean first = true;
-
-		for (Iterator itr = parts.iterator(); itr.hasNext();) {
-			GraphicalEditPart part = (GraphicalEditPart) itr.next();
-
-			if (first) {
-				getViewer().select(part);
-				first = false;
-			} else {
-				getViewer().appendSelection(part);
-			}
-
-			getViewer().reveal(part);
-		}
-
+		getViewer().setSelection(new StructuredSelection(parts));
 	}
 }

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/tools/CellDragTracker.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/tools/CellDragTracker.java
@@ -29,7 +29,6 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.KeyHandler;
 import org.eclipse.gef.Request;
@@ -251,20 +250,7 @@ public class CellDragTracker extends DragEditPartsTracker implements IDelaySelec
 			return;
 		}
 
-		boolean first = true;
-
-		for (Iterator itr = lst.iterator(); itr.hasNext();) {
-			GraphicalEditPart part = (GraphicalEditPart) itr.next();
-
-			if (first) {
-				getCurrentViewer().select(part);
-				first = false;
-			} else {
-				getCurrentViewer().appendSelection(part);
-			}
-
-			getCurrentViewer().reveal(part);
-		}
+		getCurrentViewer().setSelection(new StructuredSelection(lst));
 
 	}
 


### PR DESCRIPTION
Changed to another "set selection strategy" since appending to a
existing selection yields a lot of selection changed events, which in
turn causes a lot of updates in other parts of BIRT.

Also, removed "reveal" of all the selected EditParts on the current
viewer. The logic behind this is that the user probably already sees the
EditParts which was selected. EditParts will still be revealed in other
places of BIRT.