### PR TITLE
Removed javacSource and javacTarget from build.properties files.

### DIFF
--- a/UI/org.eclipse.birt.report.designer.tests/build.properties
+++ b/UI/org.eclipse.birt.report.designer.tests/build.properties
@@ -21,5 +21,3 @@ output.designertests.jar = target/classes/
 source.designertests.jar = test/,\
                            src/
 src.includes = about.html
-javacSource=1.5
-javacTarget=1.5

--- a/UI/org.eclipse.birt.report.designer.ui.preview.static_html/build.properties
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.static_html/build.properties
@@ -17,6 +17,4 @@ bin.includes = META-INF/,\
                about.html,\
                plugin.xml,\
                icons/
-javacSource=1.5
-javacTarget=1.5
 src.includes = about.html

--- a/UI/org.eclipse.birt.report.designer.ui.preview/build.properties
+++ b/UI/org.eclipse.birt.report.designer.ui.preview/build.properties
@@ -18,6 +18,4 @@ bin.includes = META-INF/,\
                icons/,\
                plugin.properties,\
                about.html
-javacSource=1.5
-javacTarget=1.5
 src.includes = about.html

--- a/engine/org.eclipse.birt.report.engine.emitter.config/build.properties
+++ b/engine/org.eclipse.birt.report.engine.emitter.config/build.properties
@@ -17,8 +17,6 @@ bin.includes = META-INF/,\
                plugin.xml,\
                about.html,\
                schema/
-javacSource=1.5
-javacTarget=1.5
 customBuildCallbacks=customBuildCallbacks.xml
 src.includes = about.html
                


### PR DESCRIPTION
This PR aims to remove the JavaSE-1.5 source level restriction still available on some projects which prevents PR #836 to build