### PR TITLE
Move license to EPL 2 #683

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.tests.model integration-test
     - name: Report Engine Test
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.engine.tests integration-test
-    - name: Charts Core Test
-      run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.chart.tests integration-test
+##    - name: Charts Core Test
+##      run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.chart.tests integration-test
     - name: Charts Regression Test
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.tests.chart integration-test
     - name: Engine Regression Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.tests.model integration-test
     - name: Report Engine Test
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.engine.tests integration-test
-##    - name: Charts Core Test
-##      run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.chart.tests integration-test
+    - name: Charts Core Test
+      run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.chart.tests integration-test
     - name: Charts Regression Test
       run: mvn -Dtest=AllTests -B -pl :org.eclipse.birt.report.tests.chart integration-test
     - name: Engine Regression Test

--- a/UI/org.eclipse.birt.report.debug.core/about.html
+++ b/UI/org.eclipse.birt.report.debug.core/about.html
@@ -11,25 +11,18 @@
 <p>June 28, 2007</p>	
 <h3>License</h3>
 
-	<p>
-		The Eclipse Foundation makes available all content in this plug-in
-		(&quot;Content&quot;). Unless otherwise indicated below, the Content
-		is provided to you under the terms and conditions of the Eclipse
-		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
-		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
-		For purposes of the EPL, &quot;Program&quot; will mean the Content.
-	</p>
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
 
-	<p>
-		If you did not receive this Content directly from the Eclipse
-		Foundation, the Content is being redistributed by another party
-		(&quot;Redistributor&quot;) and different terms and conditions may
-		apply to your use of any object code in the Content. Check the
-		Redistributor's license that was provided with the Content. If no such
-		license exists, contact the Redistributor. Unless otherwise indicated
-		below, the terms and conditions of the EPL still apply to any source
-		code in the Content and such source code may be obtained at <a
-			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
-	</p>
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+
 </body>
 </html>

--- a/UI/org.eclipse.birt.report.debug.core/about.html
+++ b/UI/org.eclipse.birt.report.debug.core/about.html
@@ -11,18 +11,25 @@
 <p>June 28, 2007</p>	
 <h3>License</h3>
 
-<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
-indicated below, the Content is provided to you under the terms and conditions of the
-Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
-at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
-For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
 
-<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
-being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
-apply to your use of any object code in the Content.  Check the Redistributor's license that was 
-provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
-indicated below, the terms and conditions of the EPL still apply to any source code in the Content
-and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
-
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
 </body>
 </html>

--- a/UI/org.eclipse.birt.report.debug.core/about.properties
+++ b/UI/org.eclipse.birt.report.debug.core/about.properties
@@ -1,5 +1,5 @@
 #/*******************************************************************************
-# * Copyright (c) 2021 Contributors to Eclipse Foundation
+# * Copyright (c) 2021 Contributors to the Eclipse Foundation
 # * 
 # * This program and the accompanying materials are made available under the
 # * terms of the Eclipse Public License 2.0 which is available at

--- a/UI/org.eclipse.birt.report.debug.core/about.properties
+++ b/UI/org.eclipse.birt.report.debug.core/about.properties
@@ -1,3 +1,15 @@
+#/*******************************************************************************
+# * Copyright (c) 2021 Contributors to Eclipse Foundation
+# * 
+# * This program and the accompanying materials are made available under the
+# * terms of the Eclipse Public License 2.0 which is available at
+# * https://www.eclipse.org/legal/epl-2.0/.
+# * 
+# * SPDX-License-Identifier: EPL-2.0
+# * 
+# * Contributors:
+# *   See git history
+# *******************************************************************************/
 # about.properties
 # contains externalized strings for about.ini
 # java.io.Properties file (ISO 8859-1 with "\" escapes)

--- a/UI/org.eclipse.birt.report.debug.core/about.properties
+++ b/UI/org.eclipse.birt.report.debug.core/about.properties
@@ -1,15 +1,3 @@
-#/*******************************************************************************
-# * Copyright (c) 2021 Contributors to Eclipse Foundation
-# * 
-# * This program and the accompanying materials are made available under the
-# * terms of the Eclipse Public License 2.0 which is available at
-# * https://www.eclipse.org/legal/epl-2.0/.
-# * 
-# * SPDX-License-Identifier: EPL-2.0
-# * 
-# * Contributors:
-# *   See git history
-# *******************************************************************************/
 # about.properties
 # contains externalized strings for about.ini
 # java.io.Properties file (ISO 8859-1 with "\" escapes)

--- a/UI/org.eclipse.birt.report.debug.core/build.properties
+++ b/UI/org.eclipse.birt.report.debug.core/build.properties
@@ -1,15 +1,3 @@
-#/*******************************************************************************
-# * Copyright (c) 2021 Contributors to Eclipse Foundation
-# * 
-# * This program and the accompanying materials are made available under the
-# * terms of the Eclipse Public License 2.0 which is available at
-# * https://www.eclipse.org/legal/epl-2.0/.
-# * 
-# * SPDX-License-Identifier: EPL-2.0
-# * 
-# * Contributors:
-# *   See git history
-# *******************************************************************************/
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\

--- a/UI/org.eclipse.birt.report.debug.core/build.properties
+++ b/UI/org.eclipse.birt.report.debug.core/build.properties
@@ -1,5 +1,5 @@
 #/*******************************************************************************
-# * Copyright (c) 2021 Contributors to Eclipse Foundation
+# * Copyright (c) 2021 Contributors to the Eclipse Foundation
 # * 
 # * This program and the accompanying materials are made available under the
 # * terms of the Eclipse Public License 2.0 which is available at

--- a/UI/org.eclipse.birt.report.debug.core/build.properties
+++ b/UI/org.eclipse.birt.report.debug.core/build.properties
@@ -1,3 +1,15 @@
+#/*******************************************************************************
+# * Copyright (c) 2021 Contributors to Eclipse Foundation
+# * 
+# * This program and the accompanying materials are made available under the
+# * terms of the Eclipse Public License 2.0 which is available at
+# * https://www.eclipse.org/legal/epl-2.0/.
+# * 
+# * SPDX-License-Identifier: EPL-2.0
+# * 
+# * Contributors:
+# *   See git history
+# *******************************************************************************/
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\

--- a/UI/org.eclipse.birt.report.debug.core/plugin.xml
+++ b/UI/org.eclipse.birt.report.debug.core/plugin.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.2"?>
-<!--
- *******************************************************************************
- * Copyright (c) 2021 Contributors to Eclipse Foundation
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors:
- *   See git history
- *******************************************************************************
--->
 <plugin>
     <extension
          id="ReportDebugger"

--- a/UI/org.eclipse.birt.report.debug.core/plugin.xml
+++ b/UI/org.eclipse.birt.report.debug.core/plugin.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.2"?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2021 Contributors to Eclipse Foundation
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
 <plugin>
     <extension
          id="ReportDebugger"

--- a/UI/org.eclipse.birt.report.debug.core/plugin.xml
+++ b/UI/org.eclipse.birt.report.debug.core/plugin.xml
@@ -2,7 +2,7 @@
 <?eclipse version="3.2"?>
 <!--
  *******************************************************************************
- * Copyright (c) 2021 Contributors to Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/UI/org.eclipse.birt.report.debug.core/pom.xml
+++ b/UI/org.eclipse.birt.report.debug.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  *******************************************************************************
- * Copyright (c) 2021 Contributors to Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/UI/org.eclipse.birt.report.debug.core/pom.xml
+++ b/UI/org.eclipse.birt.report.debug.core/pom.xml
@@ -1,18 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- *******************************************************************************
- * Copyright (c) 2021 Contributors to Eclipse Foundation
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors:
- *   See git history
- *******************************************************************************
--->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>

--- a/UI/org.eclipse.birt.report.debug.core/pom.xml
+++ b/UI/org.eclipse.birt.report.debug.core/pom.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2021 Contributors to Eclipse Foundation
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/Messages.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/Messages.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2008 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.core.i18n;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/Messages.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/Messages.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2008 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.core.i18n;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/Messages.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/Messages.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2008 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/nls.properties
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/nls.properties
@@ -1,10 +1,12 @@
 #/*******************************************************************************
 # * Copyright (c) 2006, 2008 Actuate Corporation.
-# * All rights reserved. This program and the accompanying materials
-# * are made available under the terms of the Eclipse Public License v1.0
-# * which accompanies this distribution, and is available at
-# * http://www.eclipse.org/legal/epl-v10.html
-# *
+# * 
+# * This program and the accompanying materials are made available under the
+# * terms of the Eclipse Public License 2.0 which is available at
+# * https://www.eclipse.org/legal/epl-2.0/.
+# * 
+# * SPDX-License-Identifier: EPL-2.0
+# * 
 # * Contributors:
 # *  Actuate Corporation  - initial API and implementation
 # *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/nls.properties
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/nls.properties
@@ -1,12 +1,16 @@
 #/*******************************************************************************
 # * Copyright (c) 2006, 2008 Actuate Corporation.
-# * All rights reserved. This program and the accompanying materials
-# * are made available under the terms of the Eclipse Public License v1.0
-# * which accompanies this distribution, and is available at
-# * http://www.eclipse.org/legal/epl-v10.html
-# *
+# * All rights reserved.
+# * 
+# * This program and the accompanying materials are made available under the
+# * terms of the Eclipse Public License 2.0 which is available at
+# * https://www.eclipse.org/legal/epl-2.0/.
+# * 
+# * SPDX-License-Identifier: EPL-2.0
+# * 
 # * Contributors:
 # *  Actuate Corporation  - initial API and implementation
+# *  Others: See git history
 # *******************************************************************************/
 
 ########################################

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/nls.properties
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/core/i18n/nls.properties
@@ -1,16 +1,12 @@
 #/*******************************************************************************
 # * Copyright (c) 2006, 2008 Actuate Corporation.
-# * All rights reserved.
-# * 
-# * This program and the accompanying materials are made available under the
-# * terms of the Eclipse Public License 2.0 which is available at
-# * https://www.eclipse.org/legal/epl-2.0/.
-# * 
-# * SPDX-License-Identifier: EPL-2.0
-# * 
+# * All rights reserved. This program and the accompanying materials
+# * are made available under the terms of the Eclipse Public License v1.0
+# * which accompanies this distribution, and is available at
+# * http://www.eclipse.org/legal/epl-v10.html
+# *
 # * Contributors:
 # *  Actuate Corporation  - initial API and implementation
-# *  Others: See git history
 # *******************************************************************************/
 
 ########################################

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/ReportDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/ReportDebugger.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/ReportDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/ReportDebugger.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/ReportDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/ReportDebugger.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/IReportLaunchConstants.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/IReportLaunchConstants.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2004 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.launcher;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/IReportLaunchConstants.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/IReportLaunchConstants.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2004 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.launcher;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/IReportLaunchConstants.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/IReportLaunchConstants.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2004 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/LauncherEngineConfig.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/LauncherEngineConfig.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/LauncherEngineConfig.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/LauncherEngineConfig.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.launcher;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/LauncherEngineConfig.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/LauncherEngineConfig.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.launcher;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/ReportLauncher.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/ReportLauncher.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2004 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.launcher;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/ReportLauncher.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/ReportLauncher.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2004 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.launcher;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/ReportLauncher.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/launcher/ReportLauncher.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2004 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVM.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVM.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVM.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVM.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVM.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVM.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMClient.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMClient.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMClient.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMClient.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMClient.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMClient.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMServer.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMServer.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMServer.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMServer.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMServer.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/ReportVMServer.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPoint.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPoint.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPoint.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPointListener.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPointListener.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPointListener.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPointListener.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPointListener.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMBreakPointListener.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMConstants.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMConstants.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMConstants.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMConstants.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMConstants.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMConstants.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMContextData.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMContextData.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMContextData.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMContextData.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMContextData.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMContextData.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMDebugger.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMDebugger.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMDebugger.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMException.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMException.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMException.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMException.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMException.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMException.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMListener.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMListener.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMListener.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMListener.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMListener.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMListener.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMStackFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMStackFrame.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMStackFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMStackFrame.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMStackFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMStackFrame.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMValue.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMValue.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMValue.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMVariable.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMVariable.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/VMVariable.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsContextData.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsContextData.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsContextData.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsContextData.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsContextData.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsContextData.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugFrame.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugFrame.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugFrame.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugger.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugger.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugger.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsDebugger.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsFunctionSource.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsFunctionSource.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsFunctionSource.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsFunctionSource.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsFunctionSource.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsFunctionSource.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsLineBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsLineBreakPoint.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsLineBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsLineBreakPoint.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsLineBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsLineBreakPoint.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsTransientLineBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsTransientLineBreakPoint.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsTransientLineBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsTransientLineBreakPoint.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsTransientLineBreakPoint.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsTransientLineBreakPoint.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsUtil.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsUtil.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsUtil.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsUtil.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsUtil.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsUtil.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsValue.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsValue.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsValue.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsVariable.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsVariable.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/js/JsVariable.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.js;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMClient.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMClient.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMClient.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMClient.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMClient.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMClient.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMStackFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMStackFrame.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMStackFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMStackFrame.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMStackFrame.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMStackFrame.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMValue.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMValue.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMValue.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMValue.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMVariable.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMVariable.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMVariable.java
+++ b/UI/org.eclipse.birt.report.debug.core/src/org/eclipse/birt/report/debug/internal/core/vm/rm/RMVariable.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core.vm.rm;

--- a/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/RemoteRunner.java
+++ b/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/RemoteRunner.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core;

--- a/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/RemoteRunner.java
+++ b/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/RemoteRunner.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/RemoteRunner.java
+++ b/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/RemoteRunner.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core;

--- a/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/Runner.java
+++ b/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/Runner.java
@@ -1,12 +1,16 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
+ *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core;

--- a/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/Runner.java
+++ b/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/Runner.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
  *******************************************************************************/

--- a/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/Runner.java
+++ b/UI/org.eclipse.birt.report.debug.core/test/org/eclipse/birt/report/debug/internal/core/Runner.java
@@ -1,16 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2007 Actuate Corporation.
- * All rights reserved.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- * 
- * SPDX-License-Identifier: EPL-2.0
- * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
- *  Others: See git history
  *******************************************************************************/
 
 package org.eclipse.birt.report.debug.internal.core;

--- a/chart/org.eclipse.birt.chart.tests/pom.xml
+++ b/chart/org.eclipse.birt.chart.tests/pom.xml
@@ -19,6 +19,22 @@
 					<testClass>org.eclipse.birt.chart.tests.AllTests</testClass>
 				</configuration>
 			</plugin>
+            <plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.eclipse.birt</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/chart/org.eclipse.birt.chart.tests/pom.xml
+++ b/chart/org.eclipse.birt.chart.tests/pom.xml
@@ -19,22 +19,6 @@
 					<testClass>org.eclipse.birt.chart.tests.AllTests</testClass>
 				</configuration>
 			</plugin>
-            <plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<dependency-resolution>
-						<extraRequirements>
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.birt</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-						</extraRequirements>
-					</dependency-resolution>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Change all occurrences of Eclipse Public License version 1 to version 2
in UI/org.eclipse.birt.report.debug.core.

Signed-off-by: Steve Schafer <sschafer@innoventsolutions.com>