### PR TITLE
Update ViewerAttributeBean.java

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/context/ViewerAttributeBean.java
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/context/ViewerAttributeBean.java
@@ -1102,4 +1102,3 @@ public class ViewerAttributeBean extends BaseAttributeBean {
 
 		}
 	}
-}


### PR DESCRIPTION
The vulnerability described in [CVE-2021-34427](https://bugs.eclipse.org/bugs/show_bug.cgi?id=538142) allows an attacker to execute code on the server by creating a `.jsp` file with the `BiRT - WebViewerExample`.  This was fixed with this commit. 

[See bug 580994](https://bugs.eclipse.org/bugs/show_bug.cgi?id=580994)