### PR TITLE
Report with Oracle JDBC ORA-01000 Too many open cursors #875

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/QueryResults.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/QueryResults.java
@@ -1,13 +1,13 @@
 /*
  *************************************************************************
  * Copyright (c) 2004, 2014 Actuate Corporation.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0/.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *
  * Contributors:
  *  Actuate Corporation - initial API and implementation
@@ -249,7 +249,7 @@ public class QueryResults implements IQueryResults, IQueryService {
 			iterator = null;
 		}
 
-		// queryService.close( );
+		queryService.close(); /* Reintroduced to fix #875 */
 		queryService = null;
 		logger.logp(Level.FINER, QueryResults.class.getName(), "close",
 				"Iterators associated with QueryResults are closed");


### PR DESCRIPTION
IServiceForQueryResults.close() is now closed upon QueryResults.close(). This is currently the only place in the frame work were IServiceForQueryResults.close() is called.

@hvbtup : Since you have problems with your dev.environment I took the liberty to make a PR for you to test.