### PR TITLE
Adjust getMaxQueries to return correct number

### DIFF
--- a/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
+++ b/data/org.eclipse.birt.report.data.oda.jdbc/src/org/eclipse/birt/report/data/oda/jdbc/Connection.java
@@ -364,7 +364,7 @@ public class Connection implements IConnection {
 				DatabaseMetaData dbMetadata = jdbcConn.getMetaData();
 				int maxstmts = dbMetadata.getMaxStatements();
 				int maxconns = dbMetadata.getMaxConnections();
-				if (maxstmts == 0 && maxconns == 0) {
+				if (maxstmts == 0) {
 					return 0;
 				} else if (maxconns == 0 || maxstmts < maxconns) {
 					return 1;


### PR DESCRIPTION
In the case that maxStatements = 0 and maxConnections is not 0, but a finite number (e.g. 32767 in SQL Server). Then this code previously would return 1. This makes BIRT generate thousands of connections for many of our reports. This is unacceptably slow. We change the code to return 0 (=unlimited) when maxStatements=0 after this change, regardless of the number of max connections. This will in most cases have BIRT use only one connection.

In general, the code should reflect that creating Connections is expensive in most contexts.