### PR TITLE
Some reports created with birt 4.2.1 don't work with 4.9.0 #838

### DIFF
--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/CompatibleExpression_golden.xml
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/CompatibleExpression_golden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.23" id="1">
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.24" id="1">
     <parameters>
         <scalar-parameter name="param1" id="42">
             <expression name="valueExpr">row["param1ValueExpr"]</expression>

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/CompatibleExpression_golden_1.xml
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/CompatibleExpression_golden_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.23" id="1">
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.24" id="1">
     <body>
         <table name="table1" id="5">
             <list-property name="filter">

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/CompatibleExpression_golden_2.xml
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/CompatibleExpression_golden_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.23" id="1">
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.24" id="1">
     <body>
         <table name="table1" id="5">
             <list-property name="boundDataColumns">

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/DataCompatibleValueExpr_golden.xml
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/api/golden/DataCompatibleValueExpr_golden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.23" id="1">
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.24" id="1">
     <body>
         <data name="data1" id="5">
             <list-property name="boundDataColumns">

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/parser/input/CompatibleConvertComputedColumnsConcatenateProperites.xml
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/parser/input/CompatibleConvertComputedColumnsConcatenateProperites.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Written by Eclipse BIRT 2.0 -->
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="1">
+    <data-sources>
+        <oda-data-source name="test-data-source"/>
+    </data-sources>
+    <data-sets>
+        <oda-data-set name="test-data-set">
+		    <property name="dataSource">test-data-source</property>
+            <list-property name="computedColumns">
+                <structure>
+                    <property name="name">concatenated_column</property>
+                    <property name="dataType">string</property>
+                    <property name="aggregateFunction">CONCATENATE</property>
+                    <list-property name="arguments">
+                        <structure>
+                            <property name="name">Expression</property>
+                            <expression name="value">row["TESTROW"]</expression>
+                        </structure>
+                        <structure>
+                            <property name="name">Separat&amp;or</property>
+                            <expression name="value">|</expression>
+                        </structure>
+                        <structure>
+                            <property name="name">Ma&amp;x length</property>
+                            <expression name="value">1234567890</expression>
+                        </structure>
+                        <structure>
+                            <property name="name">Sho&amp;w all values</property>
+                            <expression name="value">true</expression>
+                        </structure>
+                    </list-property>
+                </structure>
+            </list-property>
+     	</oda-data-set>
+    </data-sets>
+</report>

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/parser/IDesignSchemaConstants.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/parser/IDesignSchemaConstants.java
@@ -27,13 +27,13 @@ interface IDesignSchemaConstants {
 	 * The version of report design.
 	 */
 
-	String REPORT_VERSION = "3.2.23"; //$NON-NLS-1$
+	String REPORT_VERSION = "3.2.24"; //$NON-NLS-1$
 
 	/**
 	 * The number representation for the current version string.
 	 */
 
-	int REPORT_VERSION_NUMBER = VersionUtil.VERSION_3_2_23;
+	int REPORT_VERSION_NUMBER = VersionUtil.VERSION_3_2_24;
 
 	String ACCESS_CONTROL_TAG = "access-control"; //$NON-NLS-1$
 	String AUTO_TEXT_TAG = "auto-text"; //$NON-NLS-1$

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/parser/OdaDataSetState.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/parser/OdaDataSetState.java
@@ -201,7 +201,7 @@ public class OdaDataSetState extends SimpleDataSetState {
 		mergeResultSetAndResultSetHints(tmpElement);
 		doCompatibleRemoveResultSetProperty(tmpElement);
 		doCompatibleRemoveResultSetHitProperty(tmpElement);
-		doCompatibleConvertComputedColumnsConcatenateProperites(tmpElement);
+		doCompatibleConvertComputedColumnsConcatenateProperties(tmpElement);
 
 		TemplateParameterDefinition refTemplateParam = tmpElement.getTemplateParameterElement(handler.getModule());
 		if (refTemplateParam == null) {
@@ -345,7 +345,7 @@ public class OdaDataSetState extends SimpleDataSetState {
 	 *
 	 * @param dataSet the OdaDataSet to convert.
 	 */
-	private void doCompatibleConvertComputedColumnsConcatenateProperites(OdaDataSet dataSet) {
+	private void doCompatibleConvertComputedColumnsConcatenateProperties(OdaDataSet dataSet) {
 
 		if (handler.versionNumber >= VersionUtil.VERSION_3_2_24) {
 			return;

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/parser/OdaDataSetState.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/parser/OdaDataSetState.java
@@ -371,24 +371,26 @@ public class OdaDataSetState extends SimpleDataSetState {
 		 *
 		 */
 		List<Object> computedColumnProperty = dataSet.getListProperty(null, IDataSetModel.COMPUTED_COLUMNS_PROP);
-		for (Object item : computedColumnProperty) {
-			if (item instanceof ComputedColumn) {
-				ComputedColumn computedColumn = (ComputedColumn) item;
-				String stringProperty = computedColumn.getAggregateFunction();
-				if (Objects.equals(stringProperty, "CONCATENATE")) { //$NON-NLS-1$
-					Object property = computedColumn.getProperty(null, ComputedColumn.ARGUMENTS_MEMBER);
+		if (computedColumnProperty != null) {
+			for (Object item : computedColumnProperty) {
+				if (item instanceof ComputedColumn) {
+					ComputedColumn computedColumn = (ComputedColumn) item;
+					String stringProperty = computedColumn.getAggregateFunction();
+					if (Objects.equals(stringProperty, "CONCATENATE")) { //$NON-NLS-1$
+						Object property = computedColumn.getProperty(null, ComputedColumn.ARGUMENTS_MEMBER);
 
-					if (property instanceof List) {
-						List<Object> arguments = (List<Object>) property;
-						for (Object argItem : arguments) {
-							if (argItem instanceof AggregationArgument) {
-								AggregationArgument aggreagationArg = (AggregationArgument) argItem;
-								if (aggreagationArg.getName().equals("Separat&or")) { //$NON-NLS-1$
-									aggreagationArg.setName("Separator"); //$NON-NLS-1$
-								} else if (aggreagationArg.getName().equals("Ma&x length")) { //$NON-NLS-1$
-									aggreagationArg.setName("Maxlength"); //$NON-NLS-1$
-								} else if (aggreagationArg.getName().equals("Sho&w all values")) { //$NON-NLS-1$
-									aggreagationArg.setName("Showallvalues"); //$NON-NLS-1$
+						if (property instanceof List) {
+							List<Object> arguments = (List<Object>) property;
+							for (Object argItem : arguments) {
+								if (argItem instanceof AggregationArgument) {
+									AggregationArgument aggreagationArg = (AggregationArgument) argItem;
+									if (aggreagationArg.getName().equals("Separat&or")) { //$NON-NLS-1$
+										aggreagationArg.setName("Separator"); //$NON-NLS-1$
+									} else if (aggreagationArg.getName().equals("Ma&x length")) { //$NON-NLS-1$
+										aggreagationArg.setName("Maxlength"); //$NON-NLS-1$
+									} else if (aggreagationArg.getName().equals("Sho&w all values")) { //$NON-NLS-1$
+										aggreagationArg.setName("Showallvalues"); //$NON-NLS-1$
+									}
 								}
 							}
 						}

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/util/VersionUtil.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/util/VersionUtil.java
@@ -80,6 +80,8 @@ public class VersionUtil {
 
 	public static final int VERSION_3_2_23 = 3022300;
 
+	public static final int VERSION_3_2_24 = 3022400;
+
 	/**
 	 *
 	 * @param version


### PR DESCRIPTION
Added migration of old OdaDataSet that used translated strings
(Message.getString()), to the new property names introduced with commit
cac6e65a766ecbf1086728cebdbb5d54b4755728

I know that we are close to release, and introduce model migration for old issues may be a bad idea. - But here it is.