### PR TITLE
Export bookmarks in the PDF emitter

### DIFF
--- a/build/org.eclipse.birt.target/BIRT all-in-one.launch
+++ b/build/org.eclipse.birt.target/BIRT all-in-one.launch
@@ -32,8 +32,8 @@
     <setAttribute key="selected_target_bundles">
         <setEntry value="com.ibm.icu*67.1.0.v20200706-1749@default:default"/>
         <setEntry value="com.lowagie.text@default:default"/>
-        <setEntry value="com.sun.jna*5.8.0.v20210503-0343@default:default"/>
-        <setEntry value="com.sun.jna.platform*5.8.0.v20210406-1004@default:default"/>
+        <setEntry value="com.sun.jna.platform@default:default"/>
+        <setEntry value="com.sun.jna@default:default"/>
         <setEntry value="jakarta.annotation-api@default:default"/>
         <setEntry value="jakarta.servlet-api@default:default"/>
         <setEntry value="javax.activation@default:default"/>
@@ -287,7 +287,7 @@
         <setEntry value="org.eclipse.ltk.core.refactoring@default:default"/>
         <setEntry value="org.eclipse.ltk.ui.refactoring@default:default"/>
         <setEntry value="org.eclipse.orbit.mongodb@default:default"/>
-        <setEntry value="org.eclipse.osgi*3.17.100.v20211104-1730@-1:true"/>
+        <setEntry value="org.eclipse.osgi*3.17.200.v20220128-1919@-1:true"/>
         <setEntry value="org.eclipse.osgi.compatibility.state@default:false"/>
         <setEntry value="org.eclipse.osgi.services*3.10.200.v20210723-0643@2:true"/>
         <setEntry value="org.eclipse.osgi.services*3.9.0.v20200511-1725@2:true"/>

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -138,224 +138,136 @@
 			<unit id="org.eclipse.wst.web_ui.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-server</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-servlet</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-io</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-io</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-deploy</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-deploy</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-plus</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-plus</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-jndi</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-jndi</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-security</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-security</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-util</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-util</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-webapp</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-xml</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-xml</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty.osgi</groupId>
-					<artifactId>jetty-osgi-boot</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty.osgi</groupId>
+			<artifactId>jetty-osgi-boot</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>apache-jsp</artifactId>
-					<version>10.0.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>apache-jsp</artifactId>
+			<version>10.0.6</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.aries.spifly</groupId>
-					<artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-					<version>1.3.4</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.apache.aries.spifly</groupId>
+			<artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+			<version>1.3.4</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>com.ibm.icu</groupId>
-					<artifactId>icu4j</artifactId>
-					<version>70.1</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>icu4j</artifactId>
+			<version>70.1</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="error" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>javax.servlet</groupId>
-					<artifactId>javax.servlet-api</artifactId>
-					<version>3.1.0</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-continuation</artifactId>
-					<version>9.4.44.v20210927</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-continuation</artifactId>
+			<version>9.4.44.v20210927</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.glassfish</groupId>
-					<artifactId>javax.servlet</artifactId>
-					<version>3.1.1</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.servlet</artifactId>
+			<version>3.1.1</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-					<version>2.0.0-alpha1</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.0-alpha1</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-simple</artifactId>
-					<version>2.0.0-alpha1</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.0-alpha1</version>
+			<type>jar</type>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.slf4j</groupId>
-					<artifactId>osgi-over-slf4j</artifactId>
-					<version>2.0.0-alpha1</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.slf4j</groupId>
+			<artifactId>osgi-over-slf4j</artifactId>
+			<version>2.0.0-alpha1</version>
+			<type>jar</type>
 		</location>
 		<location includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.xmlgraphics</groupId>
-					<artifactId>fop</artifactId>
-					<version>2.6</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.apache.xmlgraphics</groupId>
+			<artifactId>fop</artifactId>
+			<version>2.6</version>
+			<type>jar</type>
 		</location>
 		<location includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.xmlgraphics</groupId>
-					<artifactId>batik-ext</artifactId>
-					<version>1.14</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
+			<groupId>org.apache.xmlgraphics</groupId>
+			<artifactId>batik-ext</artifactId>
+			<version>1.14</version>
+			<type>jar</type>
 			<instructions><![CDATA[
 Bundle-Name:           Bundle derived from maven artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
 version:               ${version_cleanup;${mvnVersion}}
@@ -365,6 +277,13 @@ Import-Package:        *;resolution:=optional
 Export-Package:        *;version="${version}";-noimport:=true
 DynamicImport-Package: *
 ]]></instructions>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2022-03"/>
+			<unit id="org.eclipse.mylyn.ide_feature.feature.group" version="3.25.2.v20200828-1617"/>
+			<unit id="org.eclipse.mylyn.java_feature.feature.group" version="3.25.2.v20200828-1617"/>
+			<unit id="org.eclipse.mylyn.team_feature.feature.group" version="3.25.2.v20200828-1617"/>
+			<unit id="org.eclipse.mylyn_feature.feature.group" version="3.25.2.v20200814-0512"/>
 		</location>
 	</locations>
 	<environment>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/BookmarkInfo.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/BookmarkInfo.java
@@ -1,0 +1,72 @@
+package org.eclipse.birt.report.engine.emitter.pdf;
+
+/**
+ * This describes a bookmark in the generated PDF.
+ *
+ * Note: This could be Record in Java 14+.
+ */
+public final class BookmarkInfo {
+
+	@SuppressWarnings("nls")
+	@Override
+	public String toString() {
+		StringBuilder stringBuilder = new StringBuilder();
+		stringBuilder.append("BookmarkInfo [name=");
+		stringBuilder.append(name);
+		stringBuilder.append(", pageNumber=");
+		stringBuilder.append(pageNumber);
+		stringBuilder.append(", x=");
+		stringBuilder.append(x);
+		stringBuilder.append(", y=");
+		stringBuilder.append(y);
+		stringBuilder.append(", width=");
+		stringBuilder.append(width);
+		stringBuilder.append(", height=");
+		stringBuilder.append(height);
+		stringBuilder.append("]");
+		return stringBuilder.toString();
+	}
+
+	/**
+	 * Creates a new BookmarkInfo. It consists of a unique name and the target. The
+	 * target is specified by the 1-based page number and a rectangle. The
+	 * rectangle's x and y coordinates and its width and height are specified in
+	 * milli-points. E.g. a value of 1000 means 1pt, a value of 72000 is one inch.
+	 * An A4 page is ~ 595275 x 841890.
+	 *
+	 * @param name       Unique name
+	 * @param pageNumber page number, 1-based
+	 * @param x          left position
+	 * @param y          top position, 0 = top of the page.
+	 * @param width      width
+	 * @param height     height
+	 */
+	public BookmarkInfo(String name, int pageNumber, int x, int y, int width, int height) {
+		super();
+		this.name = name;
+		this.pageNumber = pageNumber;
+		this.x = x;
+		this.y = y;
+		this.width = width;
+		this.height = height;
+	}
+
+	/** Unique name of the bookmark, used as a key */
+	public final String name;
+
+	/** Page number of the bookmark target, starting from 1. 1, 2, 3, ... */
+	public final int pageNumber;
+
+	/** Distance of the bookmark target from the left end of the page. */
+	public final int x;
+
+	/** Distance of the bookmark target from the top end of the page. */
+	public final int y;
+
+	/** Width of the bookmark target */
+	public final int width;
+
+	/** Height of the bookmark target */
+	public final int height;
+
+}

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFRender.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFRender.java
@@ -14,6 +14,7 @@ package org.eclipse.birt.report.engine.emitter.pdf;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 
@@ -201,6 +202,7 @@ public class PDFRender extends PageDeviceRender {
 			}
 	}
 
+	@SuppressWarnings("unchecked")
 	protected void createBookmark(IArea area, int x, int y) {
 		String bookmark = area.getBookmark();
 		if (null != bookmark) {
@@ -208,6 +210,32 @@ public class PDFRender extends PageDeviceRender {
 			int width = getWidth(area);
 			currentPage.createBookmark(bookmark, x, y, width, height);
 			bookmarks.add(bookmark);
+
+			// Make the bookmark available in the appContext.
+			// Note that the y value goes downwards, that means y=0 is the top of the page.
+			// This is different from PDF.
+			// The x,y,width,height values are all integers, measured in thousandth points.
+			// That means a value of 1000 is 1mm.
+			// An A4 page has a width of ~ 595275 and a height of ~ 841890.
+			// The page numbers start at 1.
+
+			@SuppressWarnings("rawtypes")
+			Map appContext = context.getAppContext();
+
+			Map<String, BookmarkInfo> bookmarksInContext = (Map<String, BookmarkInfo>) appContext.get("Bookmarks"); //$NON-NLS-1$
+			if (bookmarksInContext == null) {
+				bookmarksInContext = new HashMap<String, BookmarkInfo>();
+				appContext.put("Bookmarks", bookmarksInContext); //$NON-NLS-1$
+			}
+			final int pageNumber = this.currentPageDevice.writer.getCurrentPageNumber();
+			BookmarkInfo bm = new BookmarkInfo(bookmark, pageNumber, x, y, width, height);
+			bookmarksInContext.put(bookmark, bm);
+
+			// Note: We could use a similar approach to export the TOC.
+			// (see TOCHandler.java, PDFPageDevice.java and other methods here).
+			// This could possibly be used for
+			// generating section-wise page-numbering based on the TOC.
+
 		}
 	}
 


### PR DESCRIPTION
This PR exports information about the generated bookmarks to the appContext.
This information can then be used to easily modify the PDF afterwards, e.g. add a visible digital signature at a specific (dynamic) location. The idea is to render an (empty) placeholder and give it a bookmark name e.g. "signature".
After BIRT has created the PDF, the information about the page number, coordinates, width and size of the bookmark target location can be obtained by

    appContext.get("Bookmarks").get("signature")

It would even allow to include a whole (scaled) page from other PDFs as kind-of an image with PDF processing tools like iText, OpenPDF, PyPDF or whatever.

