### PR TITLE
Master is not building due to broken target platform, (Again) #877

### DIFF
--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -44,7 +44,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <!--			<repository location="https://download.eclipse.org/eclipse/updates/latest/"/>
 -->
-			<repository location="https://download.eclipse.org/eclipse/updates/4.24-I-builds/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.23/"/>
 			<unit id="a.jre.javase" version="11.0.0"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.platform.sdk" version="0.0.0"/>


### PR DESCRIPTION
Switching to the https://download.eclipse.org/eclipse/updates/4.23/
update-site