### PR TITLE
JavaScript IScriptEngineFactory is not found by ScriptEngineFactoryManagerImpl in non OSGI environments #948

### DIFF
--- a/core/org.eclipse.birt.core/schema/ScriptEngineFactory.exsd
+++ b/core/org.eclipse.birt.core/schema/ScriptEngineFactory.exsd
@@ -61,9 +61,6 @@
                <documentation>
                   
                </documentation>
-               <appInfo>
-                  <meta.attribute translatable="true"/>
-               </appInfo>
             </annotation>
          </attribute>
          <attribute name="factoryClass" type="string" use="required">

--- a/data/org.eclipse.birt.report.engine.script.javascript/OSGI-INF/l10n/bundle.properties
+++ b/data/org.eclipse.birt.report.engine.script.javascript/OSGI-INF/l10n/bundle.properties
@@ -1,4 +1,3 @@
 #Properties file for org.eclipse.birt.report.engine.script.javascript
-scriptEngineFactory.scriptName = javascript
 Bundle-Vendor = Eclipse BIRT Project
 Bundle-Name = BIRT Javascript Engine

--- a/data/org.eclipse.birt.report.engine.script.javascript/plugin.xml
+++ b/data/org.eclipse.birt.report.engine.script.javascript/plugin.xml
@@ -20,7 +20,7 @@
       <scriptEngineFactory
             factoryClass="org.eclipse.birt.report.engine.javascript.JavascriptEngineFactory"
             scriptID="org.eclipse.birt.report.engine.javascript"
-            scriptName="%scriptEngineFactory.scriptName">
+            scriptName="javascript">
       </scriptEngineFactory>
    </extension>
 


### PR DESCRIPTION
scriptName is not translatable since it used for lookup in
org.eclipse.birt.core.internal.plugin.ScriptEngineFactoryManagerImpl