### PR TITLE
Defective PPTX format in BIRT #813

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/util/PPTXUtil.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/util/PPTXUtil.java
@@ -71,6 +71,8 @@ public class PPTXUtil {
 		if (cssDimension == null || "0".equals(cssDimension)) {
 			return 0;
 		}
-		return convertToEnums(DimensionType.parserUnit(cssDimension).convertTo(DimensionType.UNITS_PT) * 1000);
+
+		DimensionType dimensionType = DimensionType.parserUnit(cssDimension);
+		return dimensionType != null ? convertToEnums(dimensionType.convertTo(DimensionType.UNITS_PT) * 1000) : 0;
 	}
 }


### PR DESCRIPTION
Null guard for when DimensionType.parseUnit() fails in
PPTXUtil.convertCssToEnum(). This happens typically when the
cssDimension is "auto" for margins, which really should have a special
case treatment in the TableWriter.endCell(). However, from the look of
it, the "margin" code in endCell needs a lot of refactoring and should
perhaps be done in other places in PPTXCanvas instead ( .drawText() etc
)