### PR TITLE
Remove org.w3c.dom.events import from org.eclipse.birt.chart.device 

### DIFF
--- a/chart/org.eclipse.birt.chart.device.pdf/META-INF/MANIFEST.MF
+++ b/chart/org.eclipse.birt.chart.device.pdf/META-INF/MANIFEST.MF
@@ -16,4 +16,4 @@ Bundle-ClassPath: .,
 Automatic-Module-Name: org.eclipse.birt.chart.device.pdf
 Import-Package: org.apache.batik.ext.awt.color;version="1.13.0",
  org.apache.batik.transcoder;version="1.14.0",
- org.w3c.dom.events;version="2.0.0"
+ org.w3c.dom.events


### PR DESCRIPTION
I was able to fix the resolution problems at startup (#757) with this change. Still need to investigate if this breaks anything.