### PR TITLE
Thick lines on chart after repeated build/render #1121

### DIFF
--- a/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/factory/Generator.java
+++ b/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/factory/Generator.java
@@ -100,6 +100,7 @@ public final class Generator implements IGenerator {
 	 * An internal style processor.
 	 */
 	private IStyleProcessor implicitProcessor;
+	private boolean fScaleUpdated = false;
 
 	/**
 	 * The internal singleton Generator reference created lazily.
@@ -1015,9 +1016,10 @@ public final class Generator implements IGenerator {
 	public void render(IDeviceRenderer idr, GeneratedChartState gcs) throws ChartException {
 		final Chart cm = gcs.getChartModel();
 		final int scale = idr.getDisplayServer().getDpiResolution() / 72;
-		if (scale != 1) {
+		if (scale != 1 && !fScaleUpdated) {
 			// Here multiply by integer scale so that normal dpi (96) won't
 			// change thickness by default. Only PDF case would change.
+			fScaleUpdated = true;
 			updateDeviceScale(cm, scale);
 		}
 


### PR DESCRIPTION
Scale resizing was done on every render leading to ever thicker lines when resizing. Now scale resizing is done once per render session.