### PR TITLE
Aggregation is disabled in charting #856

### DIFF
--- a/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/wizard/data/BaseDataDefinitionComponent.java
+++ b/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/wizard/data/BaseDataDefinitionComponent.java
@@ -876,7 +876,7 @@ public class BaseDataDefinitionComponent extends DefaultSelectDataComponent
 				ec.decode(expression);
 				expression = ec.convertJSExpression(false);
 
-				boolean enabled = this.context.getUIFactory().createUIHelper().useDataSetRow(context.getExtendedItem(),
+				boolean enabled = !this.context.getUIFactory().createUIHelper().useDataSetRow(context.getExtendedItem(),
 						expression);
 				fAggEditorComposite.setEnabled(enabled);
 			} catch (BirtException e) {

--- a/chart/org.eclipse.birt.chart.ui/src/org/eclipse/birt/chart/ui/integrate/ChartUIHelperBase.java
+++ b/chart/org.eclipse.birt.chart.ui/src/org/eclipse/birt/chart/ui/integrate/ChartUIHelperBase.java
@@ -48,7 +48,12 @@ public class ChartUIHelperBase implements IChartUIHelper {
 
 	@Override
 	public boolean useDataSetRow(Object reportItem, String expression) throws BirtException {
-		// Default implementation, do nothing
-		return false;
+		/*
+		 * Default implementation is a bit simple, this behavior is copied from
+		 * org.eclipse.birt.chart.ui.swt.wizard.data.BaseDataDefinitionComponent.
+		 * enableAggEditor( String expression ) prior to the refactoring that yielded
+		 * this method. According to the javadoc it should be more comprehensive though.
+		 */
+		return expression.startsWith("data"); //$NON-NLS-1$
 	}
 }


### PR DESCRIPTION
Enabled aggregation again. Seems to have been a negation wrong after refactoring. Also expanded
the default IChartUIHelper.useDataSetRow() implementation to a simple startsWith("data") check previously used in the enableAddEditor() method