### PR TITLE
Bug 580994 - BIRT 4.10.0-20221001 - CVE-2021-34427 fix bypass

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer.tests/test/org/eclipse/birt/report/context/ViewerAttributeBeanTest.java
+++ b/viewer/org.eclipse.birt.report.viewer.tests/test/org/eclipse/birt/report/context/ViewerAttributeBeanTest.java
@@ -1,0 +1,47 @@
+/*************************************************************************************
+ * Copyright (c) 2022 Remain Software.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Remain Software - Initial implementation.
+ ************************************************************************************/
+package org.eclipse.birt.report.context;
+
+import static org.junit.Assert.fail;
+
+import org.eclipse.birt.report.exception.ViewerException;
+import org.junit.Test;
+
+/**
+ *
+ * Test the VBA.
+ *
+ */
+public class ViewerAttributeBeanTest {
+
+
+	/**
+	 * Extensions with invalid characters are not allowed.
+	 *
+	 * @throws ViewerException
+	 */
+	@Test
+	public void testCheckExtensionAllowedForRPTDocument() throws ViewerException {
+
+		ViewerAttributeBean.checkExtensionAllowedForRPTDocument("report");
+		ViewerAttributeBean.checkExtensionAllowedForRPTDocument("report.pdf");
+		ViewerAttributeBean.checkExtensionAllowedForRPTDocument("report.");
+		try {
+			ViewerAttributeBean.checkExtensionAllowedForRPTDocument("report.pdf/");
+		} catch (Exception e) {
+			return;
+		}
+
+		fail("invalid extension accepted");
+	}
+}

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/context/ViewerAttributeBean.java
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/context/ViewerAttributeBean.java
@@ -632,7 +632,8 @@ public class ViewerAttributeBean extends BaseAttributeBean {
 		// don't delete document file
 		if (ParameterAccessor.HEADER_REQUEST_TYPE_SOAP.equalsIgnoreCase(this.requestType)
 				|| IBirtConstants.SERVLET_PATH_DOWNLOAD.equalsIgnoreCase(request.getServletPath())
-				|| IBirtConstants.SERVLET_PATH_EXTRACT.equalsIgnoreCase(request.getServletPath()) || (this.reportDocumentName == null)) {
+				|| IBirtConstants.SERVLET_PATH_EXTRACT.equalsIgnoreCase(request.getServletPath())
+				|| (this.reportDocumentName == null)) {
 			return;
 		}
 
@@ -1078,6 +1079,12 @@ public class ViewerAttributeBean extends BaseAttributeBean {
 		return (reportRtl != null) ? reportRtl.booleanValue() : false;
 	}
 
+	/**
+	 * Block disallowed extensions and extensions with a suspicious name.
+	 *
+	 * @param rptDocumentName
+	 * @throws ViewerException
+	 */
 	protected static void checkExtensionAllowedForRPTDocument(String rptDocumentName) throws ViewerException {
 		int extIndex = rptDocumentName.lastIndexOf(".");
 		String extension = null;
@@ -1085,6 +1092,9 @@ public class ViewerAttributeBean extends BaseAttributeBean {
 
 		if (extIndex > -1 && (extIndex + 1) < rptDocumentName.length()) {
 			extension = rptDocumentName.substring(extIndex + 1);
+			if (!extension.matches("^[A-Za-z0-9]+$")) {
+				validExtension = false;
+			}
 
 			if (!disallowedExtensionsForRptDocument.isEmpty()
 					&& disallowedExtensionsForRptDocument.contains(extension)) {
@@ -1099,7 +1109,6 @@ public class ViewerAttributeBean extends BaseAttributeBean {
 				throw new ViewerException(BirtResources.getMessage(
 						ResourceConstants.ERROR_INVALID_EXTENSION_FOR_DOCUMENT_PARAMETER, new String[] { extension }));
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
Fixes an exploit in the BIRT viewer to block file extensions with special characters.