### PR TITLE
Enable chart tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.tests.model integration-test
     - name: Report Engine Test
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.engine.tests integration-test
-##    - name: Charts Core Test
-##      run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.chart.tests integration-test
+    - name: Charts Core Test
+      run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.chart.tests integration-test
     - name: Charts Regression Test
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.tests.chart integration-test
     - name: Engine Regression Test

--- a/chart/org.eclipse.birt.chart.tests/pom.xml
+++ b/chart/org.eclipse.birt.chart.tests/pom.xml
@@ -19,6 +19,22 @@
 					<testClass>org.eclipse.birt.chart.tests.AllTests</testClass>
 				</configuration>
 			</plugin>
+            <plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.eclipse.birt</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
The chart tests did not run with the CI as they used to not work with maven, only when started from eclipse. 