### PR TITLE
Master is not building due to broken target platform #869

### DIFF
--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -392,7 +392,7 @@
           <repository
               url="https://download.eclipse.org/datatools/updates/1.14.200-SNAPSHOT/repository/"/>
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.23-I-builds/"/>
+              url="https://download.eclipse.org/eclipse/updates/4.24-I-builds/"/>
           <repository
               url="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest/"/>
           <repository

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -44,7 +44,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <!--			<repository location="https://download.eclipse.org/eclipse/updates/latest/"/>
 -->
-			<repository location="https://download.eclipse.org/eclipse/updates/4.23-I-builds/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.24-I-builds/"/>
 			<unit id="a.jre.javase" version="11.0.0"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.platform.sdk" version="0.0.0"/>


### PR DESCRIPTION
Changing https://download.eclipse.org/eclipse/updates/4.24-I-builds/ for
now.