### PR TITLE
background images based on embedded images and data-url #1175

### DIFF
--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/util/ImageManager.java
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/util/ImageManager.java
@@ -78,7 +78,7 @@ public class ImageManager {
 	 * @param uri
 	 * @return Return the image
 	 */
-	public Image getImage(ModuleHandle handle, String uri) { // TG, Module model) {
+	public Image getImage(ModuleHandle handle, String uri) {
 		return getImage(handle, uri, false);
 	}
 
@@ -115,19 +115,11 @@ public class ImageManager {
 		}
 		String key = url.toString();
 		Image image = null;
-		/*
-		 *
-		 * if (key.contentEquals(DATA_PROTOCOL)) { String[] imageDataArray =
-		 * key.split(";base64,"); String imageDataBase64 = key.split(";base64,")[1];
-		 * Decoder decoder = java.util.Base64.getDecoder(); image = new Image();
-		 * .getInstance(decoder.decode(imageDataBase64)); } else {
-		 *
-		 */
-			image = getImageRegistry().get(key);
-			if (image == null) {
-				image = loadImage(url);
-			}
-//		}
+
+		image = getImageRegistry().get(key);
+		if (image == null) {
+			image = loadImage(url);
+		}
 		if (image == null) {
 			if (!invalidUrlList.contains(url.toString())) {
 				invalidUrlList.add(url.toString());

--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/util/ImageManager.java
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/util/ImageManager.java
@@ -78,7 +78,7 @@ public class ImageManager {
 	 * @param uri
 	 * @return Return the image
 	 */
-	public Image getImage(ModuleHandle handle, String uri) {
+	public Image getImage(ModuleHandle handle, String uri) { // TG, Module model) {
 		return getImage(handle, uri, false);
 	}
 
@@ -95,7 +95,6 @@ public class ImageManager {
 		URL url = null;
 
 		try {
-
 			if (uri.contains(DATA_PROTOCOL)) {
 				image = getEmbeddedImageDataURL(uri, refresh);
 			} else {
@@ -142,10 +141,10 @@ public class ImageManager {
 	/**
 	 * Gets the image by the given URI
 	 *
-	 * @param uri     the url of the image file
+	 * @param uri     the uri of the image file
 	 * @param refresh mark if refresh necessary
 	 *
-	 * @return Returns the image,or null if the url is invalid or the file format is
+	 * @return Returns the image or null if the uri is invalid or the file format is
 	 *         unsupported.
 	 */
 	public Image getImage(String uri, boolean refresh) {
@@ -248,6 +247,14 @@ public class ImageManager {
 		return image;
 	}
 
+	/**
+	 * Get the embedded image of the data URL
+	 *
+	 * @param url     data URL of the image
+	 * @param refresh refresh the image data or use image cache
+	 * @return Return the embedded image
+	 * @throws IOException
+	 */
 	public Image getEmbeddedImageDataURL(String url, boolean refresh) throws IOException {
 		if ((url == null) || (!refresh && invalidUrlList.contains(url))) {
 			return null;
@@ -481,7 +488,6 @@ public class ImageManager {
 			return new URL(uri);
 		} catch (MalformedURLException e) {
 			String path = URIUtil.getLocalPath(uri);
-
 			if (designHandle == null) {
 				designHandle = SessionHandleAdapter.getInstance().getReportDesignHandle();
 			}

--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/util/ImageManager.java
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/util/ImageManager.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Base64.Decoder;
 import java.util.List;
 
 import org.apache.batik.transcoder.TranscoderException;
@@ -50,9 +51,11 @@ public class ImageManager {
 
 	private static final String EMBEDDED_SUFFIX = ".Embedded."; //$NON-NLS-1$
 
+	private static final String DATA_PROTOCOL = "data:";
+
 	private static final ImageManager instance = new ImageManager();
 
-	private List invalidUrlList = new ArrayList();
+	private List<String> invalidUrlList = new ArrayList<String>();
 
 	private String resourcesRootPath = "";
 
@@ -73,7 +76,7 @@ public class ImageManager {
 	 *
 	 * @param handle
 	 * @param uri
-	 * @return
+	 * @return Return the image
 	 */
 	public Image getImage(ModuleHandle handle, String uri) {
 		return getImage(handle, uri, false);
@@ -85,15 +88,20 @@ public class ImageManager {
 	 * @param handle
 	 * @param uri
 	 * @param refresh
-	 * @return
+	 * @return Return the image
 	 */
 	public Image getImage(ModuleHandle handle, String uri, boolean refresh) {
 		Image image = null;
 		URL url = null;
 
 		try {
-			url = generateURL(handle, uri);
-			image = getImageFromURL(url, refresh);
+
+			if (uri.contains(DATA_PROTOCOL)) {
+				image = getEmbeddedImageDataURL(uri, refresh);
+			} else {
+				url = generateURL(handle, uri);
+				image = getImageFromURL(url, refresh);
+			}
 		} catch (Exception e) {
 			if (url != null && !invalidUrlList.contains(url.toString())) {
 				invalidUrlList.add(url.toString());
@@ -107,10 +115,20 @@ public class ImageManager {
 			return null;
 		}
 		String key = url.toString();
-		Image image = getImageRegistry().get(key);
-		if (image == null) {
-			image = loadImage(url);
-		}
+		Image image = null;
+		/*
+		 *
+		 * if (key.contentEquals(DATA_PROTOCOL)) { String[] imageDataArray =
+		 * key.split(";base64,"); String imageDataBase64 = key.split(";base64,")[1];
+		 * Decoder decoder = java.util.Base64.getDecoder(); image = new Image();
+		 * .getInstance(decoder.decode(imageDataBase64)); } else {
+		 *
+		 */
+			image = getImageRegistry().get(key);
+			if (image == null) {
+				image = loadImage(url);
+			}
+//		}
 		if (image == null) {
 			if (!invalidUrlList.contains(url.toString())) {
 				invalidUrlList.add(url.toString());
@@ -124,7 +142,8 @@ public class ImageManager {
 	/**
 	 * Gets the image by the given URI
 	 *
-	 * @param uri the url of the image file
+	 * @param uri     the url of the image file
+	 * @param refresh mark if refresh necessary
 	 *
 	 * @return Returns the image,or null if the url is invalid or the file format is
 	 *         unsupported.
@@ -146,9 +165,10 @@ public class ImageManager {
 	/**
 	 * Gets the embedded image
 	 *
-	 * @param embeddedImage the embedded image data
+	 * @param handle handel of the design
+	 * @param name   name the image
 	 *
-	 * @return Returns the image,or null if the embedded image doesn't exist.
+	 * @return Returns the image or null if the embedded image doesn't exist.
 	 */
 	public Image getEmbeddedImage(ModuleHandle handle, String name) {
 		String key = generateKey(handle, name);
@@ -169,7 +189,7 @@ public class ImageManager {
 				// convert svg image to JPEG image bytes
 				JPEGTranscoder transcoder = new JPEGTranscoder();
 				// set the transcoding hints
-				transcoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, new Float(.8));
+				transcoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, .8f);
 				// create the transcoder input
 				TranscoderInput input = new TranscoderInput(
 						new ByteArrayInputStream(embeddedImage.getData(handle.getModule())));
@@ -228,6 +248,85 @@ public class ImageManager {
 		return image;
 	}
 
+	public Image getEmbeddedImageDataURL(String url, boolean refresh) throws IOException {
+		if ((url == null) || (!refresh && invalidUrlList.contains(url))) {
+			return null;
+		}
+		String key = url;
+		Image image = null;
+		if (!refresh) {
+			image = getImageRegistry().get(key);
+			if (image != null) {
+				return image;
+			}
+		} else {
+			removeCachedImage(key);
+		}
+		InputStream in = null;
+		String[] imageDataArray = key.split(";base64,");
+		String imageDataBase64 = imageDataArray[1];
+		Decoder decoder = java.util.Base64.getDecoder();
+
+		try {
+			if (url.toLowerCase().contains("svg+xml")) //$NON-NLS-1$
+			{
+				// convert svg image to JPEG image bytes
+				JPEGTranscoder transcoder = new JPEGTranscoder();
+				// set the transcoding hints
+				transcoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, .8f);
+				// create the transcoder input
+				String svgURI = url;
+				TranscoderInput input = new TranscoderInput(svgURI);
+				// create the transcoder output
+				ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+				TranscoderOutput output = new TranscoderOutput(ostream);
+				try {
+					transcoder.transcode(input, output);
+				} catch (TranscoderException e) {
+				}
+				// flush the stream
+				ostream.flush();
+				// use the outputstream as Image input stream.
+				in = new ByteArrayInputStream(ostream.toByteArray());
+			} else {
+				in = new ByteArrayInputStream(decoder.decode(imageDataBase64));
+			}
+			ImageData[] datas = new ImageLoader().load(in);
+			if (datas != null && datas.length != 0) {
+				ImageData cur;
+				int index = 0;
+				for (int i = 0; i < datas.length; i++) {
+					ImageData temp = datas[i];
+					if (temp.width * temp.height > datas[index].width * datas[index].height) {
+						index = i;
+					}
+				}
+				cur = datas[index];
+				image = new Image(null, cur);
+			}
+		} catch (IOException e) {
+			throw e;
+		} catch (Exception ee) {
+			// do nothing
+		} finally {
+			if (in != null) {
+				in.close();
+			}
+		}
+		if (image != null) {
+			getImageRegistry().put(key, image);
+		}
+
+		if (image == null) {
+			if (!invalidUrlList.contains(url)) {
+				invalidUrlList.add(url);
+			}
+		} else {
+			invalidUrlList.remove(url);
+		}
+		return image;
+	}
+
 	/**
 	 * Remove cached image from map
 	 *
@@ -243,7 +342,8 @@ public class ImageManager {
 	/**
 	 * Loads the image into the image registry by the given URI
 	 *
-	 * @param uri the URI of the image to load
+	 * @param designHandle handle of report design
+	 * @param uri          the URI of the image to load
 	 * @return Returns the image if it loaded correctly
 	 * @throws IOException
 	 */
@@ -258,9 +358,9 @@ public class ImageManager {
 	/**
 	 * Reload the image, refresh the cache.
 	 *
-	 * @param designHandle
-	 * @param uri
-	 * @return
+	 * @param designHandle handle of report design
+	 * @param uri          the URI of the image to load
+	 * @return Reload the image
 	 * @throws IOException
 	 */
 	public Image rloadImage(ModuleHandle designHandle, String uri) throws IOException {
@@ -271,18 +371,32 @@ public class ImageManager {
 		return loadImage(url, true);
 	}
 
+	/**
+	 * Load the image based on URI
+	 *
+	 * @param uri the image URI
+	 * @return Return the loaded image
+	 * @throws IOException
+	 */
 	public Image loadImage(String uri) throws IOException {
 		return loadImage(null, uri);
 	}
 
+	/**
+	 * Load the image based on URI
+	 *
+	 * @param url the image URL
+	 * @return Return the loaded image
+	 * @throws IOException
+	 */
 	public Image loadImage(URL url) throws IOException {
 		return loadImage(url, false);
 	}
 
 	/**
-	 * @param url
-	 * @param reload
-	 * @return
+	 * @param url    the image URL
+	 * @param reload image should be refreshed or used from cache
+	 * @return Return the loaded image
 	 * @throws IOException
 	 */
 	public Image loadImage(URL url, boolean reload) throws IOException {
@@ -304,7 +418,7 @@ public class ImageManager {
 				// convert svg image to JPEG image bytes
 				JPEGTranscoder transcoder = new JPEGTranscoder();
 				// set the transcoding hints
-				transcoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, new Float(.8));
+				transcoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, .8f);
 				// create the transcoder input
 				String svgURI = url.toString();
 				TranscoderInput input = new TranscoderInput(svgURI);
@@ -325,10 +439,6 @@ public class ImageManager {
 			ImageData[] datas = new ImageLoader().load(in);
 			if (datas != null && datas.length != 0) {
 				ImageData cur;
-				// if (datas.length == 1)
-				// {
-				// cur = datas[0];
-				// }
 				int index = 0;
 				for (int i = 0; i < datas.length; i++) {
 					ImageData temp = datas[i];
@@ -358,6 +468,14 @@ public class ImageManager {
 		return CorePlugin.getDefault().getImageRegistry();
 	}
 
+	/**
+	 * Generate the image URL
+	 *
+	 * @param designHandle
+	 * @param uri          of the image
+	 * @return Return the URL of the image
+	 * @throws MalformedURLException
+	 */
 	public URL generateURL(ModuleHandle designHandle, String uri) throws MalformedURLException {
 		try {
 			return new URL(uri);
@@ -379,7 +497,7 @@ public class ImageManager {
 	/**
 	 * Generate hash key.
 	 *
-	 * @param reportDesignHandle Moudle handle
+	 * @param reportDesignHandle Module handle
 	 * @param name               Name
 	 * @return key string
 	 */
@@ -390,9 +508,9 @@ public class ImageManager {
 	/**
 	 * Reload the URI image, refresh the cache.
 	 *
-	 * @param moduleHandel
-	 * @param uri
-	 * @return
+	 * @param moduleHandel Module handle
+	 * @param uri          uri of the image
+	 * @return Return the reloaded image
 	 */
 	public Image reloadURIImage(ModuleHandle moduleHandel, String uri) {
 		URL url = createURIURL(uri);
@@ -417,6 +535,12 @@ public class ImageManager {
 		return image;
 	}
 
+	/**
+	 * Create the URL based on URI
+	 *
+	 * @param uri uri string
+	 * @return Return the URL based on URI
+	 */
 	public URL createURIURL(String uri) {
 		URL url = null;
 		try {
@@ -440,9 +564,9 @@ public class ImageManager {
 	/**
 	 * Get image from URI
 	 *
-	 * @param moduleHandel
-	 * @param uri
-	 * @return
+	 * @param moduleHandel Module handle
+	 * @param uri          URI of the image
+	 * @return Return the image based on URI
 	 */
 	// bugzilla 245641
 	public Image getURIImage(ModuleHandle moduleHandel, String uri) {
@@ -458,6 +582,11 @@ public class ImageManager {
 		return image;
 	}
 
+	/**
+	 * Set the URI root path
+	 *
+	 * @param rootPath Root path of the URI
+	 */
 	public void setURIRootPath(String rootPath) {
 		this.resourcesRootPath = rootPath;
 	}

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportDesignEditPart.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportDesignEditPart.java
@@ -34,12 +34,14 @@ import org.eclipse.birt.report.designer.internal.ui.layout.ReportDesignLayout;
 import org.eclipse.birt.report.designer.internal.ui.util.UIUtil;
 import org.eclipse.birt.report.designer.ui.IReportGraphicConstants;
 import org.eclipse.birt.report.designer.util.DEUtil;
+import org.eclipse.birt.report.model.api.DesignElementHandle;
 import org.eclipse.birt.report.model.api.MasterPageHandle;
 import org.eclipse.birt.report.model.api.ModuleHandle;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.eclipse.birt.report.model.api.SimpleMasterPageHandle;
 import org.eclipse.birt.report.model.api.SlotHandle;
 import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
+import org.eclipse.birt.report.model.elements.interfaces.IInternalReportDesignModel;
 import org.eclipse.birt.report.model.elements.interfaces.IMasterPageModel;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -124,7 +126,7 @@ public class ReportDesignEditPart extends AbstractReportEditPart implements IAct
 	 * getModelChildren()
 	 */
 	@Override
-	protected List getModelChildren() {
+	protected List<?> getModelChildren() {
 		return HandleAdapterFactory.getInstance().getReportDesignHandleAdapter(getModel()).getChildren();
 	}
 
@@ -201,7 +203,7 @@ public class ReportDesignEditPart extends AbstractReportEditPart implements IAct
 
 	private SimpleMasterPageHandle getSimpleMasterPageHandle() {
 		SlotHandle slotHandle = ((ModuleHandle) getModel()).getMasterPages();
-		Iterator iter = slotHandle.iterator();
+		Iterator<DesignElementHandle> iter = slotHandle.iterator();
 		SimpleMasterPageHandle masterPageHandle = (SimpleMasterPageHandle) iter.next();
 		return masterPageHandle;
 	}
@@ -267,8 +269,8 @@ public class ReportDesignEditPart extends AbstractReportEditPart implements IAct
 		 * Bidi-specific behavior is addressed only if Bidi support is enabled
 		 */
 
-		if (info.get(ReportDesignHandle.BIDI_ORIENTATION_PROP) instanceof ReportDesignHandle) {
-			String newOrientation = ((ReportDesignHandle) info.get(ReportDesignHandle.BIDI_ORIENTATION_PROP))
+		if (info.get(IInternalReportDesignModel.BIDI_ORIENTATION_PROP) instanceof ReportDesignHandle) {
+			String newOrientation = ((ReportDesignHandle) info.get(IInternalReportDesignModel.BIDI_ORIENTATION_PROP))
 					.getBidiOrientation();
 
 			UIUtil.processOrientationChange(newOrientation, getViewer());
@@ -277,10 +279,10 @@ public class ReportDesignEditPart extends AbstractReportEditPart implements IAct
 		}
 
 		super.propertyChange(info);
-		if (info.get(ReportDesignHandle.LAYOUT_PREFERENCE_PROP) != null) {
-			if (info.get(ReportDesignHandle.LAYOUT_PREFERENCE_PROP) instanceof ReportDesignHandle) {
+		if (info.get(IInternalReportDesignModel.LAYOUT_PREFERENCE_PROP) != null) {
+			if (info.get(IInternalReportDesignModel.LAYOUT_PREFERENCE_PROP) instanceof ReportDesignHandle) {
 				getViewer().setProperty(IReportGraphicConstants.REPORT_LAYOUT_PROPERTY,
-						((ReportDesignHandle) info.get(ReportDesignHandle.LAYOUT_PREFERENCE_PROP))
+						((ReportDesignHandle) info.get(IInternalReportDesignModel.LAYOUT_PREFERENCE_PROP))
 								.getLayoutPreference());
 
 				// invalidate = true;
@@ -303,7 +305,7 @@ public class ReportDesignEditPart extends AbstractReportEditPart implements IAct
 					|| info.get(IMasterPageModel.HEIGHT_PROP) != null
 					|| info.get(IMasterPageModel.ORIENTATION_PROP) != null) {
 				SlotHandle slotHandle = ((ModuleHandle) getModel()).getMasterPages();
-				Iterator iter = slotHandle.iterator();
+				Iterator<DesignElementHandle> iter = slotHandle.iterator();
 				SimpleMasterPageHandle masterPageHandle = (SimpleMasterPageHandle) iter.next();
 
 				Dimension size = getMasterPageSize(masterPageHandle);

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportElementEditPart.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportElementEditPart.java
@@ -625,6 +625,16 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 				image = null;
 			}
 
+			// Try to get Embedded Image!
+			if (image == null) {
+				try {
+					image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
+							backGroundImage);
+				} catch (SWTException e) {
+					// Should not be ExceptionHandler.handle(e), see SCR#73730
+					image = null;
+				}
+			}
 			return image;
 		}
 
@@ -648,6 +658,17 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 			} catch (SWTException e) {
 				// Should not be ExceptionHandler.handle(e), see SCR#73730
 				image = null;
+			}
+
+			// Try to get Embedded Image!
+			if (image == null) {
+				try {
+					image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
+							backGroundImage);
+				} catch (SWTException e) {
+					// Should not be ExceptionHandler.handle(e), see SCR#73730
+					image = null;
+				}
 			}
 
 			if (image == null) {
@@ -712,8 +733,9 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 			} else {
 				temp = ImageManager.getInstance().generateURL(model.getModuleHandle(), backGroundImage);
 			}
-
-			in = temp.openStream();
+			if (temp != null) {
+				in = temp.openStream();
+			}
 		} catch (IOException e) {
 			in = null;
 		}

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportElementEditPart.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportElementEditPart.java
@@ -29,7 +29,7 @@ import org.eclipse.birt.report.designer.core.model.IModelAdapterHelper;
 import org.eclipse.birt.report.designer.core.model.ReportDesignHandleAdapter;
 import org.eclipse.birt.report.designer.core.model.ReportItemtHandleAdapter;
 import org.eclipse.birt.report.designer.core.model.schematic.HandleAdapterFactory;
-import org.eclipse.birt.report.designer.core.util.mediator.request.ReportRequest;
+import org.eclipse.birt.report.designer.core.util.mediator.request.ReportRequestConstants;
 import org.eclipse.birt.report.designer.internal.ui.editors.parts.DeferredGraphicalViewer;
 import org.eclipse.birt.report.designer.internal.ui.editors.schematic.border.BaseBorder;
 import org.eclipse.birt.report.designer.internal.ui.editors.schematic.editpolicies.ReportElementResizablePolicy;
@@ -45,17 +45,18 @@ import org.eclipse.birt.report.designer.internal.ui.util.UIUtil;
 import org.eclipse.birt.report.designer.util.ColorManager;
 import org.eclipse.birt.report.designer.util.DEUtil;
 import org.eclipse.birt.report.designer.util.ImageManager;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.model.api.DesignElementHandle;
 import org.eclipse.birt.report.model.api.MasterPageHandle;
 import org.eclipse.birt.report.model.api.ModuleHandle;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.eclipse.birt.report.model.api.ReportItemHandle;
-import org.eclipse.birt.report.model.api.StyleHandle;
 import org.eclipse.birt.report.model.api.activity.SemanticException;
 import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
 import org.eclipse.birt.report.model.api.metadata.DimensionValue;
 import org.eclipse.birt.report.model.api.util.ColorUtil;
 import org.eclipse.birt.report.model.api.util.URIUtil;
+import org.eclipse.birt.report.model.elements.interfaces.IStyleModel;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MouseEvent;
 import org.eclipse.draw2d.MouseMotionListener;
@@ -124,7 +125,9 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	}
 
 	/**
-	 * @return
+	 * Create the design handle adapter
+	 *
+	 * @return Return the design handle adapter
 	 */
 	public DesignElementHandleAdapter creatDesignElementHandleAdapter() {
 		HandleAdapterFactory.getInstance().remove(getModel());
@@ -140,7 +143,7 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 			return;
 		}
 		if (RequestConstants.REQ_OPEN.equals(request.getType())
-				|| ReportRequest.CREATE_ELEMENT.equals(request.getType())) {
+				|| ReportRequestConstants.CREATE_ELEMENT.equals(request.getType())) {
 			if (isEdited()) {
 				return;
 			}
@@ -154,6 +157,9 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 		}
 	}
 
+	/**
+	 * Perform the direct edit (currently nothing will be done)
+	 */
 	public void performDirectEdit() {
 		// do nothing
 	}
@@ -169,7 +175,7 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	/**
 	 * Creates the guide handle, default get from parent.
 	 *
-	 * @return
+	 * @return Return the guide handle
 	 */
 	protected AbstractGuideHandle createGuideHandle() {
 		EditPart part = getParent();
@@ -217,7 +223,7 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 
 	private AbstractGuideHandle findHandle() {
 		IFigure layer = getHandleLayer();
-		List list = layer.getChildren();
+		List<?> list = layer.getChildren();
 		int size = list.size();
 
 		for (int i = 0; i < size; i++) {
@@ -232,20 +238,20 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 
 	protected void clearGuideHandle() {
 		IFigure layer = getHandleLayer();
-		List list = layer.getChildren();
-		List temp = new ArrayList();
+		List<?> list = layer.getChildren();
+		List<IFigure> temp = new ArrayList<IFigure>();
 		int size = list.size();
 
 		for (int i = 0; i < size; i++) {
 			Object obj = list.get(i);
 			if (obj instanceof AbstractGuideHandle) {
-				temp.add(obj);
+				temp.add((IFigure) obj);
 			}
 		}
 
 		size = temp.size();
 		for (int i = 0; i < size; i++) {
-			IFigure figure = (IFigure) temp.get(i);
+			IFigure figure = temp.get(i);
 			layer.remove(figure);
 		}
 	}
@@ -382,10 +388,10 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 //				{
 //					needRefresh = true;
 //				}
-				if (isPercentageValue(handle.getProperty(StyleHandle.MARGIN_LEFT_PROP))) {
+				if (isPercentageValue(handle.getProperty(IStyleModel.MARGIN_LEFT_PROP))) {
 					needRefresh = true;
 				}
-				if (isPercentageValue(handle.getProperty(StyleHandle.MARGIN_RIGHT_PROP))) {
+				if (isPercentageValue(handle.getProperty(IStyleModel.MARGIN_RIGHT_PROP))) {
 					needRefresh = true;
 				}
 
@@ -467,7 +473,7 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	/**
 	 * Gets location
 	 *
-	 * @return
+	 * @return Return the location point
 	 */
 	public Point getLocation() {
 		return getReportElementHandleAdapt().getLocation();
@@ -547,8 +553,13 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 		super.refreshChildren();
 	}
 
+	/**
+	 * Refresh the report children
+	 *
+	 * @param parent parent like starting point of refresh
+	 */
 	public void refreshReportChildren(ReportElementEditPart parent) {
-		List list = parent.getChildren();
+		List<?> list = parent.getChildren();
 		for (int i = 0; i < list.size(); i++) {
 			Object part = list.get(i);
 			if (part instanceof ReportElementEditPart) {
@@ -561,6 +572,9 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 		}
 	}
 
+	/**
+	 *
+	 */
 	public abstract void refreshFigure();
 
 	/**
@@ -591,7 +605,7 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	 *
 	 */
 	protected void refreshBackgroundColor(DesignElementHandle handle) {
-		Object obj = handle.getProperty(StyleHandle.BACKGROUND_COLOR_PROP);
+		Object obj = handle.getProperty(IStyleModel.BACKGROUND_COLOR_PROP);
 
 		if (handle instanceof MasterPageHandle) {
 			getFigure().setOpaque(true);
@@ -616,28 +630,36 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 
 		if (backGroundImage == null) {
 			return null;
-		} else {
-			Image image = null;
+		}
+		Object obj = handle.getProperty(IStyleModel.BACKGROUND_IMAGE_TYPE_PROP);
+		String imageSourceType = CSSValueConstants.URL_VALUE.getCssText();
+		if (obj instanceof String) {
+			imageSourceType = obj.toString();
+		}
+
+		Image image = null;
+
+		// URL image
+		if (imageSourceType.equalsIgnoreCase(CSSValueConstants.URL_VALUE.getCssText())) {
 			try {
 				image = ImageManager.getInstance().getImage(getModelAdapter().getModuleHandle(), backGroundImage);
 			} catch (SWTException e) {
 				// Should not be ExceptionHandler.handle(e), see SCR#73730
 				image = null;
 			}
-
-			// Try to get Embedded Image!
-			if (image == null) {
-				try {
-					image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
-							backGroundImage);
-				} catch (SWTException e) {
-					// Should not be ExceptionHandler.handle(e), see SCR#73730
-					image = null;
-				}
-			}
-			return image;
 		}
 
+		// embedded image
+		if (imageSourceType.equalsIgnoreCase(CSSValueConstants.EMBED_VALUE.getCssText())) {
+			try {
+				image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
+						backGroundImage);
+			} catch (SWTException e) {
+				// Should not be ExceptionHandler.handle(e), see SCR#73730
+				image = null;
+			}
+		}
+		return image;
 	}
 
 	/*
@@ -651,71 +673,71 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 
 		if (backGroundImage == null) {
 			figure.setImage(null);
-		} else {
-			Image image = null;
+		}
+
+		Image image = null;
+		// URL image
+		try {
+			image = ImageManager.getInstance().getImage(getModelAdapter().getModuleHandle(), backGroundImage);
+		} catch (SWTException e) {
+			// Should not be ExceptionHandler.handle(e), see SCR#73730
+			image = null;
+		}
+
+		// embedded image
+		if (image == null) {
 			try {
-				image = ImageManager.getInstance().getImage(getModelAdapter().getModuleHandle(), backGroundImage);
+				image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
+						backGroundImage);
 			} catch (SWTException e) {
 				// Should not be ExceptionHandler.handle(e), see SCR#73730
 				image = null;
 			}
-
-			// Try to get Embedded Image!
-			if (image == null) {
-				try {
-					image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
-							backGroundImage);
-				} catch (SWTException e) {
-					// Should not be ExceptionHandler.handle(e), see SCR#73730
-					image = null;
-				}
-			}
-
-			if (image == null) {
-				figure.setImage(null);
-				return;
-			}
-			int dpi = getImageDPI(backGroundImage);
-			if (figure instanceof ReportElementFigure) {
-				((ReportElementFigure) figure).setBackgroundImageDPI(dpi);
-			}
-			figure.setImage(image);
-
-			Object[] backGroundPosition = getBackgroundPosition(handle);
-			int backGroundRepeat = getBackgroundRepeat(handle);
-
-			figure.setRepeat(backGroundRepeat);
-
-			Object xPosition = backGroundPosition[0];
-			Object yPosition = backGroundPosition[1];
-			Rectangle area = getFigure().getClientArea();
-			org.eclipse.swt.graphics.Rectangle imageArea = image.getBounds();
-			Point position = new Point(-1, -1);
-			int alignment = 0;
-
-			if (xPosition instanceof Integer) {
-				position.x = ((Integer) xPosition).intValue();
-			} else if (xPosition instanceof DimensionValue) {
-				int percentX = (int) ((DimensionValue) xPosition).getMeasure();
-
-				position.x = (area.width - imageArea.width) * percentX / 100;
-			} else if (xPosition instanceof String) {
-				alignment |= DesignElementHandleAdapter.getPosition((String) xPosition);
-			}
-
-			if (yPosition instanceof Integer) {
-				position.y = ((Integer) yPosition).intValue();
-			} else if (yPosition instanceof DimensionValue) {
-				int percentY = (int) ((DimensionValue) yPosition).getMeasure();
-
-				position.y = (area.width - imageArea.width) * percentY / 100;
-			} else if (yPosition instanceof String) {
-				alignment |= DesignElementHandleAdapter.getPosition((String) yPosition);
-			}
-
-			figure.setAlignment(alignment);
-			figure.setPosition(position);
 		}
+
+		if (image == null) {
+			figure.setImage(null);
+			return;
+		}
+		int dpi = getImageDPI(backGroundImage);
+
+		if (figure instanceof ReportElementFigure) {
+			((ReportElementFigure) figure).setBackgroundImageDPI(dpi);
+		}
+		figure.setImage(image);
+
+		Object[] backGroundPosition = getBackgroundPosition(handle);
+		int backGroundRepeat = getBackgroundRepeat(handle);
+
+		figure.setRepeat(backGroundRepeat);
+
+		Object xPosition = backGroundPosition[0];
+		Object yPosition = backGroundPosition[1];
+		Rectangle area = getFigure().getClientArea();
+		org.eclipse.swt.graphics.Rectangle imageArea = image.getBounds();
+		Point position = new Point(-1, -1);
+		int alignment = 0;
+
+		if (xPosition instanceof Integer) {
+			position.x = ((Integer) xPosition).intValue();
+		} else if (xPosition instanceof DimensionValue) {
+			int percentX = (int) ((DimensionValue) xPosition).getMeasure();
+			position.x = (area.width - imageArea.width) * percentX / 100;
+		} else if (xPosition instanceof String) {
+			alignment |= DesignElementHandleAdapter.getPosition((String) xPosition);
+		}
+
+		if (yPosition instanceof Integer) {
+			position.y = ((Integer) yPosition).intValue();
+		} else if (yPosition instanceof DimensionValue) {
+			int percentY = (int) ((DimensionValue) yPosition).getMeasure();
+			position.y = (area.width - imageArea.width) * percentY / 100;
+		} else if (yPosition instanceof String) {
+			alignment |= DesignElementHandleAdapter.getPosition((String) yPosition);
+		}
+
+		figure.setAlignment(alignment);
+		figure.setPosition(position);
 	}
 
 	private int getImageDPI(String backGroundImage) {
@@ -736,6 +758,7 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 			if (temp != null) {
 				in = temp.openStream();
 			}
+
 		} catch (IOException e) {
 			in = null;
 		}
@@ -755,7 +778,6 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	 * Marks edit part dirty
 	 *
 	 * @param bool
-	 * @param notifyParent
 	 */
 	@Override
 	public void markDirty(boolean bool) {
@@ -824,28 +846,28 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	}
 
 	protected void updateBottomBorder(DesignElementHandle handle, BaseBorder border) {
-		border.bottomColor = handle.getPropertyHandle(StyleHandle.BORDER_BOTTOM_COLOR_PROP).getIntValue();
-		border.bottomStyle = handle.getPropertyHandle(StyleHandle.BORDER_BOTTOM_STYLE_PROP).getStringValue();
-		border.bottomWidth = handle.getPropertyHandle(StyleHandle.BORDER_BOTTOM_WIDTH_PROP).getStringValue();
+		border.bottomColor = handle.getPropertyHandle(IStyleModel.BORDER_BOTTOM_COLOR_PROP).getIntValue();
+		border.bottomStyle = handle.getPropertyHandle(IStyleModel.BORDER_BOTTOM_STYLE_PROP).getStringValue();
+		border.bottomWidth = handle.getPropertyHandle(IStyleModel.BORDER_BOTTOM_WIDTH_PROP).getStringValue();
 	}
 
 	protected void updateTopBorder(DesignElementHandle handle, BaseBorder border) {
-		border.topColor = handle.getPropertyHandle(StyleHandle.BORDER_TOP_COLOR_PROP).getIntValue();
-		border.topStyle = handle.getPropertyHandle(StyleHandle.BORDER_TOP_STYLE_PROP).getStringValue();
-		border.topWidth = handle.getPropertyHandle(StyleHandle.BORDER_TOP_WIDTH_PROP).getStringValue();
+		border.topColor = handle.getPropertyHandle(IStyleModel.BORDER_TOP_COLOR_PROP).getIntValue();
+		border.topStyle = handle.getPropertyHandle(IStyleModel.BORDER_TOP_STYLE_PROP).getStringValue();
+		border.topWidth = handle.getPropertyHandle(IStyleModel.BORDER_TOP_WIDTH_PROP).getStringValue();
 	}
 
 	protected void updateLeftBorder(DesignElementHandle handle, BaseBorder border) {
-		border.leftColor = handle.getPropertyHandle(StyleHandle.BORDER_LEFT_COLOR_PROP).getIntValue();
-		border.leftStyle = handle.getPropertyHandle(StyleHandle.BORDER_LEFT_STYLE_PROP).getStringValue();
-		border.leftWidth = handle.getPropertyHandle(StyleHandle.BORDER_LEFT_WIDTH_PROP).getStringValue();
+		border.leftColor = handle.getPropertyHandle(IStyleModel.BORDER_LEFT_COLOR_PROP).getIntValue();
+		border.leftStyle = handle.getPropertyHandle(IStyleModel.BORDER_LEFT_STYLE_PROP).getStringValue();
+		border.leftWidth = handle.getPropertyHandle(IStyleModel.BORDER_LEFT_WIDTH_PROP).getStringValue();
 
 	}
 
 	protected void updateRightBorder(DesignElementHandle handle, BaseBorder border) {
-		border.rightColor = handle.getPropertyHandle(StyleHandle.BORDER_RIGHT_COLOR_PROP).getIntValue();
-		border.rightStyle = handle.getPropertyHandle(StyleHandle.BORDER_RIGHT_STYLE_PROP).getStringValue();
-		border.rightWidth = handle.getPropertyHandle(StyleHandle.BORDER_RIGHT_WIDTH_PROP).getStringValue();
+		border.rightColor = handle.getPropertyHandle(IStyleModel.BORDER_RIGHT_COLOR_PROP).getIntValue();
+		border.rightStyle = handle.getPropertyHandle(IStyleModel.BORDER_RIGHT_STYLE_PROP).getStringValue();
+		border.rightWidth = handle.getPropertyHandle(IStyleModel.BORDER_RIGHT_WIDTH_PROP).getStringValue();
 	}
 
 	protected void refreshBorder(DesignElementHandle handle, BaseBorder border) {
@@ -896,8 +918,10 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 		return center.x >= p.x;
 	}
 
-	/*
-	 * (non-Javadoc)
+	/**
+	 * Verify if the element is deleted
+	 *
+	 * @return Return if the element is deleted
 	 *
 	 * @see org.eclipse.gef.EditPart#isActive()
 	 */
@@ -912,6 +936,9 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 		return bool;
 	}
 
+	/**
+	 * Notify the model change
+	 */
 	public void notifyModelChange() {
 		if (getParent() != null && getParent() instanceof ReportElementEditPart) {
 			((ReportElementEditPart) getParent()).notifyModelChange();
@@ -919,23 +946,29 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	}
 
 	/**
+	 * Refresh after content change
 	 *
+	 * @param info Map of changed content elements
 	 */
-	protected void contentChange(Map info) {
+	protected void contentChange(Map<?, ?> info) {
 		markDirty(true);
 		refresh();
 	}
 
 	/**
-	 * @param focus
+	 * Refresh after property change
+	 *
+	 * @param info Map of changed element properties
 	 */
-	protected void propertyChange(Map info) {
+	protected void propertyChange(Map<?, ?> info) {
 		refreshVisuals();
 	}
 
 	/**
-	 * @param model
-	 * @return
+	 * Compare of the current model with the requested model
+	 *
+	 * @param model Module to validate
+	 * @return Return the compare result
 	 */
 	public boolean isinterest(Object model) {
 		return getModel().equals(model);
@@ -943,15 +976,17 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 
 	/**
 	 * @param object
-	 * @return
+	 * @return false
 	 */
 	public boolean isinterestSelection(Object object) {
 		return false;
 	}
 
 	/**
+	 * Get the resize policy object
+	 *
 	 * @param parentPolice
-	 * @return
+	 * @return Return the resize edit policy
 	 */
 	public EditPolicy getResizePolice(EditPolicy parentPolice) {
 		ReportElementResizablePolicy policy = new ReportElementResizablePolicy();
@@ -970,12 +1005,19 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 		super.removeChild(child);
 	}
 
+	/**
+	 * Get guide label
+	 *
+	 * @return Return empty guide label
+	 */
 	public String getGuideLabel() {
 		return ""; //$NON-NLS-1$
 	}
 
 	/**
-	 * @return
+	 * Get the direction of the text
+	 *
+	 * @return Return the text direction
 	 */
 	protected String getTextDirection() {
 		DesignElementHandle handle = (DesignElementHandle) getModel();
@@ -983,8 +1025,10 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	}
 
 	/**
-	 * @param handle
-	 * @return
+	 * Get the direction of the text
+	 *
+	 * @param handle design handle to be used
+	 * @return Return the text direction
 	 */
 	protected String getTextDirection(DesignElementHandle handle) {
 		return handle.isDirectionRTL() ? DesignChoiceConstants.BIDI_DIRECTION_RTL
@@ -1009,7 +1053,9 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 	}
 
 	/**
-	 * @return
+	 * Verify if the layout is fixed
+	 *
+	 * @return Return the information of fixed layout
 	 */
 	public boolean isFixLayout() {
 		return DEUtil.isFixLayout(getModel());

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportElementEditPart.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ReportElementEditPart.java
@@ -625,40 +625,36 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 		}
 	}
 
+	/*
+	 * Get background image
+	 *
+	 */
 	protected Image getBackImage(DesignElementHandle handle) {
 		String backGroundImage = getBackgroundImage(handle);
 
 		if (backGroundImage == null) {
 			return null;
 		}
+		Image image = null;
+
+		String imageSourceType = DesignChoiceConstants.IMAGE_REF_TYPE_EMBED;
 		Object obj = handle.getProperty(IStyleModel.BACKGROUND_IMAGE_TYPE_PROP);
-		String imageSourceType = CSSValueConstants.URL_VALUE.getCssText();
 		if (obj instanceof String) {
 			imageSourceType = obj.toString();
 		}
-
-		Image image = null;
-
-		// URL image
-		if (imageSourceType.equalsIgnoreCase(CSSValueConstants.URL_VALUE.getCssText())) {
-			try {
+		try {
+			if (imageSourceType.equalsIgnoreCase(CSSValueConstants.URL_VALUE.getCssText())) {
 				image = ImageManager.getInstance().getImage(getModelAdapter().getModuleHandle(), backGroundImage);
-			} catch (SWTException e) {
-				// Should not be ExceptionHandler.handle(e), see SCR#73730
-				image = null;
 			}
-		}
-
-		// embedded image
-		if (imageSourceType.equalsIgnoreCase(CSSValueConstants.EMBED_VALUE.getCssText())) {
-			try {
+			if (imageSourceType.equalsIgnoreCase(CSSValueConstants.EMBED_VALUE.getCssText()) || image == null) {
 				image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
 						backGroundImage);
-			} catch (SWTException e) {
-				// Should not be ExceptionHandler.handle(e), see SCR#73730
-				image = null;
 			}
+		} catch (SWTException e) {
+			// Should not be ExceptionHandler.handle(e), see SCR#73730
+			image = null;
 		}
+
 		return image;
 	}
 
@@ -675,24 +671,24 @@ public abstract class ReportElementEditPart extends AbstractGraphicalEditPart
 			figure.setImage(null);
 		}
 
+		Object obj = handle.getProperty(IStyleModel.BACKGROUND_IMAGE_TYPE_PROP);
+		String imageSourceType = CSSValueConstants.URL_VALUE.getCssText();
+		if (obj instanceof String) {
+			imageSourceType = obj.toString();
+		}
 		Image image = null;
-		// URL image
+
 		try {
-			image = ImageManager.getInstance().getImage(getModelAdapter().getModuleHandle(), backGroundImage);
+			if (imageSourceType.equalsIgnoreCase(CSSValueConstants.URL_VALUE.getCssText())) {
+				image = ImageManager.getInstance().getImage(getModelAdapter().getModuleHandle(), backGroundImage);
+			}
+			if (imageSourceType.equalsIgnoreCase(CSSValueConstants.EMBED_VALUE.getCssText()) || image == null) {
+				image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
+						backGroundImage);
+			}
 		} catch (SWTException e) {
 			// Should not be ExceptionHandler.handle(e), see SCR#73730
 			image = null;
-		}
-
-		// embedded image
-		if (image == null) {
-			try {
-				image = ImageManager.getInstance().getEmbeddedImage(getModelAdapter().getModuleHandle(),
-						backGroundImage);
-			} catch (SWTException e) {
-				// Should not be ExceptionHandler.handle(e), see SCR#73730
-				image = null;
-			}
 		}
 
 		if (image == null) {

--- a/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ChartReportItemUIUtil.java
+++ b/chart/org.eclipse.birt.chart.reportitem.ui/src/org/eclipse/birt/chart/reportitem/ui/ChartReportItemUIUtil.java
@@ -35,7 +35,6 @@ import org.eclipse.birt.report.model.api.ExtendedItemHandle;
 import org.eclipse.birt.report.model.api.ReportItemHandle;
 import org.eclipse.birt.report.model.api.ResultSetColumnHandle;
 import org.eclipse.birt.report.model.api.StructureFactory;
-import org.eclipse.birt.report.model.api.StyleHandle;
 import org.eclipse.birt.report.model.api.activity.SemanticException;
 import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
 import org.eclipse.birt.report.model.api.elements.structures.ComputedColumn;
@@ -43,6 +42,7 @@ import org.eclipse.birt.report.model.api.extension.ExtendedElementException;
 import org.eclipse.birt.report.model.api.extension.IReportItem;
 import org.eclipse.birt.report.model.api.metadata.DimensionValue;
 import org.eclipse.birt.report.model.api.util.ColorUtil;
+import org.eclipse.birt.report.model.elements.interfaces.IStyleModel;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -144,7 +144,7 @@ public class ChartReportItemUIUtil {
 	 * @return background image
 	 */
 	public static String getBackgroundImage(DesignElementHandle handle) {
-		return handle.getStringProperty(StyleHandle.BACKGROUND_IMAGE_PROP);
+		return handle.getStringProperty(IStyleModel.BACKGROUND_IMAGE_PROP);
 	}
 
 	/**
@@ -158,8 +158,8 @@ public class ChartReportItemUIUtil {
 		Object y = null;
 
 		if (handle != null) {
-			Object px = handle.getProperty(StyleHandle.BACKGROUND_POSITION_X_PROP);
-			Object py = handle.getProperty(StyleHandle.BACKGROUND_POSITION_Y_PROP);
+			Object px = handle.getProperty(IStyleModel.BACKGROUND_POSITION_X_PROP);
+			Object py = handle.getProperty(IStyleModel.BACKGROUND_POSITION_Y_PROP);
 
 			if (px instanceof String) {
 				x = px;
@@ -195,7 +195,7 @@ public class ChartReportItemUIUtil {
 	 * @return background repeat property
 	 */
 	public static int getBackgroundRepeat(DesignElementHandle handle) {
-		return getRepeat(handle.getStringProperty(StyleHandle.BACKGROUND_REPEAT_PROP));
+		return getRepeat(handle.getStringProperty(IStyleModel.BACKGROUND_REPEAT_PROP));
 	}
 
 	/**
@@ -219,9 +219,11 @@ public class ChartReportItemUIUtil {
 	 * Generate computed columns for the given report item with the closest data set
 	 * available.
 	 *
+	 * @param handle
 	 * @param dataSetHandle Data Set. No aggregation created.
 	 *
 	 * @return true if succeed,or fail if no column generated.
+	 * @throws SemanticException
 	 * @see DataUtil#generateComputedColumns(ReportItemHandle)
 	 *
 	 */
@@ -273,8 +275,19 @@ public class ChartReportItemUIUtil {
 			figure.setImage(null);
 		} else {
 			Image image = null;
+			String imageSourceType = DesignChoiceConstants.IMAGE_REF_TYPE_EMBED;
+			Object obj = handle.getProperty(IStyleModel.BACKGROUND_IMAGE_TYPE_PROP);
+			if (obj instanceof String) {
+				imageSourceType = obj.toString();
+			}
 			try {
-				image = ImageManager.getInstance().getImage(handle.getModuleHandle(), backGroundImage);
+				if (imageSourceType.equalsIgnoreCase(DesignChoiceConstants.IMAGE_REF_TYPE_EMBED)) {
+					// embedded image
+					image = ImageManager.getInstance().getEmbeddedImage(handle.getModuleHandle(), backGroundImage);
+				} else {
+					// URL image
+					image = ImageManager.getInstance().getImage(handle.getModuleHandle(), backGroundImage);
+				}
 			} catch (SWTException e) {
 				// Should not be ExceptionHandler.handle(e), see SCR#73730
 				image = null;
@@ -331,7 +344,7 @@ public class ChartReportItemUIUtil {
 	 * @param figure Figure
 	 */
 	public static void refreshBackgroundColor(ExtendedItemHandle handle, IFigure figure) {
-		Object obj = handle.getProperty(StyleHandle.BACKGROUND_COLOR_PROP);
+		Object obj = handle.getProperty(IStyleModel.BACKGROUND_COLOR_PROP);
 
 		figure.setOpaque(false);
 

--- a/engine/org.eclipse.birt.report.engine.emitter.html/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: org.eclipse.birt.core;bundle-version="[2.1.0,5.0.0)",
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.birt.report.engine.emitter.html
+Import-Package: com.lowagie.text
 

--- a/engine/org.eclipse.birt.report.engine.emitter.html/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/META-INF/MANIFEST.MF
@@ -15,5 +15,3 @@ Require-Bundle: org.eclipse.birt.core;bundle-version="[2.1.0,5.0.0)",
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.birt.report.engine.emitter.html
-Import-Package: com.lowagie.text
-

--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/AttributeBuilder.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/AttributeBuilder.java
@@ -101,7 +101,7 @@ public class AttributeBuilder {
 			return;
 		}
 
-		image = emitter.handleStyleImage(image, true);
+		image = emitter.handleStyleImage(image, true, style);
 		if (image != null && image.length() > 0) {
 			buildURLProperty(styleBuffer, HTMLTags.ATTR_BACKGROUND_IMAGE, image);
 			buildProperty(styleBuffer, HTMLTags.ATTR_BACKGROUND_REPEAT, style.getBackgroundRepeat());

--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/AttributeBuilder.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/AttributeBuilder.java
@@ -15,6 +15,9 @@
 package org.eclipse.birt.report.engine.emitter.html;
 
 import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.StyleConstants;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSConstants;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.emitter.HTMLTags;
 import org.eclipse.birt.report.engine.ir.DimensionType;
 import org.w3c.dom.css.CSSValue;
@@ -30,6 +33,12 @@ public class AttributeBuilder {
 
 	/**
 	 * Build the relative position of a component. This method is obsolete.
+	 *
+	 * @param x
+	 * @param y
+	 * @param width
+	 * @param height
+	 * @return Return the content string
 	 */
 	public static String buildPos(DimensionType x, DimensionType y, DimensionType width, DimensionType height) {
 		StringBuffer content = new StringBuffer();
@@ -124,6 +133,13 @@ public class AttributeBuilder {
 		}
 	}
 
+	/**
+	 * Build the background color
+	 *
+	 * @param styleBuffer
+	 * @param style
+	 * @param emitter
+	 */
 	public static void buildBackgroundColor(StringBuffer styleBuffer, IStyle style, HTMLReportEmitter emitter) {
 		buildProperty(styleBuffer, HTMLTags.ATTR_BACKGROUND_COLOR, style.getBackgroundColor());
 	}
@@ -302,7 +318,6 @@ public class AttributeBuilder {
 	 * @param styleBuffer The <code>StringBuffer</code> to which the result is
 	 *                    output.
 	 * @param style       The style object.
-	 * @param bContainer  true: shouldn't output the text-decoration.
 	 */
 	public static void buildText(StringBuffer styleBuffer, IStyle style) {
 		buildProperty(styleBuffer, HTMLTags.ATTR_TEXT_INDENT, style.getTextIndent());
@@ -349,25 +364,23 @@ public class AttributeBuilder {
 	 *
 	 * @param styleBuffer The <code>StringBuffer</code> to which the result is
 	 *                    output.
-	 * @param linethrough The line-through value.
-	 * @param underline   The underline value.
-	 * @param overline    The overline value.
+	 * @param style       The style of the text decoration.
 	 */
 	public static void buildTextDecoration(StringBuffer styleBuffer, IStyle style) {
-		CSSValue linethrough = style.getProperty(IStyle.STYLE_TEXT_LINETHROUGH);
-		CSSValue underline = style.getProperty(IStyle.STYLE_TEXT_UNDERLINE);
-		CSSValue overline = style.getProperty(IStyle.STYLE_TEXT_OVERLINE);
+		CSSValue linethrough = style.getProperty(StyleConstants.STYLE_TEXT_LINETHROUGH);
+		CSSValue underline = style.getProperty(StyleConstants.STYLE_TEXT_UNDERLINE);
+		CSSValue overline = style.getProperty(StyleConstants.STYLE_TEXT_OVERLINE);
 
-		if (linethrough == IStyle.LINE_THROUGH_VALUE || underline == IStyle.UNDERLINE_VALUE
-				|| overline == IStyle.OVERLINE_VALUE) {
+		if (linethrough == CSSValueConstants.LINE_THROUGH_VALUE || underline == CSSValueConstants.UNDERLINE_VALUE
+				|| overline == CSSValueConstants.OVERLINE_VALUE) {
 			styleBuffer.append(" text-decoration:"); //$NON-NLS-1$
-			if (IStyle.LINE_THROUGH_VALUE == linethrough) {
+			if (CSSValueConstants.LINE_THROUGH_VALUE == linethrough) {
 				addPropValue(styleBuffer, "line-through");
 			}
-			if (IStyle.UNDERLINE_VALUE == underline) {
+			if (CSSValueConstants.UNDERLINE_VALUE == underline) {
 				addPropValue(styleBuffer, "underline");
 			}
-			if (IStyle.OVERLINE_VALUE == overline) {
+			if (CSSValueConstants.OVERLINE_VALUE == overline) {
 				addPropValue(styleBuffer, "overline");
 			}
 			styleBuffer.append(';');
@@ -538,7 +551,7 @@ public class AttributeBuilder {
 		if (style != null) {
 			String direction = style.getDirection();
 			if (direction != null) {
-				buildProperty(styleBuffer, IStyle.CSS_DIRECTION_PROPERTY, direction);
+				buildProperty(styleBuffer, CSSConstants.CSS_DIRECTION_PROPERTY, direction);
 			}
 		}
 	}

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
@@ -30,12 +30,11 @@ import java.util.regex.Pattern;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.print.PrintTranscoder;
 import org.eclipse.birt.report.engine.content.IHyperlinkAction;
-import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.emitter.EmitterUtil;
 import org.eclipse.birt.report.engine.layout.emitter.AbstractPage;
 import org.eclipse.birt.report.engine.layout.pdf.font.FontInfo;
-import org.eclipse.birt.report.engine.nLayout.area.style.BackgroundImageInfo;
-import org.eclipse.birt.report.engine.nLayout.area.style.BorderInfo;
+import org.eclipse.birt.report.engine.nLayout.area.style.AreaConstants;
 import org.eclipse.birt.report.engine.nLayout.area.style.TextStyle;
 import org.eclipse.birt.report.engine.util.FlashFile;
 import org.eclipse.birt.report.engine.util.SvgFile;
@@ -57,6 +56,12 @@ import com.lowagie.text.pdf.PdfTemplate;
 import com.lowagie.text.pdf.PdfTextArray;
 import com.lowagie.text.pdf.PdfWriter;
 
+/**
+ * Definition of the PDF page
+ *
+ * @since 3.3
+ *
+ */
 public class PDFPage extends AbstractPage {
 
 	/**
@@ -84,6 +89,15 @@ public class PDFPage extends AbstractPage {
 	private static Pattern PAGE_LINK_PATTERN = Pattern
 			.compile("^((([a-zA-Z]:))(/(\\w[\\w ]*.*))+\\.(pdf|PDF))+#page=(\\d+)$");
 
+	/**
+	 * Constructor of the PDF page
+	 *
+	 * @param pageWidth
+	 * @param pageHeight
+	 * @param document
+	 * @param writer
+	 * @param pageDevice
+	 */
 	public PDFPage(int pageWidth, int pageHeight, Document document, PdfWriter writer, PDFPageDevice pageDevice) {
 		super(pageWidth, pageHeight);
 		this.writer = writer;
@@ -168,8 +182,8 @@ public class PDFPage extends AbstractPage {
 			}
 		}
 
-		boolean xExtended = (repeat & BackgroundImageInfo.REPEAT_X) == BackgroundImageInfo.REPEAT_X;
-		boolean yExtended = (repeat & BackgroundImageInfo.REPEAT_Y) == BackgroundImageInfo.REPEAT_Y;
+		boolean xExtended = (repeat & AreaConstants.REPEAT_X) == AreaConstants.REPEAT_X;
+		boolean yExtended = (repeat & AreaConstants.REPEAT_Y) == AreaConstants.REPEAT_Y;
 		imageWidth = image.getWidth();
 		imageHeight = image.getHeight();
 
@@ -270,23 +284,23 @@ public class PDFPage extends AbstractPage {
 			int lineStyle) {
 		// if the border does NOT have color or the line width of the border is
 		// zero or the lineStyle is "none", just return.
-		if (null == color || 0f == width || BorderInfo.BORDER_STYLE_NONE == lineStyle) // $NON-NLS-1$
+		if (null == color || 0f == width || AreaConstants.BORDER_STYLE_NONE == lineStyle) // $NON-NLS-1$
 		{
 			return;
 		}
 		contentByte.saveState();
-		if (BorderInfo.BORDER_STYLE_SOLID == lineStyle) // $NON-NLS-1$
+		if (AreaConstants.BORDER_STYLE_SOLID == lineStyle) // $NON-NLS-1$
 		{
 			drawRawLine(startX, startY, endX, endY, width, color, contentByte);
-		} else if (BorderInfo.BORDER_STYLE_DASHED == lineStyle) // $NON-NLS-1$
+		} else if (AreaConstants.BORDER_STYLE_DASHED == lineStyle) // $NON-NLS-1$
 		{
 			contentByte.setLineDash(3 * width, 2 * width, 0f);
 			drawRawLine(startX, startY, endX, endY, width, color, contentByte);
-		} else if (BorderInfo.BORDER_STYLE_DOTTED == lineStyle) // $NON-NLS-1$
+		} else if (AreaConstants.BORDER_STYLE_DOTTED == lineStyle) // $NON-NLS-1$
 		{
 			contentByte.setLineDash(width, width, 0f);
 			drawRawLine(startX, startY, endX, endY, width, color, contentByte);
-		} else if (BorderInfo.BORDER_STYLE_DOUBLE == lineStyle) // $NON-NLS-1$
+		} else if (AreaConstants.BORDER_STYLE_DOUBLE == lineStyle) // $NON-NLS-1$
 		{
 			return;
 		}
@@ -302,10 +316,9 @@ public class PDFPage extends AbstractPage {
 	@Override
 	protected void drawText(String text, float textX, float textY, float baseline, float width, float height,
 			TextStyle textStyle) {
-		drawText(text, textX, textY + baseline, width, height, textStyle.getFontInfo(),
+		drawText1(text, textX, textY + baseline, textStyle.getFontInfo(),
 				convertToPoint(textStyle.getLetterSpacing()), convertToPoint(textStyle.getWordSpacing()),
-				textStyle.getColor(), textStyle.isLinethrough(), textStyle.isOverline(), textStyle.isUnderline(),
-				textStyle.getAlign());
+				textStyle.getColor(), textStyle.getAlign());
 		if (textStyle.isHasHyperlink()) {
 			FontInfo fontInfo = textStyle.getFontInfo();
 			float lineWidth = fontInfo.getLineWidth();
@@ -314,12 +327,22 @@ public class PDFPage extends AbstractPage {
 		}
 	}
 
-	private void drawText(String text, float textX, float textY, float width, float height, FontInfo fontInfo,
-			float characterSpacing, float wordSpacing, Color color, boolean linethrough, boolean overline,
-			boolean underline, CSSValue align) {
+	private void drawText1(String text, float textX, float textY, FontInfo fontInfo,
+			float characterSpacing, float wordSpacing, Color color, CSSValue align) {
 		drawText(text, textX, textY, fontInfo, characterSpacing, wordSpacing, color, align);
 	}
 
+	/**
+	 * Draw the total page
+	 *
+	 * @param text
+	 * @param textX
+	 * @param textY
+	 * @param width
+	 * @param height
+	 * @param textInfo
+	 * @param scale
+	 */
 	public void drawTotalPage(String text, int textX, int textY, int width, int height, TextStyle textInfo,
 			float scale) {
 		PdfTemplate template = pageDevice.getPDFTemplate(scale);
@@ -333,14 +356,35 @@ public class PDFPage extends AbstractPage {
 		}
 	}
 
+	/**
+	 * Create the bookmarks
+	 *
+	 * @param bookmark
+	 * @param x
+	 * @param y
+	 * @param width
+	 * @param height
+	 */
 	public void createBookmark(String bookmark, int x, int y, int width, int height) {
-		createBookmark(bookmark, convertToPoint(x), convertToPoint(y), convertToPoint(width), convertToPoint(height));
+		createBookmark(bookmark, convertToPoint(y));
 	}
 
-	private void createBookmark(String bookmark, float x, float y, float width, float height) {
+	private void createBookmark(String bookmark, float y) {
 		contentByte.localDestination(bookmark, new PdfDestination(PdfDestination.XYZ, -1, transformY(y), 0));
 	}
 
+	/**
+	 * Create the hyperlinks
+	 *
+	 * @param hyperlink
+	 * @param bookmark
+	 * @param targetWindow
+	 * @param type
+	 * @param x
+	 * @param y
+	 * @param width
+	 * @param height
+	 */
 	public void createHyperlink(String hyperlink, String bookmark, String targetWindow, int type, int x, int y,
 			int width, int height) {
 		createHyperlink(hyperlink, bookmark, targetWindow, type, convertToPoint(x), convertToPoint(y),
@@ -354,6 +398,15 @@ public class PDFPage extends AbstractPage {
 				createPdfAction(hyperlink, bookmark, targetWindow, type)));
 	}
 
+	/**
+	 * Create the total page template
+	 *
+	 * @param x
+	 * @param y
+	 * @param width
+	 * @param height
+	 * @param scale
+	 */
 	public void createTotalPageTemplate(int x, int y, int width, int height, float scale) {
 		createTotalPageTemplate(convertToPoint(x), convertToPoint(y), convertToPoint(width), convertToPoint(height),
 				scale);
@@ -426,7 +479,8 @@ public class PDFPage extends AbstractPage {
 			contentByte.setWordSpacing(wordSpacing);
 		}
 		setTextMatrix(contentByte, fontInfo, textX, transformY(textY, 0, containerHeight));
-		if ((font.getFontType() == BaseFont.FONT_TYPE_TTUNI) && IStyle.JUSTIFY_VALUE.equals(align) && wordSpacing > 0) {
+		if ((font.getFontType() == BaseFont.FONT_TYPE_TTUNI) && CSSValueConstants.JUSTIFY_VALUE.equals(align)
+				&& wordSpacing > 0) {
 			int idx = text.indexOf(' ');
 			if (idx >= 0) {
 				float spaceCorrection = -wordSpacing * 1000 / fontSize;

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/IRenderOption.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/IRenderOption.java
@@ -22,20 +22,63 @@ import java.util.Map;
  */
 public interface IRenderOption extends ITaskOption {
 
+	/**
+	 * Property of format
+	 */
 	String OUTPUT_FORMAT = "Format"; //$NON-NLS-1$
+
+	/**
+	 * Property of output format HTML
+	 */
 	String OUTPUT_FORMAT_HTML = "html"; //$NON-NLS-1$
+
+	/**
+	 * Property of output format PDF
+	 */
 	String OUTPUT_FORMAT_PDF = "pdf"; //$NON-NLS-1$
+
+	/**
+	 * Property of output format FO
+	 */
 	String OUTPUT_FORMAT_FO = "fo"; //$NON-NLS-1$
+
+	/**
+	 * Property of emitter id HTML
+	 */
 	String OUTPUT_EMITTERID_HTML = "org.eclipse.birt.report.engine.emitter.html";
+
+	/**
+	 * Property of emitter id PDF
+	 */
 	String OUTPUT_EMITTERID_PDF = "org.eclipse.birt.report.engine.emitter.pdf";
+
+	/**
+	 * Property of emitter id
+	 */
 	String EMITTER_ID = "emitterID"; //$NON-NLS-1$
 
+	/**
+	 * Property of output file
+	 */
 	String OUTPUT_FILE_NAME = "outputFile"; //$NON-NLS-1$
+	/**
+	 * Property of output stream
+	 */
 	String OUTPUT_STREAM = "outputStream"; //$NON-NLS-1$
 
+	/**
+	 * Property of image handler
+	 */
 	String IMAGE_HANDLER = "imageHandler"; //$NON-NLS-1$
+
+	/**
+	 * Property of action handler
+	 */
 	String ACTION_HANDLER = "actionHandler"; //$NON-NLS-1$
 
+	/**
+	 * Property for local
+	 */
 	String LOCALE = "locale"; //$NON-NLS-1$
 
 	/** The DPI which layout engine uses to convert pixel to an abstract length */
@@ -44,8 +87,14 @@ public interface IRenderOption extends ITaskOption {
 	/** The DPI which chart engine uses to generate charts */
 	String CHART_DPI = "ChartDpi";
 
+	/**
+	 * Supported image formats
+	 */
 	String SUPPORTED_IMAGE_FORMATS = "supportedImageFormats";
 
+	/**
+	 * Property of base URL
+	 */
 	String BASE_URL = "baseUrl";
 
 	/**
@@ -59,6 +108,9 @@ public interface IRenderOption extends ITaskOption {
 	 */
 	String APP_BASE_URL = BASE_URL; // $NON-NLS-1$
 
+	/**
+	 * Property to set output display to none
+	 */
 	String OUTPUT_DISPLAY_NONE = "org.eclipse.birt.report.engine.api.IRenderOption.outputDisplayNone";
 
 	/**
@@ -73,14 +125,19 @@ public interface IRenderOption extends ITaskOption {
 	 */
 	String CLOSE_OUTPUTSTREAM_ON_EXIT = "closeOutputStreamOnExit";
 
+	/**
+	 * Property for report size
+	 */
 	String REPORTLET_SIZE = "reportletSize";
 
 	/**
-	 * @return
+	 * Get the output settings
+	 *
 	 * @deprecated use getOptions instead
+	 * @return Return the output settings
 	 */
 	@Deprecated
-	Map getOutputSetting();
+	Map<String, Object> getOutputSetting();
 
 	/**
 	 * Set output format.
@@ -92,7 +149,7 @@ public interface IRenderOption extends ITaskOption {
 	/**
 	 * Get output format.
 	 *
-	 * @return
+	 * @return Return the output format
 	 */
 	String getOutputFormat();
 
@@ -163,39 +220,67 @@ public interface IRenderOption extends ITaskOption {
 	void setAppBaseURL(String appBaseURL);
 
 	/**
+	 * Set the action handler
+	 *
 	 * @deprecated
 	 * @param handler
 	 */
 	@Deprecated
 	void setActionHandle(IHTMLActionHandler handler);
 
+	/**
+	 * Set the action handler
+	 *
+	 * @param handler
+	 */
 	void setActionHandler(IHTMLActionHandler handler);
 
 	/**
+	 * Get the action handler
+	 *
 	 * @deprecated
-	 * @return
+	 * @return Return the action handler
 	 */
 	@Deprecated
 	IHTMLActionHandler getActionHandle();
 
+	/**
+	 * Get the action handler
+	 *
+	 * @return Return the action handler
+	 */
 	IHTMLActionHandler getActionHandler();
 
 	/**
+	 * Set the image handler
+	 *
 	 * @deprecated
 	 * @param handler
 	 */
 	@Deprecated
 	void setImageHandle(IHTMLImageHandler handler);
 
+	/**
+	 * Set the image handler
+	 *
+	 * @param handler
+	 */
 	void setImageHandler(IHTMLImageHandler handler);
 
 	/**
+	 * Get the image handler
+	 *
 	 * @deprecated
-	 * @return
+	 * @return Return the image handler
 	 */
 	@Deprecated
 	IHTMLImageHandler getImageHandle();
 
+	/**
+	 * Get the image handler
+	 *
+	 * @return Return the image handler
+	 */
 	IHTMLImageHandler getImageHandler();
 
 	/**

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/ITaskOption.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/ITaskOption.java
@@ -16,14 +16,20 @@ package org.eclipse.birt.report.engine.api;
 
 import java.util.Map;
 
+/**
+ * Define the interface of task options
+ *
+ * @since 3.3
+ *
+ */
 public interface ITaskOption {
 
 	/**
-	 * get all the options defined in this object
+	 * Get all the options defined in this object
 	 *
-	 * @return
+	 * @return Return the task options
 	 */
-	Map getOptions();
+	Map<String, Object> getOptions();
 
 	/**
 	 * set the option value.

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/RenderOption.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/RenderOption.java
@@ -40,7 +40,7 @@ public class RenderOption extends TaskOption implements IRenderOption {
 	 *
 	 * @param options
 	 */
-	public RenderOption(Map options) {
+	public RenderOption(Map<String, Object> options) {
 		super(options);
 	}
 
@@ -61,7 +61,7 @@ public class RenderOption extends TaskOption implements IRenderOption {
 	 */
 	@Deprecated
 	@Override
-	public Map getOutputSetting() {
+	public Map<String, Object> getOutputSetting() {
 		return options;
 	}
 
@@ -200,7 +200,7 @@ public class RenderOption extends TaskOption implements IRenderOption {
 	/**
 	 * Set app base url
 	 *
-	 * @param appBaseURL the app base url
+	 * @param appBaseUrl the app base url
 	 */
 	@Override
 	public void setAppBaseURL(String appBaseUrl) {
@@ -223,8 +223,10 @@ public class RenderOption extends TaskOption implements IRenderOption {
 	}
 
 	/**
+	 * Get the action handler
+	 *
 	 * @deprecated
-	 * @return
+	 * @return Return the action handler
 	 */
 	@Deprecated
 	@Override
@@ -257,8 +259,10 @@ public class RenderOption extends TaskOption implements IRenderOption {
 	}
 
 	/**
+	 * Get the image handler
+	 *
 	 * @deprecated
-	 * @return
+	 * @return Return the image handler
 	 */
 	@Deprecated
 	@Override
@@ -277,6 +281,8 @@ public class RenderOption extends TaskOption implements IRenderOption {
 
 	/**
 	 * If the output stream needs to be closed on exit.
+	 *
+	 * @return true, output stream must be closed on exit
 	 */
 	public boolean needCloseOutputStreamOnExit() {
 		return getBooleanOption(CLOSE_OUTPUTSTREAM_ON_EXIT, true);

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/TOCStyle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/TOCStyle.java
@@ -19,80 +19,270 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.eclipse.birt.report.engine.api.script.ScriptException;
 import org.eclipse.birt.report.engine.api.script.instance.IScriptStyle;
 
+/**
+ * Definition of the TOC styles
+ *
+ * @since 3.3
+ *
+ */
 public class TOCStyle implements IScriptStyle, Serializable {
 
 	/**
-	 *
+	 * constant of serial version UID
 	 */
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Style property: background-attachment
+	 */
 	public static final String BACKGROUND_ATTACHMENT = "background-attachment";
+	/**
+	 * Style property: background-color
+	 */
 	public static final String BACKGROUND_COLOR = "background-color";
+	/**
+	 * Style property: background-image
+	 */
 	public static final String BACKGROUND_IMAGE = "background-image";
+	/**
+	 * Style property: background-image-type
+	 */
+	public static final String BACKGROUND_IMAGE_TYPE = "background-image-type";
+	/**
+	 * Style property: background-position-x
+	 */
 	public static final String BACKGROUND_POSITION_X = "background-position-x";
+	/**
+	 * Style property: background-position-y
+	 */
 	public static final String BACKGROUND_POSITION_Y = "background-position-y";
+	/**
+	 * Style property: background-repeat
+	 */
 	public static final String BACKGROUND_REPEAT = "background-repeat";
+	/**
+	 * Style property: border-bottom-color
+	 */
 	public static final String BORDER_BOTTOM_COLOR = "border-bottom-color";
+	/**
+	 * Style property: border-top-color
+	 */
 	public static final String BORDER_TOP_COLOR = "border-top-color";
+	/**
+	 * Style property: border-left-color
+	 */
 	public static final String BORDER_LEFT_COLOR = "border-left-color";
+	/**
+	 * Style property: border-right-color
+	 */
 	public static final String BORDER_RIGHT_COLOR = "border-right-color";
+	/**
+	 * Style property: border-bottom-width
+	 */
 	public static final String BORDER_BOTTOM_WIDTH = "border-bottom-width";
+	/**
+	 * Style property: border-top-width
+	 */
 	public static final String BORDER_TOP_WIDTH = "border-top-width";
+	/**
+	 * Style property: border-left-width
+	 */
 	public static final String BORDER_LEFT_WIDTH = "border-left-width";
+	/**
+	 * Style property: border-right-width
+	 */
 	public static final String BORDER_RIGHT_WIDTH = "border-right-width";
+	/**
+	 * Style property: border-bottom-style
+	 */
 	public static final String BORDER_BOTTOM_STYLE = "border-bottom-style";
+	/**
+	 * Style property: border-top-style
+	 */
 	public static final String BORDER_TOP_STYLE = "border-top-style";
+	/**
+	 * Style property: border-left-style
+	 */
 	public static final String BORDER_LEFT_STYLE = "border-left-style";
+	/**
+	 * Style property: border-right-style
+	 */
 	public static final String BORDER_RIGHT_STYLE = "border-right-style";
+
+	/**
+	 * Style property: can-shrink
+	 */
 	public static final String CAN_SHRINK = "can-shrink";
+	/**
+	 * Style property: color
+	 */
 	public static final String COLOR = "color";
+	/**
+	 * Style property: date-format
+	 */
 	public static final String DATE_FORMAT = "date-format";
+	/**
+	 * Style property: direction
+	 */
 	public static final String DIRECTION = "direction"; // bidi_hcg
+	/**
+	 * Style property: display
+	 */
 	public static final String DISPLAY = "display";
+
+	/**
+	 * Style property: font-family
+	 */
 	public static final String FONT_FAMILY = "font-family";
+	/**
+	 * Style property: font-size
+	 */
 	public static final String FONT_SIZE = "font-size";
+	/**
+	 * Style property: font-style
+	 */
 	public static final String FONT_STYLE = "font-style";
+	/**
+	 * Style property: font-variant
+	 */
 	public static final String FONT_VARIANT = "font-variant";
+	/**
+	 * Style property: font-weight
+	 */
 	public static final String FONT_WEIGHT = "font-weight";
+	/**
+	 * Style property: letter-spacing
+	 */
 	public static final String LETTER_SPACING = "letter-spacing";
+	/**
+	 * Style property: line-height
+	 */
 	public static final String LINE_HEIGHT = "line-height";
+
+	/**
+	 * Style property: margin-bottom
+	 */
 	public static final String MARGIN_BOTTOM = "margin-bottom";
+	/**
+	 * Style property: margin-left
+	 */
 	public static final String MARGIN_LEFT = "margin-left";
+	/**
+	 * Style property: margin-right
+	 */
 	public static final String MARGIN_RIGHT = "margin-right";
+	/**
+	 * Style property: margin-top
+	 */
 	public static final String MARGIN_TOP = "margin-top";
+	/**
+	 * Style property: margin-page
+	 */
 	public static final String MASTER_PAGE = "master-page";
+
+	/**
+	 * Style property: number-format
+	 */
 	public static final String NUMBER_FORMAT = "number-format";
+	/**
+	 * Style property: padding-bottom
+	 */
 	public static final String PADDING_BOTTOM = "padding-bottom";
+	/**
+	 * Style property: padding-left
+	 */
 	public static final String PADDING_LEFT = "padding-left";
+	/**
+	 * Style property: padding-right
+	 */
 	public static final String PADDING_RIGHT = "padding-right";
+	/**
+	 * Style property: padding-top
+	 */
 	public static final String PADDING_TOP = "padding-top";
+
+	/**
+	 * Style property: page-break-after
+	 */
 	public static final String PAGE_BREAK_AFTER = "page-break-after";
+	/**
+	 * Style property: page-break-before
+	 */
 	public static final String PAGE_BREAK_BEFORE = "page-break-before";
+	/**
+	 * Style property: page-break-inside
+	 */
 	public static final String PAGE_BREAK_INSIDE = "page-break-inside";
+	/**
+	 * Style property: show-if-blank
+	 */
 	public static final String SHOW_IF_BLANK = "show-if-blank";
+	/**
+	 * Style property: string-format
+	 */
 	public static final String STRING_FORMAT = "string-format";
+
+	/**
+	 * Style property: text-align
+	 */
 	public static final String TEXT_ALIGN = "text-align";
+	/**
+	 * Style property: text-indent
+	 */
 	public static final String TEXT_INDENT = "text-indent";
+	/**
+	 * Style property: text-line-through
+	 */
 	public static final String TEXT_LINE_THROUGH = "text-line-through";
+	/**
+	 * Style property: text-overline
+	 */
 	public static final String TEXT_OVERLINE = "text-overline";
+	/**
+	 * Style property: text-transform
+	 */
 	public static final String TEXT_TRANSFORM = "text-transform";
+	/**
+	 * Style property: text-underline
+	 */
 	public static final String TEXT_UNDERLINE = "text-underline";
+
+	/**
+	 * Style property: vertical-align
+	 */
 	public static final String VERTICAL_ALIGN = "vertical-align";
+	/**
+	 * Style property: visible-format
+	 */
 	public static final String VISIBLE_FORMAT = "visible-format";
+	/**
+	 * Style property: white-space
+	 */
 	public static final String WHITE_SPACE = "white-space";
+	/**
+	 * Style property: word-spacing
+	 */
 	public static final String WORD_SPACING = "word-spacing";
+	/**
+	 * Style property: date-local
+	 */
 	public static final String DATE_LOCALE = "date-locale";
+	/**
+	 * Style property: number-local
+	 */
 	public static final String NUMBER_LOCALE = "number-locale";
+	/**
+	 * Style property: string-local
+	 */
 	public static final String STRING_LOCALE = "string-locale";
 
 	private HashMap<String, String> properties = new HashMap<>();
 
 	@Override
 	public String getBackgroundAttachement() {
-		return (String) properties.get(BACKGROUND_ATTACHMENT);
+		return properties.get(BACKGROUND_ATTACHMENT);
 	}
 
 	/**
@@ -100,7 +290,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBackgroundAttachment() {
-		return (String) properties.get(BACKGROUND_ATTACHMENT);
+		return properties.get(BACKGROUND_ATTACHMENT);
 	}
 
 	/**
@@ -108,7 +298,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBackgroundColor() {
-		return (String) properties.get(BACKGROUND_COLOR);
+		return properties.get(BACKGROUND_COLOR);
 	}
 
 	/**
@@ -116,7 +306,15 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBackgroundImage() {
-		return (String) properties.get(BACKGROUND_IMAGE);
+		return properties.get(BACKGROUND_IMAGE);
+	}
+
+	/**
+	 * Get the background image source type
+	 */
+	@Override
+	public String getBackgroundImageType() {
+		return properties.get(BACKGROUND_IMAGE_TYPE);
 	}
 
 	/**
@@ -125,7 +323,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBackgroundPositionX() {
-		return (String) properties.get(BACKGROUND_POSITION_X);
+		return properties.get(BACKGROUND_POSITION_X);
 	}
 
 	/**
@@ -134,7 +332,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBackgroundPositionY() {
-		return (String) properties.get(BACKGROUND_POSITION_Y);
+		return properties.get(BACKGROUND_POSITION_Y);
 	}
 
 	/**
@@ -143,7 +341,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBackgroundRepeat() {
-		return (String) properties.get(BACKGROUND_REPEAT);
+		return properties.get(BACKGROUND_REPEAT);
 	}
 
 	/**
@@ -151,7 +349,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderBottomColor() {
-		return (String) properties.get(BORDER_BOTTOM_COLOR);
+		return properties.get(BORDER_BOTTOM_COLOR);
 	}
 
 	/**
@@ -160,7 +358,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderBottomStyle() {
-		return (String) properties.get(BORDER_BOTTOM_STYLE);
+		return properties.get(BORDER_BOTTOM_STYLE);
 	}
 
 	/**
@@ -168,7 +366,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderBottomWidth() {
-		return (String) properties.get(BORDER_BOTTOM_WIDTH);
+		return properties.get(BORDER_BOTTOM_WIDTH);
 	}
 
 	/**
@@ -176,7 +374,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderLeftColor() {
-		return (String) properties.get(BORDER_LEFT_COLOR);
+		return properties.get(BORDER_LEFT_COLOR);
 	}
 
 	/**
@@ -185,7 +383,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderLeftStyle() {
-		return (String) properties.get(BORDER_LEFT_STYLE);
+		return properties.get(BORDER_LEFT_STYLE);
 	}
 
 	/**
@@ -193,7 +391,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderLeftWidth() {
-		return (String) properties.get(BORDER_LEFT_WIDTH);
+		return properties.get(BORDER_LEFT_WIDTH);
 	}
 
 	/**
@@ -201,7 +399,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderRightColor() {
-		return (String) properties.get(BORDER_RIGHT_COLOR);
+		return properties.get(BORDER_RIGHT_COLOR);
 	}
 
 	/**
@@ -210,7 +408,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderRightStyle() {
-		return (String) properties.get(BORDER_RIGHT_STYLE);
+		return properties.get(BORDER_RIGHT_STYLE);
 	}
 
 	/**
@@ -218,7 +416,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderRightWidth() {
-		return (String) properties.get(BORDER_RIGHT_WIDTH);
+		return properties.get(BORDER_RIGHT_WIDTH);
 	}
 
 	/**
@@ -226,7 +424,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderTopColor() {
-		return (String) properties.get(BORDER_TOP_COLOR);
+		return properties.get(BORDER_TOP_COLOR);
 	}
 
 	/**
@@ -235,7 +433,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderTopStyle() {
-		return (String) properties.get(BORDER_TOP_STYLE);
+		return properties.get(BORDER_TOP_STYLE);
 	}
 
 	/**
@@ -243,7 +441,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getBorderTopWidth() {
-		return (String) properties.get(BORDER_TOP_WIDTH);
+		return properties.get(BORDER_TOP_WIDTH);
 	}
 
 	/**
@@ -251,7 +449,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getCanShrink() {
-		return (String) properties.get(CAN_SHRINK);
+		return properties.get(CAN_SHRINK);
 	}
 
 	/**
@@ -259,7 +457,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getColor() {
-		return (String) properties.get(COLOR);
+		return properties.get(COLOR);
 	}
 
 	/**
@@ -269,11 +467,16 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getDateFormat() {
-		return (String) properties.get(DATE_FORMAT);
+		return properties.get(DATE_FORMAT);
 	}
 
+	/**
+	 * Get the direction
+	 *
+	 * @return Return the direction
+	 */
 	public String getDirection() {
-		return (String) properties.get(DIRECTION);
+		return properties.get(DIRECTION);
 	}
 
 	/**
@@ -281,7 +484,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getDisplay() {
-		return (String) properties.get(DISPLAY);
+		return properties.get(DISPLAY);
 	}
 
 	/**
@@ -290,7 +493,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getFontFamily() {
-		return (String) properties.get(FONT_FAMILY);
+		return properties.get(FONT_FAMILY);
 	}
 
 	/**
@@ -299,7 +502,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getFontSize() {
-		return (String) properties.get(FONT_SIZE);
+		return properties.get(FONT_SIZE);
 	}
 
 	/**
@@ -308,7 +511,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getFontStyle() {
-		return (String) properties.get(FONT_STYLE);
+		return properties.get(FONT_STYLE);
 	}
 
 	/**
@@ -317,7 +520,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getFontVariant() {
-		return (String) properties.get(FONT_VARIANT);
+		return properties.get(FONT_VARIANT);
 	}
 
 	/**
@@ -326,7 +529,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getFontWeight() {
-		return (String) properties.get(FONT_WEIGHT);
+		return properties.get(FONT_WEIGHT);
 	}
 
 	/**
@@ -334,7 +537,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getLetterSpacing() {
-		return (String) properties.get(LETTER_SPACING);
+		return properties.get(LETTER_SPACING);
 	}
 
 	/**
@@ -342,7 +545,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getLineHeight() {
-		return (String) properties.get(LINE_HEIGHT);
+		return properties.get(LINE_HEIGHT);
 	}
 
 	/**
@@ -350,7 +553,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getMarginBottom() {
-		return (String) properties.get(MARGIN_BOTTOM);
+		return properties.get(MARGIN_BOTTOM);
 	}
 
 	/**
@@ -358,7 +561,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getMarginLeft() {
-		return (String) properties.get(MARGIN_LEFT);
+		return properties.get(MARGIN_LEFT);
 	}
 
 	/**
@@ -366,7 +569,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getMarginRight() {
-		return (String) properties.get(MARGIN_RIGHT);
+		return properties.get(MARGIN_RIGHT);
 	}
 
 	/**
@@ -374,7 +577,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getMarginTop() {
-		return (String) properties.get(MARGIN_TOP);
+		return properties.get(MARGIN_TOP);
 	}
 
 	/**
@@ -382,7 +585,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getMasterPage() {
-		return (String) properties.get(MASTER_PAGE);
+		return properties.get(MASTER_PAGE);
 	}
 
 	/**
@@ -392,7 +595,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getNumberFormat() {
-		return (String) properties.get(NUMBER_FORMAT);
+		return properties.get(NUMBER_FORMAT);
 	}
 
 	/**
@@ -400,7 +603,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getPaddingBottom() {
-		return (String) properties.get(PADDING_BOTTOM);
+		return properties.get(PADDING_BOTTOM);
 	}
 
 	/**
@@ -408,7 +611,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getPaddingLeft() {
-		return (String) properties.get(PADDING_LEFT);
+		return properties.get(PADDING_LEFT);
 	}
 
 	/**
@@ -416,7 +619,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getPaddingRight() {
-		return (String) properties.get(PADDING_RIGHT);
+		return properties.get(PADDING_RIGHT);
 	}
 
 	/**
@@ -424,7 +627,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getPaddingTop() {
-		return (String) properties.get(PADDING_TOP);
+		return properties.get(PADDING_TOP);
 	}
 
 	/**
@@ -432,7 +635,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getPageBreakAfter() {
-		return (String) properties.get(PAGE_BREAK_AFTER);
+		return properties.get(PAGE_BREAK_AFTER);
 	}
 
 	/**
@@ -440,7 +643,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getPageBreakBefore() {
-		return (String) properties.get(PAGE_BREAK_BEFORE);
+		return properties.get(PAGE_BREAK_BEFORE);
 	}
 
 	/**
@@ -448,7 +651,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getPageBreakInside() {
-		return (String) properties.get(PAGE_BREAK_INSIDE);
+		return properties.get(PAGE_BREAK_INSIDE);
 	}
 
 	/**
@@ -456,7 +659,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getShowIfBlank() {
-		return (String) properties.get(SHOW_IF_BLANK);
+		return properties.get(SHOW_IF_BLANK);
 	}
 
 	/**
@@ -466,7 +669,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getStringFormat() {
-		return (String) properties.get(STRING_FORMAT);
+		return properties.get(STRING_FORMAT);
 	}
 
 	/**
@@ -475,7 +678,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getTextAlign() {
-		return (String) properties.get(TEXT_ALIGN);
+		return properties.get(TEXT_ALIGN);
 	}
 
 	/**
@@ -483,7 +686,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getTextIndent() {
-		return (String) properties.get(TEXT_INDENT);
+		return properties.get(TEXT_INDENT);
 	}
 
 	/**
@@ -491,7 +694,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getTextLineThrough() {
-		return (String) properties.get(TEXT_LINE_THROUGH);
+		return properties.get(TEXT_LINE_THROUGH);
 	}
 
 	/**
@@ -499,7 +702,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getTextOverline() {
-		return (String) properties.get(TEXT_OVERLINE);
+		return properties.get(TEXT_OVERLINE);
 	}
 
 	/**
@@ -508,7 +711,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getTextTransform() {
-		return (String) properties.get(TEXT_TRANSFORM);
+		return properties.get(TEXT_TRANSFORM);
 	}
 
 	/**
@@ -516,7 +719,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getTextUnderline() {
-		return (String) properties.get(TEXT_UNDERLINE);
+		return properties.get(TEXT_UNDERLINE);
 	}
 
 	/**
@@ -525,7 +728,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getVerticalAlign() {
-		return (String) properties.get(VERTICAL_ALIGN);
+		return properties.get(VERTICAL_ALIGN);
 	}
 
 	/**
@@ -544,7 +747,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getVisibleFormat() {
-		return (String) properties.get(VISIBLE_FORMAT);
+		return properties.get(VISIBLE_FORMAT);
 	}
 
 	/**
@@ -552,7 +755,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getWhiteSpace() {
-		return (String) properties.get(WHITE_SPACE);
+		return properties.get(WHITE_SPACE);
 	}
 
 	/**
@@ -560,7 +763,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 */
 	@Override
 	public String getWordSpacing() {
-		return (String) properties.get(WORD_SPACING);
+		return properties.get(WORD_SPACING);
 	}
 
 	@Override
@@ -593,11 +796,19 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	}
 
 	/**
+	 * Set the background image source type
+	 */
+	@Override
+	public void setBackgroundImageType(String imageSourceType) {
+		setProperty(BACKGROUND_IMAGE_TYPE, imageSourceType);
+	}
+
+	/**
 	 * Set the X (horizontal) position of the background image
 	 *
 	 */
 	@Override
-	public void setBackgroundPositionX(String x) throws ScriptException {
+	public void setBackgroundPositionX(String x) {
 		setProperty(BACKGROUND_POSITION_X, x);
 	}
 
@@ -606,7 +817,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 *
 	 */
 	@Override
-	public void setBackgroundPositionY(String y) throws ScriptException {
+	public void setBackgroundPositionY(String y) {
 		setProperty(BACKGROUND_POSITION_Y, y);
 	}
 
@@ -745,6 +956,11 @@ public class TOCStyle implements IScriptStyle, Serializable {
 		setProperty(DATE_FORMAT, dateTimeFormat);
 	}
 
+	/**
+	 * Set direction
+	 *
+	 * @param direction
+	 */
 	public void setDirection(String direction) {
 		setProperty(DIRECTION, direction);
 	}
@@ -963,7 +1179,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 * Set the text line through
 	 */
 	@Override
-	public void setTextLineThrough(String through) throws ScriptException {
+	public void setTextLineThrough(String through) {
 		setProperty(TEXT_LINE_THROUGH, through);
 	}
 
@@ -971,7 +1187,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 * Set the text overline
 	 */
 	@Override
-	public void setTextOverline(String overline) throws ScriptException {
+	public void setTextOverline(String overline) {
 		setProperty(TEXT_OVERLINE, overline);
 	}
 
@@ -988,7 +1204,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	 * Set the text underline
 	 */
 	@Override
-	public void setTextUnderline(String underline) throws ScriptException {
+	public void setTextUnderline(String underline) {
 		setProperty(TEXT_UNDERLINE, underline);
 	}
 
@@ -1040,7 +1256,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 
 	@Override
 	public String getDateLocale() {
-		return (String) properties.get(DATE_LOCALE);
+		return properties.get(DATE_LOCALE);
 	}
 
 	@Override
@@ -1050,7 +1266,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 
 	@Override
 	public String getNumberLocale() {
-		return (String) properties.get(NUMBER_LOCALE);
+		return properties.get(NUMBER_LOCALE);
 	}
 
 	@Override
@@ -1060,7 +1276,7 @@ public class TOCStyle implements IScriptStyle, Serializable {
 
 	@Override
 	public String getStringLocale() {
-		return (String) properties.get(STRING_LOCALE);
+		return properties.get(STRING_LOCALE);
 	}
 
 	@Override
@@ -1070,6 +1286,9 @@ public class TOCStyle implements IScriptStyle, Serializable {
 
 	/**
 	 * Set property.
+	 *
+	 * @param name
+	 * @param value
 	 */
 	public void setProperty(String name, String value) {
 		if (value != null) {
@@ -1080,9 +1299,11 @@ public class TOCStyle implements IScriptStyle, Serializable {
 	}
 
 	/**
-	 * Get property.
+	 * Get properties.
+	 *
+	 * @return Return properties
 	 */
-	public Map getProperties() {
+	public Map<String, String> getProperties() {
 		return properties;
 	}
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/TaskOption.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/TaskOption.java
@@ -17,17 +17,23 @@ package org.eclipse.birt.report.engine.api;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Define the class of task options
+ *
+ * @since 3.3
+ *
+ */
 public class TaskOption implements ITaskOption {
 	/**
 	 * a hash map that stores the rendering options
 	 */
-	protected Map options;
+	protected Map<String, Object> options;
 
 	/**
 	 * constructor
 	 */
 	public TaskOption() {
-		options = new HashMap();
+		options = new HashMap<String, Object>();
 	}
 
 	/**
@@ -35,7 +41,7 @@ public class TaskOption implements ITaskOption {
 	 *
 	 * @param options
 	 */
-	public TaskOption(Map options) {
+	public TaskOption(Map<String, Object> options) {
 		this.options = options;
 	}
 
@@ -75,7 +81,7 @@ public class TaskOption implements ITaskOption {
 	 * @return options
 	 */
 	@Override
-	public Map getOptions() {
+	public Map<String, Object> getOptions() {
 		return options;
 	}
 
@@ -110,6 +116,13 @@ public class TaskOption implements ITaskOption {
 		return defaultValue;
 	}
 
+	/**
+	 * Get the options int based
+	 *
+	 * @param name
+	 * @param defaultValue
+	 * @return Return the options int based
+	 */
 	public int getIntOption(String name, int defaultValue) {
 		Object value = options.get(name);
 		if (value instanceof Integer) {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/script/instance/IScriptStyle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/script/instance/IScriptStyle.java
@@ -14,6 +14,12 @@ package org.eclipse.birt.report.engine.api.script.instance;
 
 import org.eclipse.birt.report.engine.api.script.ScriptException;
 
+/**
+ * Definition of the script style methods
+ *
+ * @since 3.3
+ *
+ */
 public interface IScriptStyle {
 
 	/**
@@ -28,6 +34,8 @@ public interface IScriptStyle {
 	 * org.eclipse.birt.report.model.api.elements.DesignChoiceConstants.FORMAT_TYPE_EXCEL
 	 * org.eclipse.birt.report.model.api.elements.DesignChoiceConstants.FORMAT_TYPE_WORD
 	 * org.eclipse.birt.report.model.api.elements.DesignChoiceConstants.FORMAT_TYPE_POWERPOINT
+	 *
+	 * @return Return format to hide in. Should be one of
 	 *
 	 */
 	String getVisibleFormat();
@@ -52,102 +60,140 @@ public interface IScriptStyle {
 
 	/**
 	 * Get the letter spacing
+	 *
+	 * @return Return the letter spacing
 	 */
 	String getLetterSpacing();
 
 	/**
 	 * Set the letter spacing
+	 *
+	 * @param spacing
 	 */
 	void setLetterSpacing(String spacing);
 
 	/**
 	 * Get the line height
+	 *
+	 * @return Return the line height
 	 */
 	String getLineHeight();
 
 	/**
 	 * Set the line height
+	 *
+	 * @param lineHeight
 	 */
 	void setLineHeight(String lineHeight);
 
 	/**
 	 * Get the text alignment. Valid return types are LEFT, RIGHT, CENTER and
 	 * JUSTIFY.
+	 *
+	 * @return Return the text alignment
 	 */
 	String getTextAlign();
 
 	/**
 	 * Set the text alignment. Valid return types are LEFT, RIGHT, CENTER and
 	 * JUSTIFY.
+	 *
+	 * @param align
 	 */
 	void setTextAlign(String align);
 
 	/**
 	 * Get the text indent
+	 *
+	 * @return Return the text indent
 	 */
 	String getTextIndent();
 
 	/**
 	 * Set text indent
+	 *
+	 * @param indent
 	 */
 	void setTextIndent(String indent);
 
 	/**
 	 * Get the text transform. Valid return values are NONE, CAPITALIZE, UPPERCASE
 	 * and LOWERCASE.
+	 *
+	 * @return Return the text transform
 	 */
 	String getTextTransform();
 
 	/**
 	 * Set the text transform. Valid transform values are NONE, CAPITALIZE,
 	 * UPPERCASE and LOWERCASE.
+	 *
+	 * @param transform
 	 */
 	void setTextTransform(String transform);
 
 	/**
 	 * Get the vertical alignment. Valid return values are BASELINE, SUB, SUPER,
 	 * TOP, TEXT_TOP, MIDDLE, BOTTOM and TEXT_BOTTOM
+	 *
+	 * @return Return the vertical alignment
 	 */
 	String getVerticalAlign();
 
 	/**
 	 * Set the vertical alignment. Valid values are BASELINE, SUB, SUPER, TOP,
 	 * TEXT_TOP, MIDDLE, BOTTOM and TEXT_BOTTOM
+	 *
+	 * @param valign
 	 */
 	void setVerticalAlign(String valign);
 
 	/**
 	 * Get the whitespace. Valid return values are NORMAL, PRE and NOWRAP
+	 *
+	 * @return Return the whitespace option
 	 */
 	String getWhiteSpace();
 
 	/**
 	 * Set the whitespace. The values retruned can be NORMAL, PRE and NOWRAP
+	 *
+	 * @param whitespace
 	 */
 	void setWhiteSpace(String whitespace);
 
 	/**
 	 * Get the word spacing
+	 *
+	 * @return Return the word spacing
 	 */
 	String getWordSpacing();
 
 	/**
 	 * Set the word spacing
+	 *
+	 * @param wordspacing
 	 */
 	void setWordSpacing(String wordspacing);
 
 	/**
 	 * Get the font color
+	 *
+	 * @return Return the font color
 	 */
 	String getColor();
 
 	/**
 	 * Set the font color
+	 *
+	 * @param color
 	 */
 	void setColor(String color);
 
 	/**
 	 * Get the attachement type (either SCROLL or FIXED)
+	 *
+	 * @return Return the attachment type
 	 *
 	 * @deprecated replaced by getBackgroundAttachment()
 	 */
@@ -157,6 +203,8 @@ public interface IScriptStyle {
 	/**
 	 * Set the attachement type (either SCROLL or FIXED)
 	 *
+	 * @param attachement
+	 *
 	 * @deprecated replaced by setBackgroundAttachment( String attachment )
 	 */
 	@Deprecated
@@ -164,321 +212,458 @@ public interface IScriptStyle {
 
 	/**
 	 * Get the attachment type (either SCROLL or FIXED)
+	 *
+	 * @return Return the attachement type
 	 */
 	String getBackgroundAttachment();
 
 	/**
 	 * Set the attachment type (either SCROLL or FIXED)
+	 *
+	 * @param attachment
 	 */
 	void setBackgroundAttachment(String attachment);
 
 	/**
 	 * Get the background color
+	 *
+	 * @return Return the background color
 	 */
 	String getBackgroundColor();
 
 	/**
 	 * Set the background color
+	 *
+	 * @param color
 	 */
 	void setBackgroundColor(String color);
 
 	/**
 	 * Get the background image URI
+	 *
+	 * @return Return the background image URI
 	 */
 	String getBackgroundImage();
 
 	/**
 	 * Set the background image URI
+	 *
+	 * @param imageURI
 	 */
 	void setBackgroundImage(String imageURI);
 
 	/**
+	 * Get the background image source type
+	 *
+	 * @return Return the background image source type
+	 */
+	String getBackgroundImageType();
+
+	/**
+	 * Set the background image source type
+	 *
+	 * @param imageSourceType
+	 */
+	void setBackgroundImageType(String imageSourceType);
+
+	/**
 	 * Get the background repeat type (valid types are REPEAT, REPEAT_X, REPEAT_Y
 	 * and NO_REPEAT)
+	 *
+	 * @return Return the background repeat
 	 */
 	String getBackgroundRepeat();
 
 	/**
 	 * Set the background repeat type (valid types are REPEAT, REPEAT_X, REPEAT_Y
 	 * and NO_REPEAT)
+	 *
+	 * @param repeat
 	 */
 	void setBackgroundRepeat(String repeat);
 
 	/**
 	 * Get the bottom border color
+	 *
+	 * @return Return the bottom border color
 	 */
 	String getBorderBottomColor();
 
 	/**
 	 * Set the bottom border color
+	 *
+	 * @param color
 	 */
 	void setBorderBottomColor(String color);
 
 	/**
 	 * Get the top border color
+	 *
+	 * @return Return the top border color
 	 */
 	String getBorderTopColor();
 
 	/**
 	 * Set the top border color
+	 *
+	 * @param color
 	 */
 	void setBorderTopColor(String color);
 
 	/**
 	 * Get the right border color
+	 *
+	 * @return Return the right border color
 	 */
 	String getBorderRightColor();
 
 	/**
 	 * Set the right border color
+	 *
+	 * @param color
 	 */
 	void setBorderRightColor(String color);
 
 	/**
 	 * Get the left border color
+	 *
+	 * @return Return the left border color
 	 */
 	String getBorderLeftColor();
 
 	/**
 	 * Set the left border color
+	 *
+	 * @param color
 	 */
 	void setBorderLeftColor(String color);
 
 	/**
 	 * Get the bottom border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @return Return the bottom border style.
 	 */
 	String getBorderBottomStyle();
 
 	/**
 	 * Set the bottom border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @param borderstyle
 	 */
 	void setBorderBottomStyle(String borderstyle);
 
 	/**
 	 * Get the top border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @return Return the top border style.
 	 */
 	String getBorderTopStyle();
 
 	/**
 	 * Set the top border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @param borderstyle
 	 */
 	void setBorderTopStyle(String borderstyle);
 
 	/**
 	 * Get the left border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @return Return the left border style.
 	 */
 	String getBorderLeftStyle();
 
 	/**
 	 * Set the left border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @param borderstyle
 	 */
 	void setBorderLeftStyle(String borderstyle);
 
 	/**
 	 * Get the right border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @return Return the right border style.
 	 */
 	String getBorderRightStyle();
 
 	/**
 	 * Set the right border style. Valid styles are NONE, SOLID, DOTTED, DASHED,
 	 * DOUBLE, GROVE, RIDGE, INSET and OUTSET.
+	 *
+	 * @param borderstyle
 	 */
 	void setBorderRightStyle(String borderstyle);
 
 	/**
 	 * Get the bottom border width.
+	 * @return Return the bottom border width.
 	 */
 	String getBorderBottomWidth();
 
 	/**
 	 * Set the bottom border width.
+	 *
+	 * @param width
 	 */
 	void setBorderBottomWidth(String width);
 
 	/**
 	 * Get the top border width.
+	 *
+	 * @return Return the top border width.
 	 */
 	String getBorderTopWidth();
 
 	/**
 	 * Set the top border width.
+	 *
+	 * @param width
 	 */
 	void setBorderTopWidth(String width);
 
 	/**
 	 * Get the left border width.
+	 *
+	 * @return Return the left border width.
 	 */
 	String getBorderLeftWidth();
 
 	/**
 	 * Set the left border width.
+	 *
+	 * @param width
 	 */
 	void setBorderLeftWidth(String width);
 
 	/**
-	 * Get the right border width.
+	 * Get the left border width.
+	 *
+	 * @return Return the left border width.
 	 */
 	String getBorderRightWidth();
 
 	/**
 	 * Set the right border width.
+	 *
+	 * @param width
 	 */
 	void setBorderRightWidth(String width);
 
 	/**
 	 * Get the bottom margin
+	 *
+	 * @return Return the bottom margin
 	 */
 	String getMarginBottom();
 
 	/**
 	 * Set the bottom margin
+	 *
+	 * @param margin
 	 */
 	void setMarginBottom(String margin);
 
 	/**
 	 * Get the top margin
+	 *
+	 * @return Return the top margin
 	 */
 	String getMarginTop();
 
 	/**
 	 * Set the top margin
+	 *
+	 * @param margin
 	 */
 	void setMarginTop(String margin);
 
 	/**
 	 * Get the left margin
+	 *
+	 * @return Return the left margin
 	 */
 	String getMarginLeft();
 
 	/**
 	 * Set the left margin
+	 *
+	 * @param margin
 	 */
 	void setMarginLeft(String margin);
 
 	/**
 	 * Get the right margin
+	 *
+	 * @return Return the right margin
 	 */
 	String getMarginRight();
 
 	/**
 	 * Set the right margin
+	 *
+	 * @param margin
 	 */
 	void setMarginRight(String margin);
 
 	/**
 	 * Get the bottom padding.
+	 *
+	 * @return Return the bottom padding.
 	 */
 	String getPaddingBottom();
 
 	/**
 	 * Set the bottom padding.
+	 *
+	 * @param padding
 	 */
 	void setPaddingBottom(String padding);
 
 	/**
 	 * Get the top padding.
+	 *
+	 * @return Return the top padding.
 	 */
 	String getPaddingTop();
 
 	/**
 	 * Set the top padding.
+	 *
+	 * @param padding
 	 */
 	void setPaddingTop(String padding);
 
 	/**
 	 * Get the left padding.
+	 *
+	 * @return Return the left padding.
 	 */
 	String getPaddingLeft();
 
 	/**
 	 * Set the left padding.
+	 *
+	 * @param padding
 	 */
 	void setPaddingLeft(String padding);
 
 	/**
 	 * Get the right padding.
+	 *
+	 * @return Return the right padding.
 	 */
 	String getPaddingRight();
 
 	/**
 	 * Set the right padding.
+	 *
+	 * @param padding
 	 */
 	void setPaddingRight(String padding);
 
 	/**
 	 * Get the display type (valid types are BLOCK, INLINE and NONE)
+	 *
+	 * @return Return the display type (valid types are BLOCK, INLINE and NONE)
 	 */
 	String getDisplay();
 
 	/**
 	 * Set the display type (valid types are BLOCK, INLINE and NONE)
+	 *
+	 * @param display
 	 */
 	void setDisplay(String display);
 
 	/**
 	 * Get the master page
+	 *
+	 * @return Return the master page
 	 */
 	String getMasterPage();
 
 	/**
 	 * Set the master page
+	 *
+	 * @param masterPage
 	 */
 	void setMasterPage(String masterPage);
 
 	/**
 	 * Get the page break before.
+	 *
+	 * @return Return the page break before.
 	 */
 	String getPageBreakBefore();
 
 	/**
 	 * Set the page break before
+	 *
+	 * @param pageBreak
 	 */
 	void setPageBreakBefore(String pageBreak);
 
 	/**
 	 * Get the page break after.
+	 *
+	 * @return Return the page break after.
 	 */
 	String getPageBreakAfter();
 
 	/**
 	 * Set the page break after
+	 *
+	 * @param pageBreak
 	 */
 	void setPageBreakAfter(String pageBreak);
 
 	/**
 	 * Get the page break inside.
+	 *
+	 * @return Return the page break inside.
 	 */
 	String getPageBreakInside();
 
 	/**
 	 * Set the page break inside
+	 *
+	 * @param pageBreak
 	 */
 	void setPageBreakInside(String pageBreak);
 
 	/**
 	 * Show if blank?
+	 *
+	 * @return Show if blank?
 	 */
 	String getShowIfBlank();
 
 	/**
 	 * Set show if blank
+	 *
+	 * @param showIfBlank
 	 */
 	void setShowIfBlank(String showIfBlank);
 
 	/**
 	 * Can this element shrink?
+	 *
+	 * @return Can this element shrink?
 	 */
 	String getCanShrink();
 
 	/**
 	 * Can this element shrink?
+	 *
+	 * @param canShrink
 	 */
 	void setCanShrink(String canShrink);
 
@@ -569,11 +754,14 @@ public interface IScriptStyle {
 	/**
 	 * Get the font family
 	 *
+	 * @return Return the font family
 	 */
 	String getFontFamily();
 
 	/**
 	 * Set the font family
+	 *
+	 * @param fontFamily
 	 *
 	 */
 	void setFontFamily(String fontFamily);
@@ -581,11 +769,14 @@ public interface IScriptStyle {
 	/**
 	 * Get the font style
 	 *
+	 * @return Return the font style
 	 */
 	String getFontStyle();
 
 	/**
 	 * Set the font style
+	 *
+	 * @param fontStyle
 	 *
 	 */
 	void setFontStyle(String fontStyle);
@@ -593,90 +784,117 @@ public interface IScriptStyle {
 	/**
 	 * Get the font variant
 	 *
+	 * @return Return the font variant
 	 */
 	String getFontVariant();
 
 	/**
 	 * Set the font variant
 	 *
+	 * @param fontVariant
 	 */
 	void setFontVariant(String fontVariant);
 
 	/**
 	 * Get the font weight
 	 *
+	 * @return Return the font weight
 	 */
 	String getFontWeight();
 
 	/**
 	 * Set the font weight
 	 *
+	 * @param fontWeight
 	 */
 	void setFontWeight(String fontWeight);
 
 	/**
 	 * Get the font size
 	 *
+	 * @return Return the font size
 	 */
 	String getFontSize();
 
 	/**
 	 * Set the font size
 	 *
+	 * @param fontSize
 	 */
 	void setFontSize(String fontSize);
 
 	/**
 	 * Get the text underline
+	 *
+	 * @return Return the text underline
 	 */
 	String getTextUnderline();
 
 	/**
 	 * Set the text underline
+	 *
+	 * @param underline
+	 * @throws ScriptException
 	 */
 	void setTextUnderline(String underline) throws ScriptException;
 
 	/**
 	 * Get the text overline
+	 *
+	 * @return Return the text overline
 	 */
 	String getTextOverline();
 
 	/**
 	 * Set the text overline
+	 *
+	 * @param overline
+	 * @throws ScriptException
 	 */
 	void setTextOverline(String overline) throws ScriptException;
 
 	/**
 	 * Get the text line through
+	 *
+	 * @return Return the text line through
 	 */
 	String getTextLineThrough();
 
 	/**
 	 * Set the text line through
+	 *
+	 * @param through
+	 * @throws ScriptException
 	 */
 	void setTextLineThrough(String through) throws ScriptException;
 
 	/**
 	 * Get the X (horizontal) position of the background image
 	 *
+	 * @return Return the X (horizontal) position of the background image
 	 */
 	String getBackgroundPositionX();
 
 	/**
 	 * Set the X (horizontal) position of the background image
 	 *
+	 * @param x
+	 * @throws ScriptException
 	 */
 	void setBackgroundPositionX(String x) throws ScriptException;
 
 	/**
 	 * Get the Y (vertical) position of the background image
 	 *
+	 * @return Return the Y (vertical) position of the background image
 	 */
 	String getBackgroundPositionY();
 
 	/**
 	 * Set the Y (vertical) position of the background image
 	 *
+	 * @param y
+	 * @throws ScriptException
 	 */
 	void setBackgroundPositionY(String y) throws ScriptException;
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/content/IStyle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/content/IStyle.java
@@ -38,83 +38,317 @@ import org.w3c.dom.css.CSSValue;
 public interface IStyle extends CSSStyleDeclaration, StyleConstants, CSS2Properties, CSSConstants, CSSValueConstants,
 		BIRTConstants, BIRTValueConstants {
 
+	/**
+	 * Get the background position X
+	 *
+	 * @return Return the background position X
+	 */
 	String getBackgroundPositionX();
 
+	/**
+	 * Get the background position Y
+	 *
+	 * @return Return the background position Y
+	 */
 	String getBackgroundPositionY();
 
+	/**
+	 * Get the text underline
+	 *
+	 * @return Return the text underline
+	 */
 	String getTextUnderline();
 
+	/**
+	 * Get the text overline
+	 *
+	 * @return Return the text overline
+	 */
 	String getTextOverline();
 
+	/**
+	 * Get the text line through
+	 *
+	 * @return Return the text line through
+	 */
 	String getTextLineThrough();
 
+	/**
+	 * Get the master page
+	 *
+	 * @return Return the master page
+	 */
 	String getMasterPage();
 
+	/**
+	 * Get the option show if blank
+	 *
+	 * @return Return the option show if blank
+	 */
 	String getShowIfBlank();
 
+	/**
+	 * Get the option can shrink
+	 *
+	 * @return Return the option can shrink
+	 */
 	String getCanShrink();
 
+	/**
+	 * Get the string format
+	 *
+	 * @return Return the string format
+	 */
 	String getStringFormat();
 
+	/**
+	 * Get the number format
+	 *
+	 * @return Return the number format
+	 */
 	String getNumberFormat();
 
+	/**
+	 * Get the date format
+	 *
+	 * @return Return the date format
+	 */
 	String getDateFormat();
 
+	/**
+	 * Get the date time format
+	 *
+	 * @return Return the date time format
+	 */
 	String getDateTimeFormat();
 
+	/**
+	 * Get the time format
+	 *
+	 * @return Return the time format
+	 */
 	String getTimeFormat();
 
+	/**
+	 * Get the number align
+	 *
+	 * @return Return the number align
+	 */
 	String getNumberAlign();
 
+	/**
+	 * Get the visible format
+	 *
+	 * @return Return the visible format
+	 */
 	String getVisibleFormat();
 
+	/**
+	 * Set the background position X
+	 *
+	 * @param x
+	 * @throws DOMException
+	 */
 	void setBackgroundPositionX(String x) throws DOMException;
 
+	/**
+	 * Set the background position Y
+	 *
+	 * @param y
+	 * @throws DOMException
+	 */
 	void setBackgroundPositionY(String y) throws DOMException;
 
+	/**
+	 * Set the text underline
+	 *
+	 * @param underline
+	 * @throws DOMException
+	 */
 	void setTextUnderline(String underline) throws DOMException;
 
+	/**
+	 * Set the text overline
+	 *
+	 * @param overline
+	 * @throws DOMException
+	 */
 	void setTextOverline(String overline) throws DOMException;
 
+	/**
+	 * Set the text line through
+	 *
+	 * @param through
+	 * @throws DOMException
+	 */
 	void setTextLineThrough(String through) throws DOMException;
 
+	/**
+	 * Set the master page
+	 *
+	 * @param page
+	 * @throws DOMException
+	 */
 	void setMasterPage(String page) throws DOMException;
 
+	/**
+	 * Set the show if blank
+	 *
+	 * @param blank
+	 * @throws DOMException
+	 */
 	void setShowIfBlank(String blank) throws DOMException;
 
+	/**
+	 * Set the option can shrink
+	 *
+	 * @param shrink
+	 * @throws DOMException
+	 */
 	void setCanShrink(String shrink) throws DOMException;
 
+	/**
+	 * Set the string format
+	 *
+	 * @param format
+	 * @throws DOMException
+	 */
 	void setStringFormat(String format) throws DOMException;
 
+	/**
+	 * Set the number format
+	 *
+	 * @param format
+	 * @throws DOMException
+	 */
 	void setNumberFormat(String format) throws DOMException;
 
+	/**
+	 * Set the date format
+	 *
+	 * @param format
+	 * @throws DOMException
+	 */
 	void setDateFormat(String format) throws DOMException;
 
+	/**
+	 * Set the number align
+	 *
+	 * @param align
+	 * @throws DOMException
+	 */
 	void setNumberAlign(String align) throws DOMException;
 
+	/**
+	 * Set visible format
+	 *
+	 * @param visibility
+	 * @throws DOMException
+	 */
 	void setVisibleFormat(String visibility) throws DOMException;
 
+	/**
+	 * Get the property value
+	 *
+	 * @param index
+	 * @return Return the property value
+	 */
 	CSSValue getProperty(int index);
 
+	/**
+	 * Set the property value
+	 *
+	 * @param index
+	 * @param value
+	 */
 	void setProperty(int index, CSSValue value);
 
+	/**
+	 * Set the properties style based
+	 *
+	 * @param style
+	 */
 	void setProperties(IStyle style);
 
+	/**
+	 * Get the CSS text
+	 *
+	 * @param index
+	 * @return Return the CSS text
+	 */
 	String getCssText(int index);
 
+	/**
+	 * Set the CSS text
+	 *
+	 * @param index
+	 * @param value
+	 * @throws DOMException
+	 */
 	void setCssText(int index, String value) throws DOMException;
 
+	/**
+	 * Is empty
+	 *
+	 * @return true, is empty
+	 */
 	boolean isEmpty();
 
+	/**
+	 * Write the report ROM stream
+	 *
+	 * @param out
+	 * @throws IOException
+	 */
 	void write(DataOutputStream out) throws IOException;
 
+	/**
+	 * Read the report ROM stream
+	 *
+	 * @param in
+	 * @throws IOException
+	 */
 	void read(DataInputStream in) throws IOException;
 
+	/**
+	 * Get the background image height
+	 *
+	 * @return Return the background image height
+	 */
 	String getBackgroundHeight();
 
+	/**
+	 * Get the background image width
+	 *
+	 * @return Return the background image width
+	 */
 	String getBackgroundWidth();
 
+	/**
+	 * Get the date format
+	 *
+	 * @return Return the date format
+	 */
 	DataFormatValue getDataFormat();
 
+	/**
+	 * Set the date format
+	 *
+	 * @param value
+	 */
 	void setDataFormat(DataFormatValue value);
+
+	/**
+	 * Get the background image source type
+	 *
+	 * @return Return the background image source type
+	 */
+	String getBackgroundImageType();
+
+	/**
+	 * Set the image background type
+	 *
+	 * @param imageType
+	 */
+	void setBackgroundImageType(String imageType);
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/dom/AbstractStyle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/dom/AbstractStyle.java
@@ -1903,11 +1903,6 @@ abstract public class AbstractStyle implements IStyle {
 			int index = getPropertyIndex(propertyName);
 			if (index == -1) {
 				String propertyCssText = IOUtil.readString(in);
-				if (propertyName == "background-image-type") {
-
-					var test = 1;
-					test = test + 61;
-				}
 				if (BIRTConstants.BIRT_STRING_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
 					this.setStringFormat(propertyCssText);
 				} else if (BIRTConstants.BIRT_NUMBER_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/dom/AbstractStyle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/dom/AbstractStyle.java
@@ -23,19 +23,36 @@ import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.css.engine.CSSEngine;
 import org.eclipse.birt.report.engine.css.engine.StyleConstants;
 import org.eclipse.birt.report.engine.css.engine.value.DataFormatValue;
+import org.eclipse.birt.report.engine.css.engine.value.birt.BIRTConstants;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSRule;
 import org.w3c.dom.css.CSSValue;
 
+/**
+ * Definition of the abstract style class
+ *
+ * @since 3.3
+ *
+ */
 abstract public class AbstractStyle implements IStyle {
 
 	protected CSSEngine engine;
 
+	/**
+	 * Consructor
+	 *
+	 * @param engine
+	 */
 	public AbstractStyle(CSSEngine engine) {
 		this.engine = engine;
 	}
 
+	/**
+	 * Get the CSS engine
+	 *
+	 * @return Return the CSS engine
+	 */
 	public CSSEngine getCSSEngine() {
 		return this.engine;
 	}
@@ -58,7 +75,7 @@ abstract public class AbstractStyle implements IStyle {
 			// we don't return the format in css as the format
 			// is a complex object which can't be represented as
 			// css string.
-			if (i == IStyle.STYLE_DATA_FORMAT) {
+			if (i == StyleConstants.STYLE_DATA_FORMAT) {
 				continue;
 			}
 			CSSValue value = getProperty(i);
@@ -108,7 +125,7 @@ abstract public class AbstractStyle implements IStyle {
 	@Override
 	public void setCssText(String cssText) throws DOMException {
 		IStyle style = (IStyle) engine.parseStyleDeclaration(cssText);
-		for (int i = 0; i < IStyle.NUMBER_OF_STYLE; i++) {
+		for (int i = 0; i < StyleConstants.NUMBER_OF_STYLE; i++) {
 			CSSValue value = style.getProperty(i);
 			if (value != null) {
 				setProperty(i, value);
@@ -232,6 +249,11 @@ abstract public class AbstractStyle implements IStyle {
 	@Override
 	public String getBackgroundImage() {
 		return getCssText(STYLE_BACKGROUND_IMAGE);
+	}
+
+	@Override
+	public String getBackgroundImageType() {
+		return getCssText(STYLE_BACKGROUND_IMAGE_TYPE);
 	}
 
 	@Override
@@ -491,6 +513,14 @@ abstract public class AbstractStyle implements IStyle {
 	@Override
 	public void setBackgroundImage(String backgroundImage) {
 		setCssText(STYLE_BACKGROUND_IMAGE, backgroundImage);
+	}
+
+	/**
+	 * @param backgroundImageSourceType The backgroundImage to set.
+	 */
+	@Override
+	public void setBackgroundImageType(String backgroundImageSourceType) {
+		setCssText(STYLE_BACKGROUND_IMAGE_TYPE, backgroundImageSourceType);
 	}
 
 	/**
@@ -909,12 +939,24 @@ abstract public class AbstractStyle implements IStyle {
 		newValue.setDateFormat(format, value == null ? null : value.getDateLocale());
 	}
 
+	/**
+	 * Set the date time format
+	 *
+	 * @param format
+	 * @throws DOMException
+	 */
 	public void setDateTimeFormat(String format) throws DOMException {
 		DataFormatValue value = getDataFormat();
 		DataFormatValue newValue = copyDataFormat(value);
 		newValue.setDateTimeFormat(format, value == null ? null : value.getDateTimeLocale());
 	}
 
+	/**
+	 * Set the time format
+	 *
+	 * @param format
+	 * @throws DOMException
+	 */
 	public void setTimeFormat(String format) throws DOMException {
 		DataFormatValue value = getDataFormat();
 		DataFormatValue newValue = copyDataFormat(value);
@@ -1861,16 +1903,23 @@ abstract public class AbstractStyle implements IStyle {
 			int index = getPropertyIndex(propertyName);
 			if (index == -1) {
 				String propertyCssText = IOUtil.readString(in);
-				if (IStyle.BIRT_STRING_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
+				if (propertyName == "background-image-type") {
+
+					var test = 1;
+					test = test + 61;
+				}
+				if (BIRTConstants.BIRT_STRING_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
 					this.setStringFormat(propertyCssText);
-				} else if (IStyle.BIRT_NUMBER_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
+				} else if (BIRTConstants.BIRT_NUMBER_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
 					this.setNumberFormat(propertyCssText);
-				} else if (IStyle.BIRT_DATE_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
+				} else if (BIRTConstants.BIRT_DATE_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
 					this.setDateFormat(propertyCssText);
-				} else if (IStyle.BIRT_TIME_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
+				} else if (BIRTConstants.BIRT_TIME_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
 					this.setTimeFormat(propertyCssText);
-				} else if (IStyle.BIRT_DATE_TIME_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
+				} else if (BIRTConstants.BIRT_DATE_TIME_FORMAT_PROPERTY.equalsIgnoreCase(propertyName)) {
 					this.setDateTimeFormat(propertyCssText);
+				} else if (BIRTConstants.BIRT_BACKGROUND_IMAGE_TYPE.equalsIgnoreCase(propertyName)) {
+					this.setBackgroundImageType(propertyCssText);
 				} else {
 					throw new IOException(propertyName + " not valid");
 				}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/dom/StyleDeclaration.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/dom/StyleDeclaration.java
@@ -21,6 +21,12 @@ import org.eclipse.birt.core.util.IOUtil;
 import org.eclipse.birt.report.engine.css.engine.CSSEngine;
 import org.w3c.dom.css.CSSValue;
 
+/**
+ * Definition of the style declarations
+ *
+ * @since 3.3
+ *
+ */
 public class StyleDeclaration extends AbstractStyle {
 	protected CSSValue[] values;
 	protected boolean shared;
@@ -54,6 +60,11 @@ public class StyleDeclaration extends AbstractStyle {
 		return values[index];
 	}
 
+	/**
+	 * Constructor of style declaration based on style declaration
+	 *
+	 * @param style
+	 */
 	public StyleDeclaration(StyleDeclaration style) {
 		super(style.engine);
 		this.values = style.values;
@@ -61,6 +72,11 @@ public class StyleDeclaration extends AbstractStyle {
 		this.shared = true;
 	}
 
+	/**
+	 * Constructor of style declaration based on CSS engine
+	 *
+	 * @param engine
+	 */
 	public StyleDeclaration(CSSEngine engine) {
 		super(engine);
 		this.values = new CSSValue[NUMBER_OF_STYLE];

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/BIRTPropertyManagerFactory.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/BIRTPropertyManagerFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.birt.report.engine.css.engine.value.birt.BooleanManager;
 import org.eclipse.birt.report.engine.css.engine.value.birt.DataFormatManager;
 import org.eclipse.birt.report.engine.css.engine.value.birt.VisibleFormatManager;
 import org.eclipse.birt.report.engine.css.engine.value.css.BackgroundAttachmentManager;
+import org.eclipse.birt.report.engine.css.engine.value.css.BackgroundImageType;
 import org.eclipse.birt.report.engine.css.engine.value.css.BackgroundRepeatManager;
 import org.eclipse.birt.report.engine.css.engine.value.css.BackgroundSizeManager;
 import org.eclipse.birt.report.engine.css.engine.value.css.BorderColorManager;
@@ -180,6 +181,8 @@ public class BIRTPropertyManagerFactory implements PropertyManagerFactory {
 				CSSValueConstants.NUMBER_0);
 		vms[StyleConstants.STYLE_WIDTH] = new LengthManager(CSSConstants.CSS_WIDTH_PROPERTY, false,
 				CSSValueConstants.NUMBER_0);
+		vms[StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE] = new BackgroundImageType();
+
 	}
 
 	@Override

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/PerfectHash.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/PerfectHash.java
@@ -18,7 +18,7 @@ public class PerfectHash {
 	// bidi_hcg: Aligned with generated token.cpp after the "direction" keyword
 	// was added.
 
-	final static int TOTAL_KEYWORDS = 61;
+	final static int TOTAL_KEYWORDS = 62;
 
 	final static int MIN_WORD_LENGTH = 5;
 
@@ -35,7 +35,7 @@ public class PerfectHash {
 			112, 112, 112, 112, 112, 112, 112, 45, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112,
 			112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112,
 			112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 112, 52, 5, 0, 0, 15, 40, 20, 0,
-			40, 112, 15, 0, 20, 5, 0, 5, 112, 5, 40, 0, 112, 15, 45, 30, 36, 112, 112, 112, 112, 112, 112 };
+			40, 112, 15, 0, 20, 5, 0, 5, 112, 5, 40, 0, 112, 15, 45, 30, 36, 112, 112, 112, 112, 112, 112, 112 };
 
 	public static int hash(String str) {
 		int hashValue = str.length();
@@ -62,7 +62,7 @@ public class PerfectHash {
 
 	static int lengthtable[] = { 5, 11, 11, 12, 13, 9, 11, 17, 16, 17, 18, 19, 10, 16, 18, 19, 11, 12, 14, 10, 11, 18,
 			19, 10, 6, 12, 5, 16, 7, 11, 12, 13, 21, 17, 13, 14, 16, 21, 8, 9, 10, 16, 17, 13, 14, 16, 17, 21, 14, 16,
-			7, 11, 17, 14, 6, 11, 17, 16, 14, 12, 11 };
+			7, 11, 17, 14, 6, 11, 17, 16, 14, 12, 11, 21 };
 	static String wordlist[] = { "color" /* hash value = 10, index = 0 */,
 			"data-format" /* hash value = 11, index = 1 */, "line-height" /* hash value = 16, index = 2 */,
 			"padding-left" /* hash value = 17, index = 3 */, "padding-right" /* hash value = 18, index = 4 */,
@@ -97,14 +97,14 @@ public class PerfectHash {
 			"widows" /* hash value = 91, index = 54 */, "font-family" /* hash value = 92, index = 55 */,
 			"page-break-inside" /* hash value = 97, index = 56 */, "page-break-after" /* hash value = 98, index = 57 */,
 			"text-underline" /* hash value = 99, index = 58 */, "word-spacing" /* hash value = 102, index = 59 */,
-			"white-space" /* hash value = 111, index = 60 */
+			"white-space" /* hash value = 111, index = 60 */, "background-image-type" /* hash value = ??, index = 61 */
 	};
 
 	static short lookup[] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, -1, -1, -1, -1, 2, 3, 4, 5, -1, 6, 7, -1,
 			-1, -1, 8, 9, 10, 11, 12, 13, -1, 14, 15, -1, 16, 17, -1, 18, 19, 20, -1, 21, 22, 23, 24, 25, -1, -1, 26,
 			27, 28, -1, -1, -1, 29, 30, 31, -1, -1, 32, 33, 34, 35, -1, 36, 37, 38, 39, 40, 41, 42, 43, 44, -1, 45, 46,
 			47, 48, -1, 49, -1, 50, -1, -1, 51, 52, -1, 53, -1, 54, 55, -1, -1, -1, -1, 56, 57, 58, -1, -1, 59, -1, -1,
-			-1, -1, -1, -1, -1, -1, 60 };
+			-1, -1, -1, -1, -1, -1, 60, -1 };
 
 	public static int in_word_set(String str) {
 		int len = str.length();

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/StyleConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/StyleConstants.java
@@ -13,72 +13,203 @@
  *******************************************************************************/
 package org.eclipse.birt.report.engine.css.engine;
 
+/**
+ * Definition of the style constants index based
+ *
+ * @since 3.3
+ *
+ */
 public interface StyleConstants {
 	// bidi_hcg: As a result of a new style added ("direction"), align the
 	// constants with org.eclipse.birt.report.engine.css.engine.PerfectHash
 
+	/** style property: color */
 	int STYLE_COLOR = 0;
+
+	/** style property: data format */
 	int STYLE_DATA_FORMAT = 1;
+
+	/** style property: line height */
 	int STYLE_LINE_HEIGHT = 2;
+
+	/** style property: padding left */
 	int STYLE_PADDING_LEFT = 3;
+
+	/** style property: padding right */
 	int STYLE_PADDING_RIGHT = 4;
+
+	/** style property: direction */
 	int STYLE_DIRECTION = 5;
+
+	/** style property: padding top */
 	int STYLE_PADDING_TOP = 6;
+
+	/** style property: background height */
 	int STYLE_BACKGROUND_HEIGHT = 7;
+
+	/** style property: background color */
 	int STYLE_BACKGROUND_COLOR = 8;
+
+	/** style property: background repeat */
 	int STYLE_BACKGROUND_REPEAT = 9;
+
+	/** style property: border right width */
 	int STYLE_BORDER_RIGHT_WIDTH = 10;
+
+	/** style property: border bottom width */
 	int STYLE_BORDER_BOTTOM_WIDTH = 11;
+
+	/** style property: can shrink */
 	int STYLE_CAN_SHRINK = 12;
+
+	/** style property: border top color */
 	int STYLE_BORDER_TOP_COLOR = 13;
+
+	/** style property: border right color */
 	int STYLE_BORDER_RIGHT_COLOR = 14;
+
+	/** style property: border bottom color */
 	int STYLE_BORDER_BOTTOM_COLOR = 15;
+
+	/** style property: margin left */
 	int STYLE_MARGIN_LEFT = 16;
+
+	/** style property: margin right */
 	int STYLE_MARGIN_RIGHT = 17;
+
+	/** style property: padding bottom */
 	int STYLE_PADDING_BOTTOM = 18;
+
+	/** style property: margin top */
 	int STYLE_MARGIN_TOP = 19;
+
+	/** style property: text indent */
 	int STYLE_TEXT_INDENT = 20;
+
+	/** style property: border right style */
 	int STYLE_BORDER_RIGHT_STYLE = 21;
+
+	/** style property: border bottom style */
 	int STYLE_BORDER_BOTTOM_STYLE = 22;
+
+	/** style property: text align */
 	int STYLE_TEXT_ALIGN = 23;
+
+	/** style property: height */
 	int STYLE_HEIGHT = 24;
+
+	/** style property: number align */
 	int STYLE_NUMBER_ALIGN = 25;
+
+	/** style property: width */
 	int STYLE_WIDTH = 26;
+
+	/** style property: text linethrough */
 	int STYLE_TEXT_LINETHROUGH = 27;
+
+	/** style property: orphans */
 	int STYLE_ORPHANS = 28;
+
+	/** style property: font weight */
 	int STYLE_FONT_WEIGHT = 29;
+
+	/** style property: font variant */
 	int STYLE_FONT_VARIANT = 30;
+
+	/** style property: margin bottom */
 	int STYLE_MARGIN_BOTTOM = 31;
+
+	/** style property: background position x */
 	int STYLE_BACKGROUND_POSITION_X = 32;
+
+	/** style property: page break before */
 	int STYLE_PAGE_BREAK_BEFORE = 33;
+
+	/** style property: text overline */
 	int STYLE_TEXT_OVERLINE = 34;
+
+	/** style property: text transform */
 	int STYLE_TEXT_TRANSFORM = 35;
+
+	/** style property: background width */
 	int STYLE_BACKGROUND_WIDTH = 36;
+
+	/** style property: background position y */
 	int STYLE_BACKGROUND_POSITION_Y = 37;
+
+	/** style property: overflow */
 	int STYLE_OVERFLOW = 38;
+
+	/** style property: font size */
 	int STYLE_FONT_SIZE = 39;
+
+	/** style property: font style */
 	int STYLE_FONT_STYLE = 40;
+
+	/** style property: border top width */
 	int STYLE_BORDER_TOP_WIDTH = 41;
+
+	/** style property: border left width */
 	int STYLE_BORDER_LEFT_WIDTH = 42;
+
+	/** style property: show if blank */
 	int STYLE_SHOW_IF_BLANK = 43;
+
+	/** style property: letter spacing */
 	int STYLE_LETTER_SPACING = 44;
+
+	/** style property: background image */
 	int STYLE_BACKGROUND_IMAGE = 45;
+
+	/** style property: border left color */
 	int STYLE_BORDER_LEFT_COLOR = 46;
+
+	/** style property: background attachment */
 	int STYLE_BACKGROUND_ATTACHMENT = 47;
+
+	/** style property: vertical align */
 	int STYLE_VERTICAL_ALIGN = 48;
+
+	/** style property: border top style */
 	int STYLE_BORDER_TOP_STYLE = 49;
+
+	/** style property: display */
 	int STYLE_DISPLAY = 50;
+
+	/** style property: master page */
 	int STYLE_MASTER_PAGE = 51;
+
+	/** style property: border left style */
 	int STYLE_BORDER_LEFT_STYLE = 52;
+
+	/** style property: visible format */
 	int STYLE_VISIBLE_FORMAT = 53;
+
+	/** style property: widows */
 	int STYLE_WIDOWS = 54;
+
+	/** style property: font family */
 	int STYLE_FONT_FAMILY = 55;
+
+	/** style property: page break inside */
 	int STYLE_PAGE_BREAK_INSIDE = 56;
+
+	/** style property: page break after */
 	int STYLE_PAGE_BREAK_AFTER = 57;
+
+	/** style property: text underline */
 	int STYLE_TEXT_UNDERLINE = 58;
+
+	/** style property: word spacing */
 	int STYLE_WORD_SPACING = 59;
+
+	/** style property: white space */
 	int STYLE_WHITE_SPACE = 60;
+
+	/** style property: background image type */
 	int STYLE_BACKGROUND_IMAGE_TYPE = 61;
 
+
+	/** number (count) of style constants */
 	int NUMBER_OF_STYLE = 62;
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/StyleConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/StyleConstants.java
@@ -78,6 +78,7 @@ public interface StyleConstants {
 	int STYLE_TEXT_UNDERLINE = 58;
 	int STYLE_WORD_SPACING = 59;
 	int STYLE_WHITE_SPACE = 60;
+	int STYLE_BACKGROUND_IMAGE_TYPE = 61;
 
-	int NUMBER_OF_STYLE = 61;
+	int NUMBER_OF_STYLE = 62;
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/birt/BIRTConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/birt/BIRTConstants.java
@@ -24,33 +24,87 @@ public interface BIRTConstants extends CSSConstants {
 	/////////////////////////////////////////////////////////////////////////
 	// BIRT attributes
 	/////////////////////////////////////////////////////////////////////////
+	/**
+	 * BIRT property: background image type
+	 */
+	String BIRT_BACKGROUND_IMAGE_TYPE = "background-image-type";
+	/**
+	 * BIRT property: background position X
+	 */
 	String BIRT_BACKGROUND_POSITION_X_PROPERTY = "background-position-x";
+	/**
+	 * BIRT property: background position Y
+	 */
 	String BIRT_BACKGROUND_POSITION_Y_PROPERTY = "background-position-y";
+	/**
+	 * BIRT property: can shrink
+	 */
 	String BIRT_CAN_SHRINK_PROPERTY = "can-shrink"; //$NON-NLS-1$
+	/**
+	 * BIRT property: master-page
+	 */
 	String BIRT_MASTER_PAGE_PROPERTY = "master-page"; //$NON-NLS-1$
+	/**
+	 * BIRT property: number-align
+	 */
 	String BIRT_NUMBER_ALIGN_PROPERTY = "number-align";
+	/**
+	 * BIRT property: show-if-blank
+	 */
 	String BIRT_SHOW_IF_BLANK_PROPERTY = "show-if-blank"; //$NON-NLS-1$
+	/**
+	 * BIRT property: text underline
+	 */
 	String BIRT_TEXT_UNDERLINE_PROPERTY = "text-underline"; //$NON-NLS-1$
+	/**
+	 * BIRT property: text overline
+	 */
 	String BIRT_TEXT_OVERLINE_PROPERTY = "text-overline"; //$NON-NLS-1$
+	/**
+	 * BIRT property: text linethrough
+	 */
 	String BIRT_TEXT_LINETHROUGH_PROPERTY = "text-linethrough"; //$NON-NLS-1$
+	/**
+	 * BIRT property: visible format
+	 */
 	String BIRT_VISIBLE_FORMAT_PROPERTY = "visible-format";
+	/**
+	 * BIRT property: data format
+	 */
 	String BIRT_STYLE_DATA_FORMAT = "data-format";
 
 	///////////////////////////////////////////////////////////////////////
 	// Deprecated format constants, they are replaced by data-format
 	//////////////////////////////////////////////////////////////////////
+	/** BIRT property: date format */
 	String BIRT_DATE_TIME_FORMAT_PROPERTY = "date-format"; //$NON-NLS-1$
+	/** BIRT property: sql time format */
 	String BIRT_TIME_FORMAT_PROPERTY = "sql-time-format"; //$NON-NLS-1$
+	/** BIRT property: sql date format */
 	String BIRT_DATE_FORMAT_PROPERTY = "sql-date-format"; //$NON-NLS-1$
+	/** BIRT property: number format */
 	String BIRT_NUMBER_FORMAT_PROPERTY = "number-format"; //$NON-NLS-1$
+	/** BIRT property: string format */
 	String BIRT_STRING_FORMAT_PROPERTY = "string-format"; //$NON-NLS-1$
 
 	/////////////////////////////////////////////////////////////////////////
 	// BIRT attribute value
 	/////////////////////////////////////////////////////////////////////////
 
+	/**
+	 * BIRT attribute value: true
+	 */
 	String BIRT_TRUE_VALUE = "true";
+	/**
+	 * BIRT attribute value: false
+	 */
 	String BIRT_FALSE_VALUE = "false";
+	/**
+	 * BIRT attribute value: all
+	 */
 	String BIRT_ALL_VALUE = "all";
+	/**
+	 * BIRT attribute value: soft
+	 */
 	String BIRT_SOFT_VALUE = "soft";
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
@@ -16,6 +16,7 @@ package org.eclipse.birt.report.engine.css.engine.value.css;
 import org.eclipse.birt.report.engine.css.engine.value.IdentifierManager;
 import org.eclipse.birt.report.engine.css.engine.value.StringMap;
 import org.eclipse.birt.report.engine.css.engine.value.Value;
+import org.eclipse.birt.report.engine.css.engine.value.birt.BIRTConstants;
 
 /**
  * class to handle the CSS properties of background image type
@@ -48,7 +49,7 @@ public class BackgroundImageType extends IdentifierManager {
 
 	@Override
 	public String getPropertyName() {
-		return CSSConstants.CSS_BACKGROUND_IMAGE_TYPE_PROPERTY;
+		return BIRTConstants.BIRT_BACKGROUND_IMAGE_TYPE;
 	}
 
 	@Override

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004 Actuate Corporation.
+ * Copyright (c) 2023 Thomas Gutmann.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
  *
  *
  * Contributors:
- *  Actuate Corporation  - initial API and implementation
+ *  Thomas Gutmann  - initial API and implementation
  *******************************************************************************/
 package org.eclipse.birt.report.engine.css.engine.value.css;
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2004 Actuate Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.birt.report.engine.css.engine.value.css;
+
+import org.eclipse.birt.report.engine.css.engine.value.IdentifierManager;
+import org.eclipse.birt.report.engine.css.engine.value.StringMap;
+import org.eclipse.birt.report.engine.css.engine.value.Value;
+
+/**
+ * class to handle the CSS properties of background image type
+ *
+ * @since 3.3
+ *
+ */
+public class BackgroundImageType extends IdentifierManager {
+
+	/**
+	 * The identifier values.
+	 */
+	protected final static StringMap values = new StringMap();
+	static {
+		// CSSConstants.CSS_BACKGROUND_IMAGE_TYPE_PROPERTY
+		values.put(CSSConstants.CSS_URL_VALUE, CSSValueConstants.URL_VALUE);
+		values.put(CSSConstants.CSS_EMBED_VALUE, CSSValueConstants.EMBED_VALUE);
+	}
+
+	@Override
+	public StringMap getIdentifiers() {
+		return values;
+	}
+
+	/**
+	 * constructor of the new identifier manager of the backround image type
+	 */
+	public BackgroundImageType() {
+	}
+
+	@Override
+	public String getPropertyName() {
+		return CSSConstants.CSS_BACKGROUND_IMAGE_TYPE_PROPERTY;
+	}
+
+	@Override
+	public boolean isInheritedProperty() {
+		return false;
+	}
+
+	@Override
+	public Value getDefaultValue() {
+		return CSSValueConstants.URL_VALUE;
+	}
+}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/BackgroundImageType.java
@@ -21,7 +21,7 @@ import org.eclipse.birt.report.engine.css.engine.value.birt.BIRTConstants;
 /**
  * class to handle the CSS properties of background image type
  *
- * @since 3.3
+ * @since 4.13
  *
  */
 public class BackgroundImageType extends IdentifierManager {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSConstants.java
@@ -21,331 +21,1199 @@ package org.eclipse.birt.report.engine.css.engine.value.css;
 public interface CSSConstants {
 
 	//
-	// The CSS property names.
+	// The CSS property.
 	//
-	String CSS_BACKGROUND_ATTACHMENT_PROPERTY = "background-attachment";
-	String CSS_BACKGROUND_COLOR_PROPERTY = "background-color";
-	String CSS_BACKGROUND_IMAGE_PROPERTY = "background-image";
-	String CSS_BACKGROUND_IMAGE_TYPE_PROPERTY = "background-image-type";
-	String CSS_BACKGROUND_REPEAT_PROPERTY = "background-repeat";
-	String CSS_BACKGROUND_REPEAT_X_PROPERTY = "background-repeat-x";
-	String CSS_BACKGROUND_REPEAT_Y_PROPERTY = "background-repeat-y";
-	String CSS_BACKGROUND_HEIGHT_PROPERTY = "background-height";
-	String CSS_BACKGROUND_WIDTH_PROPERTY = "background-width";
 
-	String CSS_BORDER_TOP_COLOR_PROPERTY = "border-top-color";
-	String CSS_BORDER_RIGHT_COLOR_PROPERTY = "border-right-color";
-	String CSS_BORDER_BOTTOM_COLOR_PROPERTY = "border-bottom-color";
-	String CSS_BORDER_LEFT_COLOR_PROPERTY = "border-left-color";
-	String CSS_BORDER_TOP_STYLE_PROPERTY = "border-top-style";
-	String CSS_BORDER_RIGHT_STYLE_PROPERTY = "border-right-style";
-	String CSS_BORDER_BOTTOM_STYLE_PROPERTY = "border-bottom-style";
-	String CSS_BORDER_LEFT_STYLE_PROPERTY = "border-left-style";
-	String CSS_BORDER_TOP_WIDTH_PROPERTY = "border-top-width";
-	String CSS_BORDER_RIGHT_WIDTH_PROPERTY = "border-right-width";
-	String CSS_BORDER_BOTTOM_WIDTH_PROPERTY = "border-bottom-width";
-	String CSS_BORDER_LEFT_WIDTH_PROPERTY = "border-left-width";
-	String CSS_COLOR_PROPERTY = "color";
-	String CSS_DISPLAY_PROPERTY = "display";
-	String CSS_FONT_FAMILY_PROPERTY = "font-family";
-	String CSS_FONT_SIZE_PROPERTY = "font-size";
-	String CSS_FONT_STYLE_PROPERTY = "font-style";
-	String CSS_FONT_VARIANT_PROPERTY = "font-variant";
-	String CSS_FONT_WEIGHT_PROPERTY = "font-weight";
-	String CSS_LETTER_SPACING_PROPERTY = "letter-spacing";
-	String CSS_LINE_HEIGHT_PROPERTY = "line-height";
-	String CSS_MARGIN_RIGHT_PROPERTY = "margin-right";
-	String CSS_MARGIN_LEFT_PROPERTY = "margin-left";
-	String CSS_MARGIN_TOP_PROPERTY = "margin-top";
-	String CSS_MARGIN_BOTTOM_PROPERTY = "margin-bottom";
-	String CSS_ORPHANS_PROPERTY = "orphans";
-	String CSS_PADDING_TOP_PROPERTY = "padding-top";
-	String CSS_PADDING_RIGHT_PROPERTY = "padding-right";
-	String CSS_PADDING_BOTTOM_PROPERTY = "padding-bottom";
-	String CSS_PADDING_LEFT_PROPERTY = "padding-left";
-	String CSS_PAGE_BREAK_AFTER_PROPERTY = "page-break-after";
-	String CSS_PAGE_BREAK_BEFORE_PROPERTY = "page-break-before";
-	String CSS_PAGE_BREAK_INSIDE_PROPERTY = "page-break-inside";
-	String CSS_TEXT_ALIGN_PROPERTY = "text-align";
-	String CSS_TEXT_INDENT_PROPERTY = "text-indent";
-	String CSS_TEXT_TRANSFORM_PROPERTY = "text-transform";
-	String CSS_VERTICAL_ALIGN_PROPERTY = "vertical-align";
-	String CSS_WHITE_SPACE_PROPERTY = "white-space";
-	String CSS_WIDOWS_PROPERTY = "widows";
-	String CSS_WORD_SPACING_PROPERTY = "word-spacing";
+	/**
+	 * CSS property: background-attachment
+	 */
+	public final static String CSS_BACKGROUND_ATTACHMENT_PROPERTY = "background-attachment";
+	/**
+	 * CSS property: background-color
+	 */
+	public final static String CSS_BACKGROUND_COLOR_PROPERTY = "background-color";
+	/**
+	 * CSS property: background-image
+	 */
+	public final static String CSS_BACKGROUND_IMAGE_PROPERTY = "background-image";
+	/**
+	 * CSS property: background-repeat
+	 */
+	public final static String CSS_BACKGROUND_REPEAT_PROPERTY = "background-repeat";
+	/**
+	 * CSS property: background-repeat-x
+	 */
+	public final static String CSS_BACKGROUND_REPEAT_X_PROPERTY = "background-repeat-x";
+	/**
+	 * CSS property: background-repeat-y
+	 */
+	public final static String CSS_BACKGROUND_REPEAT_Y_PROPERTY = "background-repeat-y";
+	/**
+	 * CSS property: background-height
+	 */
+	public final static String CSS_BACKGROUND_HEIGHT_PROPERTY = "background-height";
+	/**
+	 * CSS property: background-width
+	 */
+	public final static String CSS_BACKGROUND_WIDTH_PROPERTY = "background-width";
+
+	/**
+	 * CSS property: border-top-color
+	 */
+	public final static String CSS_BORDER_TOP_COLOR_PROPERTY = "border-top-color";
+	/**
+	 * CSS property: border-top-color
+	 */
+	public final static String CSS_BORDER_RIGHT_COLOR_PROPERTY = "border-right-color";
+	/**
+	 * CSS property: border-right-color
+	 */
+	public final static String CSS_BORDER_BOTTOM_COLOR_PROPERTY = "border-bottom-color";
+	/**
+	 * CSS property: border-left-color
+	 */
+	public final static String CSS_BORDER_LEFT_COLOR_PROPERTY = "border-left-color";
+	/**
+	 * CSS property: border-top-style
+	 */
+	public final static String CSS_BORDER_TOP_STYLE_PROPERTY = "border-top-style";
+	/**
+	 * CSS property: border-right-style
+	 */
+	public final static String CSS_BORDER_RIGHT_STYLE_PROPERTY = "border-right-style";
+	/**
+	 * CSS property: border-bottom-style
+	 */
+	public final static String CSS_BORDER_BOTTOM_STYLE_PROPERTY = "border-bottom-style";
+	/**
+	 * CSS property: border-left-style
+	 */
+	public final static String CSS_BORDER_LEFT_STYLE_PROPERTY = "border-left-style";
+
+	/**
+	 * CSS property: border-top-width
+	 */
+	public final static String CSS_BORDER_TOP_WIDTH_PROPERTY = "border-top-width";
+	/**
+	 * CSS property: border-right-width
+	 */
+	public final static String CSS_BORDER_RIGHT_WIDTH_PROPERTY = "border-right-width";
+	/**
+	 * CSS property: border-bottom-width
+	 */
+	public final static String CSS_BORDER_BOTTOM_WIDTH_PROPERTY = "border-bottom-width";
+	/**
+	 * CSS property: border-left-width
+	 */
+	public final static String CSS_BORDER_LEFT_WIDTH_PROPERTY = "border-left-width";
+
+	/**
+	 * CSS property: color
+	 */
+	public final static String CSS_COLOR_PROPERTY = "color";
+	/**
+	 * CSS property: display
+	 */
+	public final static String CSS_DISPLAY_PROPERTY = "display";
+	/**
+	 * CSS property: font-family
+	 */
+	public final static String CSS_FONT_FAMILY_PROPERTY = "font-family";
+	/**
+	 * CSS property: font-size
+	 */
+	public final static String CSS_FONT_SIZE_PROPERTY = "font-size";
+	/**
+	 * CSS property: font-style
+	 */
+	public final static String CSS_FONT_STYLE_PROPERTY = "font-style";
+	/**
+	 * CSS property: font-variant
+	 */
+	public final static String CSS_FONT_VARIANT_PROPERTY = "font-variant";
+	/**
+	 * CSS property: font-weight
+	 */
+	public final static String CSS_FONT_WEIGHT_PROPERTY = "font-weight";
+	/**
+	 * CSS property: letter-spacing
+	 */
+	public final static String CSS_LETTER_SPACING_PROPERTY = "letter-spacing";
+	/**
+	 * CSS property: line-height
+	 */
+	public final static String CSS_LINE_HEIGHT_PROPERTY = "line-height";
+	/**
+	 * CSS property: margin-right
+	 */
+	public final static String CSS_MARGIN_RIGHT_PROPERTY = "margin-right";
+	/**
+	 * CSS property: margin-left
+	 */
+	public final static String CSS_MARGIN_LEFT_PROPERTY = "margin-left";
+	/**
+	 * CSS property: margin-top
+	 */
+	public final static String CSS_MARGIN_TOP_PROPERTY = "margin-top";
+	/**
+	 * CSS property: margin-bottom
+	 */
+	public final static String CSS_MARGIN_BOTTOM_PROPERTY = "margin-bottom";
+	/**
+	 * CSS property: orphans
+	 */
+	public final static String CSS_ORPHANS_PROPERTY = "orphans";
+	/**
+	 * CSS property: padding-top
+	 */
+	public final static String CSS_PADDING_TOP_PROPERTY = "padding-top";
+	/**
+	 * CSS property: padding-right
+	 */
+	public final static String CSS_PADDING_RIGHT_PROPERTY = "padding-right";
+	/**
+	 * CSS property: padding-bottom
+	 */
+	public final static String CSS_PADDING_BOTTOM_PROPERTY = "padding-bottom";
+	/**
+	 * CSS property: padding-left
+	 */
+	public final static String CSS_PADDING_LEFT_PROPERTY = "padding-left";
+	/**
+	 * CSS property: page-break-after
+	 */
+	public final static String CSS_PAGE_BREAK_AFTER_PROPERTY = "page-break-after";
+	/**
+	 * CSS property: page-break-before
+	 */
+	public final static String CSS_PAGE_BREAK_BEFORE_PROPERTY = "page-break-before";
+	/**
+	 * CSS property: page-break-inside
+	 */
+	public final static String CSS_PAGE_BREAK_INSIDE_PROPERTY = "page-break-inside";
+	/**
+	 * CSS property: text-align
+	 */
+	public final static String CSS_TEXT_ALIGN_PROPERTY = "text-align";
+	/**
+	 * CSS property: text-indent
+	 */
+	public final static String CSS_TEXT_INDENT_PROPERTY = "text-indent";
+	/**
+	 * CSS property: text-transform
+	 */
+	public final static String CSS_TEXT_TRANSFORM_PROPERTY = "text-transform";
+	/**
+	 * CSS property: text-transform
+	 */
+	public final static String CSS_VERTICAL_ALIGN_PROPERTY = "vertical-align";
+	/**
+	 * CSS property: white-space
+	 */
+	public final static String CSS_WHITE_SPACE_PROPERTY = "white-space";
+	/**
+	 * CSS property: widows
+	 */
+	public final static String CSS_WIDOWS_PROPERTY = "widows";
+	/**
+	 * CSS property: word-spacing
+	 */
+	public final static String CSS_WORD_SPACING_PROPERTY = "word-spacing";
+
 
 	//
 	// The CSS property values.
 	//
 
-	// background attachment
-	String CSS_SCROLL_VALUE = "scroll";
-	String CSS_FIXED_VALUE = "fixed";
+	/**
+	 * CSS property value, background attachment: scroll
+	 */
+	public final static String CSS_SCROLL_VALUE = "scroll";
+	/**
+	 * CSS property value, background attachment: fixed
+	 */
+	public final static String CSS_FIXED_VALUE = "fixed";
 
-	// background color
-	String CSS_TRANSPARENT_VALUE = "transparent";
+	/**
+	 * CSS property value, background color: transparent
+	 */
+	public final static String CSS_TRANSPARENT_VALUE = "transparent";
 
-	// background position
-	String CSS_CENTER_VALUE = "center";
-	String CSS_LEFT_VALUE = "left";
-	String CSS_BOTTOM_VALUE = "bottom";
+	/**
+	 * CSS property value, background position: center
+	 */
+	public final static String CSS_CENTER_VALUE = "center";
+	/**
+	 * CSS property value, background position: left
+	 */
+	public final static String CSS_LEFT_VALUE = "left";
+	/**
+	 * CSS property value, background position: bottom
+	 */
+	public final static String CSS_BOTTOM_VALUE = "bottom";
 
-	// background size
-	String CSS_CONTAIN_VALUE = "contain";
-	String CSS_COVER_VALUE = "cover";
 
-	String CSS_100_VALUE = "100";
-	String CSS_200_VALUE = "200";
-	String CSS_300_VALUE = "300";
-	String CSS_400_VALUE = "400";
-	String CSS_500_VALUE = "500";
-	String CSS_600_VALUE = "600";
-	String CSS_700_VALUE = "700";
-	String CSS_800_VALUE = "800";
-	String CSS_900_VALUE = "900";
-	String CSS_ABOVE_VALUE = "above";
-	String CSS_ABSOLUTE_VALUE = "absolute";
-	String CSS_ALWAYS_VALUE = "always";
-	String CSS_ARMENIAN_VALUE = "armenian";
-	String CSS_ATTR_VALUE = "attr()";
-	String CSS_AUTO_VALUE = "auto";
-	String CSS_AVOID_VALUE = "avoid";
-	String CSS_BASELINE_VALUE = "baseline";
-	String CSS_BEHIND_VALUE = "behind";
-	String CSS_BELOW_VALUE = "below";
-	String CSS_BIDI_OVERRIDE_VALUE = "bidi-override";
-	String CSS_BLINK_VALUE = "blink";
-	String CSS_BLOCK_VALUE = "block";
-	String CSS_BOLD_VALUE = "bold";
-	String CSS_BOLDER_VALUE = "bolder";
-	String CSS_BOTH_VALUE = "both";
-	String CSS_CAPITALIZE_VALUE = "capitalize";
-	String CSS_CAPTION_VALUE = "caption";
-	String CSS_CENTER_LEFT_VALUE = "center-left";
-	String CSS_CENTER_RIGHT_VALUE = "center-right";
-	String CSS_CIRCLE_VALUE = "circle";
-	String CSS_CLOSE_QUOTE_VALUE = "close-quote";
-	String CSS_CODE_VALUE = "code";
-	String CSS_COLLAPSE_VALUE = "collapse";
-	String CSS_CONTINUOUS_VALUE = "continuous";
-	String CSS_CROSSHAIR_VALUE = "crosshair";
-	String CSS_DECIMAL_VALUE = "decimal";
-	String CSS_DECIMAL_LEADING_ZERO_VALUE = "decimal-leading-zero";
-	String CSS_DEFAULT_VALUE = "default";
-	String CSS_DIGITS_VALUE = "digits";
-	String CSS_DISC_VALUE = "disc";
-	String CSS_EMBED_VALUE = "embed";
-	String CSS_E_RESIZE_VALUE = "e-resize";
-	String CSS_FAR_LEFT_VALUE = "far-left";
-	String CSS_FAR_RIGHT_VALUE = "far-right";
-	String CSS_FAST_VALUE = "fast";
-	String CSS_FASTER_VALUE = "faster";
-	String CSS_GEORGIAN_VALUE = "georgian";
-	String CSS_HELP_VALUE = "help";
-	String CSS_HIDDEN_VALUE = "hidden";
-	String CSS_HIDE_VALUE = "hide";
-	String CSS_HIGH_VALUE = "high";
-	String CSS_HIGHER_VALUE = "higher";
-	String CSS_ICON_VALUE = "icon";
-	String CSS_INHERIT_VALUE = "inherit";
-	String CSS_INLINE_VALUE = "inline";
-	String CSS_INLINE_BLOCK_VALUE = "inline-block";
-	String CSS_INLINE_TABLE_VALUE = "inline-table";
-	String CSS_INSIDE_VALUE = "inside";
-	String CSS_INVERT_VALUE = "invert";
-	String CSS_ITALIC_VALUE = "italic";
-	String CSS_JUSTIFY_VALUE = "justify";
-	String CSS_LEFT_SIDE_VALUE = "left-side";
-	String CSS_LEFTWARDS_VALUE = "leftwards";
-	String CSS_LEVEL_VALUE = "level";
-	String CSS_LIGHTER_VALUE = "lighter";
-	String CSS_LINE_THROUGH_VALUE = "line-through";
-	String CSS_LIST_ITEM_VALUE = "list-item";
-	String CSS_LOUD_VALUE = "loud";
-	String CSS_LOW_VALUE = "low";
-	String CSS_LOWER_VALUE = "lower";
-	String CSS_LOWER_ALPHA_VALUE = "lower-alpha";
-	String CSS_LOWERCASE_VALUE = "lowercase";
-	String CSS_LOWER_GREEK_VALUE = "lower-greek";
-	String CSS_LOWER_LATIN_VALUE = "lower-latin";
-	String CSS_LOWER_ROMAN_VALUE = "lower-roman";
-	String CSS_LTR_VALUE = "ltr";
-	String CSS_MEDIUM_VALUE = "medium";
-	String CSS_MENU_VALUE = "menu";
-	String CSS_MESSAGE_BOX_VALUE = "message-box";
-	String CSS_MIDDLE_VALUE = "middle";
-	String CSS_MIX_VALUE = "mix";
-	String CSS_MOVE_VALUE = "move";
-	String CSS_NE_RESIZE_VALUE = "ne-resize";
-	String CSS_NO_CLOSE_QUOTE_VALUE = "no-close-quote";
-	String CSS_NONE_VALUE = "none";
-	String CSS_NO_OPEN_QUOTE_VALUE = "no-open-quote";
-	String CSS_NO_REPEAT_VALUE = "no-repeat";
-	String CSS_NORMAL_VALUE = "normal";
-	String CSS_NOWRAP_VALUE = "nowrap";
-	String CSS_N_RESIZE_VALUE = "n-resize";
-	String CSS_NW_RESIZE_VALUE = "nw-resize";
-	String CSS_OBLIQUE_VALUE = "oblique";
-	String CSS_ONCE_VALUE = "once";
-	String CSS_OPEN_QUOTE_VALUE = "open-quote";
-	String CSS_OUTSIDE_VALUE = "outside";
-	String CSS_OVERLINE_VALUE = "overline";
-	String CSS_POINTER_VALUE = "pointer";
-	String CSS_PRE_VALUE = "pre";
-	String CSS_PRE_LINE_VALUE = "pre-line";
-	String CSS_PRE_WRAP_VALUE = "pre-wrap";
-	String CSS_PROGRESS_VALUE = "progress";
-	String CSS_RELATIVE_VALUE = "relative";
-	String CSS_REPEAT_VALUE = "repeat";
-	String CSS_REPEAT_X_VALUE = "repeat-x";
-	String CSS_REPEAT_Y_VALUE = "repeat-y";
-	String CSS_RIGHT_VALUE = "right";
-	String CSS_RIGHT_SIDE_VALUE = "right-side";
-	String CSS_RIGHTWARDS_VALUE = "rightwards";
-	String CSS_RTL_VALUE = "rtl";
-	String CSS_RUN_IN_VALUE = "run-in";
-	String CSS_SEPARATE_VALUE = "separate";
-	String CSS_SE_RESIZE_VALUE = "se-resize";
-	String CSS_SHOW_VALUE = "show";
-	String CSS_SILENT_VALUE = "silent";
-	String CSS_SLOW_VALUE = "slow";
-	String CSS_SLOWER_VALUE = "slower";
-	String CSS_SMALL_CAPS_VALUE = "small-caps";
-	String CSS_SMALL_CAPTION_VALUE = "small-caption";
-	String CSS_SOFT_VALUE = "soft";
-	String CSS_SPELL_OUT_VALUE = "spell-out";
-	String CSS_SQUARE_VALUE = "square";
-	String CSS_S_RESIZE_VALUE = "s-resize";
-	String CSS_STATIC_VALUE = "static";
-	String CSS_STATUS_BAR_VALUE = "status-bar";
-	String CSS_SUB_VALUE = "sub";
-	String CSS_SUPER_VALUE = "super";
-	String CSS_SW_RESIZE_VALUE = "sw-resize";
-	String CSS_TABLE_VALUE = "table";
-	String CSS_TABLE_CAPTION_VALUE = "table-caption";
-	String CSS_TABLE_CELL_VALUE = "table-cell";
-	String CSS_TABLE_COLUMN_VALUE = "table-column";
-	String CSS_TABLE_COLUMN_GROUP_VALUE = "table-column-group";
-	String CSS_TABLE_FOOTER_GROUP_VALUE = "table-footer-group";
-	String CSS_TABLE_HEADER_GROUP_VALUE = "table-header-group";
-	String CSS_TABLE_ROW_VALUE = "table-row";
-	String CSS_TABLE_ROW_GROUP_VALUE = "table-row-group";
-	String CSS_TEXT_VALUE = "text";
-	String CSS_TEXT_BOTTOM_VALUE = "text-bottom";
-	String CSS_TEXT_TOP_VALUE = "text-top";
-	String CSS_TOP_VALUE = "top";
-	String CSS_UNDERLINE_VALUE = "underline";
-	String CSS_UPPER_ALPHA_VALUE = "upper-alpha";
-	String CSS_UPPERCASE_VALUE = "uppercase";
-	String CSS_UPPER_LATIN_VALUE = "upper-latin";
-	String CSS_UPPER_ROMAN_VALUE = "upper-roman";
-	String CSS_VISIBLE_VALUE = "visible";
-	String CSS_WAIT_VALUE = "wait";
-	String CSS_W_RESIZE_VALUE = "w-resize";
-	String CSS_X_FAST_VALUE = "x-fast";
-	String CSS_X_HIGH_VALUE = "x-high";
-	String CSS_X_LOUD_VALUE = "x-loud";
-	String CSS_X_LOW_VALUE = "x-low";
-	String CSS_X_SLOW_VALUE = "x-slow";
-	String CSS_X_SOFT_VALUE = "x-soft";
+	/**
+	 * CSS property value, background size: contain
+	 */
+	public final static String CSS_CONTAIN_VALUE = "contain";
+	/**
+	 * CSS property value, background size: cover
+	 */
+	public final static String CSS_COVER_VALUE = "cover";
+
+	/**
+	 * CSS property value: 100
+	 */
+	public final static String CSS_100_VALUE = "100";
+	/**
+	 * CSS property value: 200
+	 */
+	public final static String CSS_200_VALUE = "200";
+	/**
+	 * CSS property value: 300
+	 */
+	public final static String CSS_300_VALUE = "300";
+	/**
+	 * CSS property value: 400
+	 */
+	public final static String CSS_400_VALUE = "400";
+	/**
+	 * CSS property value: 500
+	 */
+	public final static String CSS_500_VALUE = "500";
+	/**
+	 * CSS property value: 600
+	 */
+	public final static String CSS_600_VALUE = "600";
+	/**
+	 * CSS property value: 700
+	 */
+	public final static String CSS_700_VALUE = "700";
+	/**
+	 * CSS property value: 800
+	 */
+	public final static String CSS_800_VALUE = "800";
+	/**
+	 * CSS property value: 900
+	 */
+	public final static String CSS_900_VALUE = "900";
+	/**
+	 * CSS property value: above
+	 */
+	public final static String CSS_ABOVE_VALUE = "above";
+	/**
+	 * CSS property value: absolute
+	 */
+	public final static String CSS_ABSOLUTE_VALUE = "absolute";
+	/**
+	 * CSS property value: always
+	 */
+	public final static String CSS_ALWAYS_VALUE = "always";
+	/**
+	 * CSS property value: armenian
+	 */
+	public final static String CSS_ARMENIAN_VALUE = "armenian";
+	/**
+	 * CSS property value: attr()
+	 */
+	public final static String CSS_ATTR_VALUE = "attr()";
+
+	/**
+	 * CSS property value: auto
+	 */
+	public final static String CSS_AUTO_VALUE = "auto";
+	/**
+	 * CSS property value: avoid
+	 */
+	public final static String CSS_AVOID_VALUE = "avoid";
+	/**
+	 * CSS property value: baseline
+	 */
+	public final static String CSS_BASELINE_VALUE = "baseline";
+	/**
+	 * CSS property value: behind
+	 */
+	public final static String CSS_BEHIND_VALUE = "behind";
+	/**
+	 * CSS property value: below
+	 */
+	public final static String CSS_BELOW_VALUE = "below";
+	/**
+	 * CSS property value:bidi-override
+	 */
+	public final static String CSS_BIDI_OVERRIDE_VALUE = "bidi-override";
+	/**
+	 * CSS property value: blink
+	 */
+	public final static String CSS_BLINK_VALUE = "blink";
+	/**
+	 * CSS property value: block
+	 */
+	public final static String CSS_BLOCK_VALUE = "block";
+	/**
+	 * CSS property value: bold
+	 */
+	public final static String CSS_BOLD_VALUE = "bold";
+	/**
+	 * CSS property value: bolder
+	 */
+	public final static String CSS_BOLDER_VALUE = "bolder";
+	/**
+	 * CSS property value: both
+	 */
+	public final static String CSS_BOTH_VALUE = "both";
+	/**
+	 * CSS property value: capitalize
+	 */
+	public final static String CSS_CAPITALIZE_VALUE = "capitalize";
+	/**
+	 * CSS property value: caption
+	 */
+	public final static String CSS_CAPTION_VALUE = "caption";
+	/**
+	 * CSS property value: center-left
+	 */
+	public final static String CSS_CENTER_LEFT_VALUE = "center-left";
+	/**
+	 * CSS property value: center-right
+	 */
+	public final static String CSS_CENTER_RIGHT_VALUE = "center-right";
+	/**
+	 * CSS property value: circle
+	 */
+	public final static String CSS_CIRCLE_VALUE = "circle";
+	/**
+	 * CSS property value: close-quote
+	 */
+	public final static String CSS_CLOSE_QUOTE_VALUE = "close-quote";
+	/**
+	 * CSS property value: code
+	 */
+	public final static String CSS_CODE_VALUE = "code";
+	/**
+	 * CSS property value: collapse
+	 */
+	public final static String CSS_COLLAPSE_VALUE = "collapse";
+	/**
+	 * CSS property value: continuous
+	 */
+	public final static String CSS_CONTINUOUS_VALUE = "continuous";
+	/**
+	 * CSS property value: crosshair
+	 */
+	public final static String CSS_CROSSHAIR_VALUE = "crosshair";
+	/**
+	 * CSS property value: decimal
+	 */
+	public final static String CSS_DECIMAL_VALUE = "decimal";
+	/**
+	 * CSS property value: decimal-leading-zero
+	 */
+	public final static String CSS_DECIMAL_LEADING_ZERO_VALUE = "decimal-leading-zero";
+	/**
+	 * CSS property value: default
+	 */
+	public final static String CSS_DEFAULT_VALUE = "default";
+	/**
+	 * CSS property value: digits
+	 */
+	public final static String CSS_DIGITS_VALUE = "digits";
+	/**
+	 * CSS property value: disc
+	 */
+	public final static String CSS_DISC_VALUE = "disc";
+	/**
+	 * CSS property value: embed
+	 */
+	public final static String CSS_EMBED_VALUE = "embed";
+	/**
+	 * CSS property value: e-resize
+	 */
+	public final static String CSS_E_RESIZE_VALUE = "e-resize";
+	/**
+	 * CSS property value: far-left
+	 */
+	public final static String CSS_FAR_LEFT_VALUE = "far-left";
+	/**
+	 * CSS property value: far-right
+	 */
+	public final static String CSS_FAR_RIGHT_VALUE = "far-right";
+	/**
+	 * CSS property value: fast
+	 */
+	public final static String CSS_FAST_VALUE = "fast";
+	/**
+	 * CSS property value: faster
+	 */
+	public final static String CSS_FASTER_VALUE = "faster";
+	/**
+	 * CSS property value: georgian
+	 */
+	public final static String CSS_GEORGIAN_VALUE = "georgian";
+	/**
+	 * CSS property value: help
+	 */
+	public final static String CSS_HELP_VALUE = "help";
+	/**
+	 * CSS property value: hidden
+	 */
+	public final static String CSS_HIDDEN_VALUE = "hidden";
+	/**
+	 * CSS property value: hide
+	 */
+	public final static String CSS_HIDE_VALUE = "hide";
+	/**
+	 * CSS property value: high
+	 */
+	public final static String CSS_HIGH_VALUE = "high";
+	/**
+	 * CSS property value: higher
+	 */
+	public final static String CSS_HIGHER_VALUE = "higher";
+	/**
+	 * CSS property value: icon
+	 */
+	public final static String CSS_ICON_VALUE = "icon";
+	/**
+	 * CSS property value: inherit
+	 */
+	public final static String CSS_INHERIT_VALUE = "inherit";
+	/**
+	 * CSS property value: inline
+	 */
+	public final static String CSS_INLINE_VALUE = "inline";
+	/**
+	 * CSS property value: inline-block
+	 */
+	public final static String CSS_INLINE_BLOCK_VALUE = "inline-block";
+	/**
+	 * CSS property value: inline-table
+	 */
+	public final static String CSS_INLINE_TABLE_VALUE = "inline-table";
+	/**
+	 * CSS property value: inside
+	 */
+	public final static String CSS_INSIDE_VALUE = "inside";
+	/**
+	 * CSS property value: invert
+	 */
+	public final static String CSS_INVERT_VALUE = "invert";
+	/**
+	 * CSS property value: italic
+	 */
+	public final static String CSS_ITALIC_VALUE = "italic";
+	/**
+	 * CSS property value: justify
+	 */
+	public final static String CSS_JUSTIFY_VALUE = "justify";
+	/**
+	 * CSS property value: left-side
+	 */
+	public final static String CSS_LEFT_SIDE_VALUE = "left-side";
+	/**
+	 * CSS property value: leftwards
+	 */
+	public final static String CSS_LEFTWARDS_VALUE = "leftwards";
+	/**
+	 * CSS property value: level
+	 */
+	public final static String CSS_LEVEL_VALUE = "level";
+	/**
+	 * CSS property value: lighter
+	 */
+	public final static String CSS_LIGHTER_VALUE = "lighter";
+	/**
+	 * CSS property value: line-through
+	 */
+	public final static String CSS_LINE_THROUGH_VALUE = "line-through";
+	/**
+	 * CSS property value: list-item
+	 */
+	public final static String CSS_LIST_ITEM_VALUE = "list-item";
+	/**
+	 * CSS property value: loud
+	 */
+	public final static String CSS_LOUD_VALUE = "loud";
+	/**
+	 * CSS property value: low
+	 */
+	public final static String CSS_LOW_VALUE = "low";
+	/**
+	 * CSS property value: lower
+	 */
+	public final static String CSS_LOWER_VALUE = "lower";
+	/**
+	 * CSS property value: lower-alpha
+	 */
+	public final static String CSS_LOWER_ALPHA_VALUE = "lower-alpha";
+	/**
+	 * CSS property value: lowercase
+	 */
+	public final static String CSS_LOWERCASE_VALUE = "lowercase";
+	/**
+	 * CSS property value: lower-greek
+	 */
+	public final static String CSS_LOWER_GREEK_VALUE = "lower-greek";
+	/**
+	 * CSS property value: lower-latin
+	 */
+	public final static String CSS_LOWER_LATIN_VALUE = "lower-latin";
+	/**
+	 * CSS property value: lower-roman
+	 */
+	public final static String CSS_LOWER_ROMAN_VALUE = "lower-roman";
+	/**
+	 * CSS property value: ltr
+	 */
+	public final static String CSS_LTR_VALUE = "ltr";
+	/**
+	 * CSS property value: medium
+	 */
+	public final static String CSS_MEDIUM_VALUE = "medium";
+	/**
+	 * CSS property value: menu
+	 */
+	public final static String CSS_MENU_VALUE = "menu";
+	/**
+	 * CSS property value: message-box
+	 */
+	public final static String CSS_MESSAGE_BOX_VALUE = "message-box";
+	/**
+	 * CSS property value: middle
+	 */
+	public final static String CSS_MIDDLE_VALUE = "middle";
+	/**
+	 * CSS property value: mix
+	 */
+	public final static String CSS_MIX_VALUE = "mix";
+	/**
+	 * CSS property value: move
+	 */
+	public final static String CSS_MOVE_VALUE = "move";
+	/**
+	 * CSS property value: ne-resize
+	 */
+	public final static String CSS_NE_RESIZE_VALUE = "ne-resize";
+	/**
+	 * CSS property value: no-close-quote
+	 */
+	public final static String CSS_NO_CLOSE_QUOTE_VALUE = "no-close-quote";
+	/**
+	 * CSS property value: none
+	 */
+	public final static String CSS_NONE_VALUE = "none";
+	/**
+	 * CSS property value: no-open-quote
+	 */
+	public final static String CSS_NO_OPEN_QUOTE_VALUE = "no-open-quote";
+	/**
+	 * CSS property value: no-repeat
+	 */
+	public final static String CSS_NO_REPEAT_VALUE = "no-repeat";
+	/**
+	 * CSS property value: normal
+	 */
+	public final static String CSS_NORMAL_VALUE = "normal";
+	/**
+	 * CSS property value: nowrap
+	 */
+	public final static String CSS_NOWRAP_VALUE = "nowrap";
+	/**
+	 * CSS property value: n-resize
+	 */
+	public final static String CSS_N_RESIZE_VALUE = "n-resize";
+	/**
+	 * CSS property value: nw-resize
+	 */
+	public final static String CSS_NW_RESIZE_VALUE = "nw-resize";
+	/**
+	 * CSS property value: oblique
+	 */
+	public final static String CSS_OBLIQUE_VALUE = "oblique";
+	/**
+	 * CSS property value: once
+	 */
+	public final static String CSS_ONCE_VALUE = "once";
+	/**
+	 * CSS property value: open-quote
+	 */
+	public final static String CSS_OPEN_QUOTE_VALUE = "open-quote";
+	/**
+	 * CSS property value: outside
+	 */
+	public final static String CSS_OUTSIDE_VALUE = "outside";
+	/**
+	 * CSS property value: overline
+	 */
+	public final static String CSS_OVERLINE_VALUE = "overline";
+	/**
+	 * CSS property value: pointer
+	 */
+	public final static String CSS_POINTER_VALUE = "pointer";
+	/**
+	 * CSS property value: pre
+	 */
+	public final static String CSS_PRE_VALUE = "pre";
+	/**
+	 * CSS property value: pre-line
+	 */
+	public final static String CSS_PRE_LINE_VALUE = "pre-line";
+	/**
+	 * CSS property value: pre-wrap
+	 */
+	public final static String CSS_PRE_WRAP_VALUE = "pre-wrap";
+	/**
+	 * CSS property value: progress
+	 */
+	public final static String CSS_PROGRESS_VALUE = "progress";
+	/**
+	 * CSS property value: relative
+	 */
+	public final static String CSS_RELATIVE_VALUE = "relative";
+	/**
+	 * CSS property value: repeat
+	 */
+	public final static String CSS_REPEAT_VALUE = "repeat";
+	/**
+	 * CSS property value: repeat-x
+	 */
+	public final static String CSS_REPEAT_X_VALUE = "repeat-x";
+	/**
+	 * CSS property value: repeat-y
+	 */
+	public final static String CSS_REPEAT_Y_VALUE = "repeat-y";
+	/**
+	 * CSS property value: right
+	 */
+	public final static String CSS_RIGHT_VALUE = "right";
+	/**
+	 * CSS property value: right-side
+	 */
+	public final static String CSS_RIGHT_SIDE_VALUE = "right-side";
+	/**
+	 * CSS property value: rightwards
+	 */
+	public final static String CSS_RIGHTWARDS_VALUE = "rightwards";
+	/**
+	 * CSS property value: rtl
+	 */
+	public final static String CSS_RTL_VALUE = "rtl";
+	/**
+	 * CSS property value: run-in
+	 */
+	public final static String CSS_RUN_IN_VALUE = "run-in";
+	/**
+	 * CSS property value: separate
+	 */
+	public final static String CSS_SEPARATE_VALUE = "separate";
+	/**
+	 * CSS property value: se-resize
+	 */
+	public final static String CSS_SE_RESIZE_VALUE = "se-resize";
+	/**
+	 * CSS property value: show
+	 */
+	public final static String CSS_SHOW_VALUE = "show";
+	/**
+	 * CSS property value: silent
+	 */
+	public final static String CSS_SILENT_VALUE = "silent";
+	/**
+	 * CSS property value: slow
+	 */
+	public final static String CSS_SLOW_VALUE = "slow";
+	/**
+	 * CSS property value: slower
+	 */
+	public final static String CSS_SLOWER_VALUE = "slower";
+	/**
+	 * CSS property value: small-caps
+	 */
+	public final static String CSS_SMALL_CAPS_VALUE = "small-caps";
+	/**
+	 * CSS property value: small-caption
+	 */
+	public final static String CSS_SMALL_CAPTION_VALUE = "small-caption";
+	/**
+	 * CSS property value: soft
+	 */
+	public final static String CSS_SOFT_VALUE = "soft";
+	/**
+	 * CSS property value: spell-out
+	 */
+	public final static String CSS_SPELL_OUT_VALUE = "spell-out";
+	/**
+	 * CSS property value: square
+	 */
+	public final static String CSS_SQUARE_VALUE = "square";
+	/**
+	 * CSS property value: s-resize
+	 */
+	public final static String CSS_S_RESIZE_VALUE = "s-resize";
+	/**
+	 * CSS property value: static
+	 */
+	public final static String CSS_STATIC_VALUE = "static";
+	/**
+	 * CSS property value: status-bar
+	 */
+	public final static String CSS_STATUS_BAR_VALUE = "status-bar";
+	/**
+	 * CSS property value: sub
+	 */
+	public final static String CSS_SUB_VALUE = "sub";
+	/**
+	 * CSS property value: super
+	 */
+	public final static String CSS_SUPER_VALUE = "super";
+	/**
+	 * CSS property value: sw-resize
+	 */
+	public final static String CSS_SW_RESIZE_VALUE = "sw-resize";
+	/**
+	 * CSS property value: table
+	 */
+	public final static String CSS_TABLE_VALUE = "table";
+	/**
+	 * CSS property value: table-caption
+	 */
+	public final static String CSS_TABLE_CAPTION_VALUE = "table-caption";
+	/**
+	 * CSS property value: table-cell
+	 */
+	public final static String CSS_TABLE_CELL_VALUE = "table-cell";
+	/**
+	 * CSS property value: table-column
+	 */
+	public final static String CSS_TABLE_COLUMN_VALUE = "table-column";
+	/**
+	 * CSS property value: table-column-group
+	 */
+	public final static String CSS_TABLE_COLUMN_GROUP_VALUE = "table-column-group";
+	/**
+	 * CSS property value: table-footer-group
+	 */
+	public final static String CSS_TABLE_FOOTER_GROUP_VALUE = "table-footer-group";
+	/**
+	 * CSS property value: table-header-group
+	 */
+	public final static String CSS_TABLE_HEADER_GROUP_VALUE = "table-header-group";
+	/**
+	 * CSS property value: table-row
+	 */
+	public final static String CSS_TABLE_ROW_VALUE = "table-row";
+	/**
+	 * CSS property value: table-row-group
+	 */
+	public final static String CSS_TABLE_ROW_GROUP_VALUE = "table-row-group";
+	/**
+	 * CSS property value: text
+	 */
+	public final static String CSS_TEXT_VALUE = "text";
+	/**
+	 * CSS property value: text-bottom
+	 */
+	public final static String CSS_TEXT_BOTTOM_VALUE = "text-bottom";
+	/**
+	 * CSS property value: text-top
+	 */
+	public final static String CSS_TEXT_TOP_VALUE = "text-top";
+	/**
+	 * CSS property value: top
+	 */
+	public final static String CSS_TOP_VALUE = "top";
+	/**
+	 * CSS property value: underline
+	 */
+	public final static String CSS_UNDERLINE_VALUE = "underline";
+	/**
+	 * CSS property value: upper-alpha
+	 */
+	public final static String CSS_UPPER_ALPHA_VALUE = "upper-alpha";
+	/**
+	 * CSS property value: uppercase
+	 */
+	public final static String CSS_UPPERCASE_VALUE = "uppercase";
+	/**
+	 * CSS property value: upper-latin
+	 */
+	public final static String CSS_UPPER_LATIN_VALUE = "upper-latin";
+	/**
+	 * CSS property value: upper-roman
+	 */
+	public final static String CSS_UPPER_ROMAN_VALUE = "upper-roman";
+	/**
+	 * CSS property value: visible
+	 */
+	public final static String CSS_VISIBLE_VALUE = "visible";
+	/**
+	 * CSS property value: wait
+	 */
+	public final static String CSS_WAIT_VALUE = "wait";
+	/**
+	 * CSS property value: w-resize
+	 */
+	public final static String CSS_W_RESIZE_VALUE = "w-resize";
+	/**
+	 * CSS property value: x-fast
+	 */
+	public final static String CSS_X_FAST_VALUE = "x-fast";
+	/**
+	 * CSS property value: x-high
+	 */
+	public final static String CSS_X_HIGH_VALUE = "x-high";
+	/**
+	 * CSS property value: x-loud
+	 */
+	public final static String CSS_X_LOUD_VALUE = "x-loud";
+	/**
+	 * CSS property value: x-low
+	 */
+	public final static String CSS_X_LOW_VALUE = "x-low";
+	/**
+	 * CSS property value: x-slow
+	 */
+	public final static String CSS_X_SLOW_VALUE = "x-slow";
+	/**
+	 * CSS property value: x-soft
+	 */
+	public final static String CSS_X_SOFT_VALUE = "x-soft";
 
 	// absolute fone size
-	String CSS_X_SMALL_VALUE = "x-small";
-	String CSS_XX_SMALL_VALUE = "xx-small";
-	String CSS_SMALL_VALUE = "small";
-	String CSS_LARGE_VALUE = "large";
-	String CSS_X_LARGE_VALUE = "x-large";
-	String CSS_XX_LARGE_VALUE = "xx-large";
+	/**
+	 * CSS property value: x-small
+	 */
+	public final static String CSS_X_SMALL_VALUE = "x-small";
+	/**
+	 * CSS property value: xx-small
+	 */
+	public final static String CSS_XX_SMALL_VALUE = "xx-small";
+	/**
+	 * CSS property value: small
+	 */
+	public final static String CSS_SMALL_VALUE = "small";
+	/**
+	 * CSS property value: large
+	 */
+	public final static String CSS_LARGE_VALUE = "large";
+	/**
+	 * CSS property value: x-large
+	 */
+	public final static String CSS_X_LARGE_VALUE = "x-large";
+	/**
+	 * CSS property value: xx-large
+	 */
+	public final static String CSS_XX_LARGE_VALUE = "xx-large";
 
 	// relative font size
-	String CSS_LARGER_VALUE = "larger";
-	String CSS_SMALLER_VALUE = "smaller";
+	/**
+	 * CSS property value: larger
+	 */
+	public final static String CSS_LARGER_VALUE = "larger";
+	/**
+	 * CSS property value: smaller
+	 */
+	public final static String CSS_SMALLER_VALUE = "smaller";
 
 	// genric font family
-	String CSS_SERIF_VALUE = "serif";
-	String CSS_SANS_SERIF_VALUE = "sans-serif";
-	String CSS_CURSIVE_VALUE = "cursive";
-	String CSS_FANTASY_VALUE = "fantasy";
-	String CSS_MONOSPACE_VALUE = "monospace";
+	/**
+	 * CSS property value: serif
+	 */
+	public final static String CSS_SERIF_VALUE = "serif";
+	/**
+	 * CSS property value: sans-serif
+	 */
+	public final static String CSS_SANS_SERIF_VALUE = "sans-serif";
+	/**
+	 * CSS property value: cursive
+	 */
+	public final static String CSS_CURSIVE_VALUE = "cursive";
+	/**
+	 * CSS property value: fantasy
+	 */
+	public final static String CSS_FANTASY_VALUE = "fantasy";
+	/**
+	 * CSS property value: monospace
+	 */
+	public final static String CSS_MONOSPACE_VALUE = "monospace";
+
 
 	// color
-	String CSS_AQUA_VALUE = "aqua";
-	String CSS_BLACK_VALUE = "black";
-	String CSS_BLUE_VALUE = "blue";
-	String CSS_FUCHSIA_VALUE = "fuchsia";
-	String CSS_GRAY_VALUE = "gray";
-	String CSS_GREEN_VALUE = "green";
-	String CSS_LIME_VALUE = "lime";
-	String CSS_MAROON_VALUE = "maroon";
-	String CSS_NAVY_VALUE = "navy";
-	String CSS_OLIVE_VALUE = "olive";
-	String CSS_ORANGE_VALUE = "orange";
-	String CSS_PURPLE_VALUE = "purple";
-	String CSS_RED_VALUE = "red";
-	String CSS_SILVER_VALUE = "silver";
-	String CSS_TEAL_VALUE = "teal";
-	String CSS_WHITE_VALUE = "white";
-	String CSS_YELLOW_VALUE = "yellow";
+	/**
+	 * CSS property value: aqua
+	 */
+	public final static String CSS_AQUA_VALUE = "aqua";
+	/**
+	 * CSS property value: black
+	 */
+	public final static String CSS_BLACK_VALUE = "black";
+	/**
+	 * CSS property value: blue
+	 */
+	public final static String CSS_BLUE_VALUE = "blue";
+	/**
+	 * CSS property value: fuchsia
+	 */
+	public final static String CSS_FUCHSIA_VALUE = "fuchsia";
+	/**
+	 * CSS property value: gray
+	 */
+	public final static String CSS_GRAY_VALUE = "gray";
+	/**
+	 * CSS property value: green
+	 */
+	public final static String CSS_GREEN_VALUE = "green";
+	/**
+	 * CSS property value: lime
+	 */
+	public final static String CSS_LIME_VALUE = "lime";
+	/**
+	 * CSS property value: maroon
+	 */
+	public final static String CSS_MAROON_VALUE = "maroon";
+	/**
+	 * CSS property value: navy
+	 */
+	public final static String CSS_NAVY_VALUE = "navy";
+	/**
+	 * CSS property value: olive
+	 */
+	public final static String CSS_OLIVE_VALUE = "olive";
+	/**
+	 * CSS property value: orange
+	 */
+	public final static String CSS_ORANGE_VALUE = "orange";
+	/**
+	 * CSS property value: purple
+	 */
+	public final static String CSS_PURPLE_VALUE = "purple";
+	/**
+	 * CSS property value: red
+	 */
+	public final static String CSS_RED_VALUE = "red";
+	/**
+	 * CSS property value: silver
+	 */
+	public final static String CSS_SILVER_VALUE = "silver";
+	/**
+	 * CSS property value: teal
+	 */
+	public final static String CSS_TEAL_VALUE = "teal";
+	/**
+	 * CSS property value: white
+	 */
+	public final static String CSS_WHITE_VALUE = "white";
+	/**
+	 * CSS property value: yellow
+	 */
+	public final static String CSS_YELLOW_VALUE = "yellow";
+
 
 	// System defined color
-	String CSS_ACTIVEBORDER_VALUE = "ActiveBorder";
-	String CSS_ACTIVECAPTION_VALUE = "ActiveCaption";
-	String CSS_APPWORKSPACE_VALUE = "AppWorkspace";
-	String CSS_BACKGROUND_VALUE = "Background";
-	String CSS_BUTTONFACE_VALUE = "ButtonFace";
-	String CSS_BUTTONHIGHLIGHT_VALUE = "ButtonHighlight";
-	String CSS_BUTTONSHADOW_VALUE = "ButtonShadow";
-	String CSS_BUTTONTEXT_VALUE = "ButtonText";
-	String CSS_CAPTIONTEXT_VALUE = "CaptionText";
-	String CSS_GRAYTEXT_VALUE = "GrayText";
-	String CSS_HIGHLIGHT_VALUE = "Highlight";
-	String CSS_HIGHLIGHTTEXT_VALUE = "HighlightText";
-	String CSS_INACTIVEBORDER_VALUE = "InactiveBorder";
-	String CSS_INACTIVECAPTION_VALUE = "InactiveCaption";
-	String CSS_INACTIVECAPTIONTEXT_VALUE = "InactiveCaptionText";
-	String CSS_INFOBACKGROUND_VALUE = "InfoBackground";
-	String CSS_INFOTEXT_VALUE = "InfoText";
+	/**
+	 * CSS property value: ActiveBorder
+	 */
+	public final static String CSS_ACTIVEBORDER_VALUE = "ActiveBorder";
+	/**
+	 * CSS property value: ActiveCaption
+	 */
+	public final static String CSS_ACTIVECAPTION_VALUE = "ActiveCaption";
+	/**
+	 * CSS property value: AppWorkspace
+	 */
+	public final static String CSS_APPWORKSPACE_VALUE = "AppWorkspace";
+	/**
+	 * CSS property value: Background
+	 */
+	public final static String CSS_BACKGROUND_VALUE = "Background";
+	/**
+	 * CSS property value: ButtonFace
+	 */
+	public final static String CSS_BUTTONFACE_VALUE = "ButtonFace";
+	/**
+	 * CSS property value: ButtonHighlight
+	 */
+	public final static String CSS_BUTTONHIGHLIGHT_VALUE = "ButtonHighlight";
+	/**
+	 * CSS property value: ButtonShadow
+	 */
+	public final static String CSS_BUTTONSHADOW_VALUE = "ButtonShadow";
+	/**
+	 * CSS property value: ButtonText
+	 */
+	public final static String CSS_BUTTONTEXT_VALUE = "ButtonText";
+	/**
+	 * CSS property value: CaptionText
+	 */
+	public final static String CSS_CAPTIONTEXT_VALUE = "CaptionText";
+	/**
+	 * CSS property value: GrayText
+	 */
+	public final static String CSS_GRAYTEXT_VALUE = "GrayText";
+	/**
+	 * CSS property value: Highlight
+	 */
+	public final static String CSS_HIGHLIGHT_VALUE = "Highlight";
+	/**
+	 * CSS property value: HighlightText
+	 */
+	public final static String CSS_HIGHLIGHTTEXT_VALUE = "HighlightText";
+	/**
+	 * CSS property value: InactiveBorder
+	 */
+	public final static String CSS_INACTIVEBORDER_VALUE = "InactiveBorder";
+	/**
+	 * CSS property value: InactiveCaption
+	 */
+	public final static String CSS_INACTIVECAPTION_VALUE = "InactiveCaption";
+	/**
+	 * CSS property value: InactiveCaptionText
+	 */
+	public final static String CSS_INACTIVECAPTIONTEXT_VALUE = "InactiveCaptionText";
+	/**
+	 * CSS property value: InfoBackground
+	 */
+	public final static String CSS_INFOBACKGROUND_VALUE = "InfoBackground";
+	/**
+	 * CSS property value: InfoText
+	 */
+	public final static String CSS_INFOTEXT_VALUE = "InfoText";
+
+
 	// String CSS_MENU_VALUE = "Menu";
-	String CSS_MENUTEXT_VALUE = "MenuText";
-	String CSS_SCROLLBAR_VALUE = "Scrollbar";
-	String CSS_THREEDDARKSHADOW_VALUE = "ThreeDDarkShadow";
-	String CSS_THREEDFACE_VALUE = "ThreeDFace";
-	String CSS_THREEDHIGHLIGHT_VALUE = "ThreeDHighlight";
-	String CSS_THREEDLIGHTSHADOW_VALUE = "ThreeDLightShadow";
-	String CSS_THREEDSHADOW_VALUE = "ThreeDShadow";
-	String CSS_WINDOW_VALUE = "Window";
-	String CSS_WINDOWFRAME_VALUE = "WindowFrame";
-	String CSS_WINDOWTEXT_VALUE = "WindowText";
+	/**
+	 * CSS property value: MenuText
+	 */
+	public final static String CSS_MENUTEXT_VALUE = "MenuText";
+	/**
+	 * CSS property value: Scrollbar
+	 */
+	public final static String CSS_SCROLLBAR_VALUE = "Scrollbar";
+	/**
+	 * CSS property value: ThreeDDarkShadow
+	 */
+	public final static String CSS_THREEDDARKSHADOW_VALUE = "ThreeDDarkShadow";
+	/**
+	 * CSS property value: ThreeDFace
+	 */
+	public final static String CSS_THREEDFACE_VALUE = "ThreeDFace";
+	/**
+	 * CSS property value: ThreeDHighlight
+	 */
+	public final static String CSS_THREEDHIGHLIGHT_VALUE = "ThreeDHighlight";
+	/**
+	 * CSS property value: ThreeDLightShadow
+	 */
+	public final static String CSS_THREEDLIGHTSHADOW_VALUE = "ThreeDLightShadow";
+	/**
+	 * CSS property value: ThreeDShadow
+	 */
+	public final static String CSS_THREEDSHADOW_VALUE = "ThreeDShadow";
+	/**
+	 * CSS property value: Window
+	 */
+	public final static String CSS_WINDOW_VALUE = "Window";
+	/**
+	 * CSS property value: WindowFrame
+	 */
+	public final static String CSS_WINDOWFRAME_VALUE = "WindowFrame";
+	/**
+	 * CSS property value: WindowText
+	 */
+	public final static String CSS_WINDOWTEXT_VALUE = "WindowText";
 
-	String CSS_DOTTED_VALUE = "dotted";
-	String CSS_DASHED_VALUE = "dashed";
-	String CSS_SOLID_VALUE = "solid";
-	String CSS_DOUBLE_VALUE = "double";
-	String CSS_GROOVE_VALUE = "groove";
-	String CSS_RIDGE_VALUE = "ridge";
-	String CSS_INSET_VALUE = "inset";
-	String CSS_OUTSET_VALUE = "outset";
+	// line property value
+	/**
+	 * CSS property value: dotted
+	 */
+	public final static String CSS_DOTTED_VALUE = "dotted";
+	/**
+	 * CSS property value: dashed
+	 */
+	public final static String CSS_DASHED_VALUE = "dashed";
+	/**
+	 * CSS property value: solid
+	 */
+	public final static String CSS_SOLID_VALUE = "solid";
+	/**
+	 * CSS property value: double
+	 */
+	public final static String CSS_DOUBLE_VALUE = "double";
+	/**
+	 * CSS property value: groove
+	 */
+	public final static String CSS_GROOVE_VALUE = "groove";
+	/**
+	 * CSS property value: ridge
+	 */
+	public final static String CSS_RIDGE_VALUE = "ridge";
+	/**
+	 * CSS property value: inset
+	 */
+	public final static String CSS_INSET_VALUE = "inset";
+	/**
+	 * CSS property value: outset
+	 */
+	public final static String CSS_OUTSET_VALUE = "outset";
 
-	String CSS_THIN_VALUE = "thin";
+	/**
+	 * CSS property value: thin
+	 */
+	public final static String CSS_THIN_VALUE = "thin";
+
 	// String CSS_MEDIUM_VALUE = "medium";
-	String CSS_THICK_VALUE = "thick";
+	/**
+	 * CSS property value: thick
+	 */
+	public final static String CSS_THICK_VALUE = "thick";
 
-	String CSS_OVERFLOW_AUTO_VALUE = "auto";
-	String CSS_OVERFLOW_VISIBLE_VALUE = "visible";
-	String CSS_OVERFLOW_SCROLL_VALUE = "scroll";
-	String CSS_OVERFLOW_HIDDEN_VALUE = "hidden";
+	/**
+	 * CSS property value: auto
+	 */
+	public final static String CSS_OVERFLOW_AUTO_VALUE = "auto";
+	/**
+	 * CSS property value: visible
+	 */
+	public final static String CSS_OVERFLOW_VISIBLE_VALUE = "visible";
+	/**
+	 * CSS property value: scroll
+	 */
+	public final static String CSS_OVERFLOW_SCROLL_VALUE = "scroll";
+	/**
+	 * CSS property value: hidden
+	 */
+	public final static String CSS_OVERFLOW_HIDDEN_VALUE = "hidden";
 
 	// bidi_hcg: Bidi related
 	// "rtl" and "ltr" values are already specified above.
 	// We preserve here the name for direction defined in CSS specs.
-	String CSS_DIRECTION_PROPERTY = "direction";
+	/**
+	 * CSS property value: direction
+	 */
+	public final static String CSS_DIRECTION_PROPERTY = "direction";
 
 	// overflow property: auto, visible, scroll, hidden
-	String CSS_OVERFLOW_PROPERTY = "overflow";
+	/**
+	 * CSS property value: overflow
+	 */
+	public final static String CSS_OVERFLOW_PROPERTY = "overflow";
 
-	String CSS_HEIGHT_PROPERTY = "height";
-	String CSS_WIDTH_PROPERTY = "width";
+	/**
+	 * CSS property value: height
+	 */
+	public final static String CSS_HEIGHT_PROPERTY = "height";
+	/**
+	 * CSS property value: width
+	 */
+	public final static String CSS_WIDTH_PROPERTY = "width";
 
-	String CSS_URL_VALUE = "url";
-
+	/**
+	 * CSS property value: url
+	 */
+	public final static String CSS_URL_VALUE = "url";
+	/**
+	 * CSS property value: independent
+	 */
+	public final static String CSS_INDEPENDENT_VALUE = "independent";
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSConstants.java
@@ -26,6 +26,7 @@ public interface CSSConstants {
 	String CSS_BACKGROUND_ATTACHMENT_PROPERTY = "background-attachment";
 	String CSS_BACKGROUND_COLOR_PROPERTY = "background-color";
 	String CSS_BACKGROUND_IMAGE_PROPERTY = "background-image";
+	String CSS_BACKGROUND_IMAGE_TYPE_PROPERTY = "background-image-type";
 	String CSS_BACKGROUND_REPEAT_PROPERTY = "background-repeat";
 	String CSS_BACKGROUND_REPEAT_X_PROPERTY = "background-repeat-x";
 	String CSS_BACKGROUND_REPEAT_Y_PROPERTY = "background-repeat-y";
@@ -344,5 +345,7 @@ public interface CSSConstants {
 
 	String CSS_HEIGHT_PROPERTY = "height";
 	String CSS_WIDTH_PROPERTY = "width";
+
+	String CSS_URL_VALUE = "url";
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSValueConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSValueConstants.java
@@ -931,4 +931,10 @@ public interface CSSValueConstants {
 	 * the "hidden" value for overflow
 	 */
 	Value OVERFLOW_HIDDEN_VALUE = new StringValue(CSSPrimitiveValue.CSS_IDENT, CSSConstants.CSS_OVERFLOW_HIDDEN_VALUE);
+
+	/**
+	 * The 'url' keyword.
+	 */
+	Value URL_VALUE = new StringValue(CSSPrimitiveValue.CSS_IDENT, CSSConstants.CSS_URL_VALUE);
+
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSValueConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/css/CSSValueConstants.java
@@ -762,8 +762,14 @@ public interface CSSValueConstants {
 	 */
 	Value JUSTIFY_VALUE = new StringValue(CSSPrimitiveValue.CSS_IDENT, CSSConstants.CSS_JUSTIFY_VALUE);
 
+	/**
+	 * the "contain" value
+	 */
 	Value CONTAIN_VALUE = new StringValue(CSSPrimitiveValue.CSS_IDENT, CSSConstants.CSS_CONTAIN_VALUE);
 
+	/**
+	 * the "cover" value
+	 */
 	Value COVER_VALUE = new StringValue(CSSPrimitiveValue.CSS_IDENT, CSSConstants.CSS_COVER_VALUE);
 
 	/**

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/util/PropertyUtil.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/util/PropertyUtil.java
@@ -28,20 +28,28 @@ import org.eclipse.birt.report.engine.content.IImageContent;
 import org.eclipse.birt.report.engine.content.IPageContent;
 import org.eclipse.birt.report.engine.content.IReportContent;
 import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.StyleConstants;
 import org.eclipse.birt.report.engine.css.engine.value.FloatValue;
 import org.eclipse.birt.report.engine.css.engine.value.RGBColorValue;
 import org.eclipse.birt.report.engine.css.engine.value.StringValue;
 import org.eclipse.birt.report.engine.css.engine.value.Value;
 import org.eclipse.birt.report.engine.css.engine.value.css.CSSConstants;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.ir.DimensionType;
-import org.eclipse.birt.report.engine.ir.EngineIRConstants;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
+import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
 import org.w3c.dom.Element;
 import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSValue;
 
 import com.lowagie.text.Font;
 
+/**
+ * Utility class of properties
+ *
+ * @since 3.3
+ *
+ */
 public class PropertyUtil {
 
 	private static Logger logger = Logger.getLogger(PropertyUtil.class.getName());
@@ -50,26 +58,26 @@ public class PropertyUtil {
 
 	private static HashMap<Value, Integer> fontWeightMap = new HashMap<>();
 	static {
-		fontWeightMap.put(IStyle.LIGHTER_VALUE, 200);
-		fontWeightMap.put(IStyle.NORMAL_VALUE, 400);
-		fontWeightMap.put(IStyle.BOLD_VALUE, 700);
-		fontWeightMap.put(IStyle.BOLDER_VALUE, 900);
+		fontWeightMap.put(CSSValueConstants.LIGHTER_VALUE, 200);
+		fontWeightMap.put(CSSValueConstants.NORMAL_VALUE, 400);
+		fontWeightMap.put(CSSValueConstants.BOLD_VALUE, 700);
+		fontWeightMap.put(CSSValueConstants.BOLDER_VALUE, 900);
 
-		fontWeightMap.put(IStyle.NUMBER_100, 100);
-		fontWeightMap.put(IStyle.NUMBER_200, 200);
-		fontWeightMap.put(IStyle.NUMBER_300, 300);
-		fontWeightMap.put(IStyle.NUMBER_400, 400);
-		fontWeightMap.put(IStyle.NUMBER_500, 500);
-		fontWeightMap.put(IStyle.NUMBER_600, 600);
-		fontWeightMap.put(IStyle.NUMBER_700, 700);
-		fontWeightMap.put(IStyle.NUMBER_800, 800);
-		fontWeightMap.put(IStyle.NUMBER_900, 900);
+		fontWeightMap.put(CSSValueConstants.NUMBER_100, 100);
+		fontWeightMap.put(CSSValueConstants.NUMBER_200, 200);
+		fontWeightMap.put(CSSValueConstants.NUMBER_300, 300);
+		fontWeightMap.put(CSSValueConstants.NUMBER_400, 400);
+		fontWeightMap.put(CSSValueConstants.NUMBER_500, 500);
+		fontWeightMap.put(CSSValueConstants.NUMBER_600, 600);
+		fontWeightMap.put(CSSValueConstants.NUMBER_700, 700);
+		fontWeightMap.put(CSSValueConstants.NUMBER_800, 800);
+		fontWeightMap.put(CSSValueConstants.NUMBER_900, 900);
 	}
 
 	/**
 	 * Checks if the font is bold
 	 *
-	 * @param value the CSSValue
+	 * @param fontWeight
 	 * @return true if the font is bold false if not
 	 */
 	public static boolean isBoldFont(int fontWeight) {
@@ -79,33 +87,56 @@ public class PropertyUtil {
 		return false;
 	}
 
+	/**
+	 * Parse font weight
+	 *
+	 * @param value
+	 * @return get font weight
+	 */
 	public static int parseFontWeight(CSSValue value) {
 		if (fontWeightMap.containsKey(value)) {
 			return fontWeightMap.get(value);
-		} else {
-			return 400; // Normal
 		}
+		return 400; // Normal
 	}
 
+	/**
+	 * Is display none
+	 *
+	 * @param content
+	 * @return true, display is none
+	 */
 	public static boolean isDisplayNone(IContent content) {
 		IStyle style = content.getStyle();
 		if (style != null) {
-			return IStyle.NONE_VALUE.equals(style.getProperty(IStyle.STYLE_DISPLAY));
+			return CSSValueConstants.NONE_VALUE.equals(style.getProperty(StyleConstants.STYLE_DISPLAY));
 		}
 		return false;
 	}
 
+	/**
+	 * Is inline element
+	 *
+	 * @param content
+	 * @return true, is inline element
+	 */
 	public static boolean isInlineElement(IContent content) {
 		if (content instanceof IPageContent) {
 			return false;
 		}
 		IStyle style = content.getStyle();
 		if (style != null) {
-			return IStyle.INLINE_VALUE.equals(style.getProperty(IStyle.STYLE_DISPLAY));
+			return CSSValueConstants.INLINE_VALUE.equals(style.getProperty(StyleConstants.STYLE_DISPLAY));
 		}
 		return false;
 	}
 
+	/**
+	 * Get the line height
+	 *
+	 * @param lineHeight
+	 * @return Return line height
+	 */
 	public static int getLineHeight(String lineHeight) {
 		try {
 			if (lineHeight.equalsIgnoreCase("normal")) //$NON-NLS-1$
@@ -122,6 +153,12 @@ public class PropertyUtil {
 		}
 	}
 
+	/**
+	 * Get the color
+	 *
+	 * @param value
+	 * @return Return the color
+	 */
 	public static Color getColor(CSSValue value) {
 		if (value instanceof RGBColorValue) {
 			RGBColorValue color = (RGBColorValue) value;
@@ -218,6 +255,13 @@ public class PropertyUtil {
 		return c;
 	}
 
+	/**
+	 * Get font style
+	 *
+	 * @param fontStyle
+	 * @param fontWeight
+	 * @return Return the font style
+	 */
 	public static int getFontStyle(String fontStyle, String fontWeight) {
 		int styleValue = Font.NORMAL;
 
@@ -233,6 +277,12 @@ public class PropertyUtil {
 		return styleValue;
 	}
 
+	/**
+	 * Get the background image
+	 *
+	 * @param value
+	 * @return Return the background image
+	 */
 	public static String getBackgroundImage(CSSValue value) {
 		if (value instanceof StringValue) {
 			String strValue = ((StringValue) value).getStringValue();
@@ -243,6 +293,14 @@ public class PropertyUtil {
 		return null;
 	}
 
+	/**
+	 * Get the image dpi
+	 *
+	 * @param content
+	 * @param imageFileDpi
+	 * @param renderOptionDpi
+	 * @return Return the image dpi
+	 */
 	public static int getImageDpi(IImageContent content, int imageFileDpi, int renderOptionDpi) {
 		// The DPI resolution of the image.
 		// the preference of the DPI setting is:
@@ -262,7 +320,7 @@ public class PropertyUtil {
 	 *
 	 * @param content
 	 * @param renderOptionDpi
-	 * @return
+	 * @return Return the render dpi
 	 */
 	public static int getRenderDpi(IReportContent content, int renderOptionDpi) {
 		int resolution = renderOptionDpi;
@@ -279,6 +337,13 @@ public class PropertyUtil {
 		return resolution;
 	}
 
+	/**
+	 * Get the render dpi
+	 *
+	 * @param content
+	 * @param renderOptionDpi
+	 * @return Return the render dpi
+	 */
 	public static int getRenderDpi(IContent content, int renderOptionDpi) {
 		return getRenderDpi(content.getReportContent(), renderOptionDpi);
 	}
@@ -305,11 +370,22 @@ public class PropertyUtil {
 		return screenDpi;
 	}
 
+	/**
+	 * Get dimension value
+	 *
+	 * @param value
+	 * @return Return the dimension value
+	 */
 	public static int getDimensionValue(CSSValue value) {
 		return getDimensionValue(value, 96, 0);
 	}
 
 	/**
+	 * Get dimension value
+	 *
+	 * @param value
+	 * @param referenceLength
+	 * @return Return the dimension value
 	 * @deprecated keep for backward compatibility.
 	 */
 	@Deprecated
@@ -317,6 +393,13 @@ public class PropertyUtil {
 		return getDimensionValue(value, 96, referenceLength);
 	}
 
+	/**
+	 * Get dimension value with consideration of dpi
+	 *
+	 * @param value
+	 * @param content
+	 * @return Return the dimension value
+	 */
 	public static int getDimensionValueConsiderDpi(CSSValue value, IContent content) {
 		if (value != null && (value instanceof FloatValue)) {
 			FloatValue fv = (FloatValue) value;
@@ -385,6 +468,13 @@ public class PropertyUtil {
 		return 0;
 	}
 
+	/**
+	 * Get dimension value
+	 *
+	 * @param content
+	 * @param d
+	 * @return Return the dimension value
+	 */
 	public static int getDimensionValue(IContent content, DimensionType d) {
 		return getDimensionValue(content, d, 0, 0);
 	}
@@ -393,25 +483,25 @@ public class PropertyUtil {
 			int referenceLength) {
 		if (d.getValueType() == DimensionType.TYPE_DIMENSION) {
 			String units = d.getUnits();
-			if (units.equals(EngineIRConstants.UNITS_PT) || units.equals(EngineIRConstants.UNITS_CM)
-					|| units.equals(EngineIRConstants.UNITS_MM) || units.equals(EngineIRConstants.UNITS_PC)
-					|| units.equals(EngineIRConstants.UNITS_IN)) {
-				double point = d.convertTo(EngineIRConstants.UNITS_PT) * 1000;
+			if (units.equals(DesignChoiceConstants.UNITS_PT) || units.equals(DesignChoiceConstants.UNITS_CM)
+					|| units.equals(DesignChoiceConstants.UNITS_MM) || units.equals(DesignChoiceConstants.UNITS_PC)
+					|| units.equals(DesignChoiceConstants.UNITS_IN)) {
+				double point = d.convertTo(DesignChoiceConstants.UNITS_PT) * 1000;
 				return (int) point;
-			} else if (units.equals(EngineIRConstants.UNITS_PX)) {
+			} else if (units.equals(DesignChoiceConstants.UNITS_PX)) {
 				double point = d.getMeasure() / getRenderDpi(content, renderOptionDpi) * 72000d;
 				return (int) point;
-			} else if (units.equals(EngineIRConstants.UNITS_PERCENTAGE)) {
+			} else if (units.equals(DesignChoiceConstants.UNITS_PERCENTAGE)) {
 				if (referenceLength < 0) {
 					return -1;
 				}
 				double point = referenceLength * d.getMeasure() / 100.0;
 				return (int) point;
-			} else if (units.equals(EngineIRConstants.UNITS_EM) || units.equals(EngineIRConstants.UNITS_EX)) {
+			} else if (units.equals(DesignChoiceConstants.UNITS_EM) || units.equals(DesignChoiceConstants.UNITS_EX)) {
 				int size = 9000;
 				if (content != null) {
 					IStyle style = content.getComputedStyle();
-					CSSValue fontSize = style.getProperty(IStyle.STYLE_FONT_SIZE);
+					CSSValue fontSize = style.getProperty(StyleConstants.STYLE_FONT_SIZE);
 					size = getDimensionValue(fontSize);
 				}
 				double point = size * d.getMeasure();
@@ -419,17 +509,26 @@ public class PropertyUtil {
 			}
 		} else if (d.getValueType() == DimensionType.TYPE_CHOICE) {
 			String choice = d.getChoice();
-			if (IStyle.CSS_MEDIUM_VALUE.equals(choice)) {
+			if (CSSConstants.CSS_MEDIUM_VALUE.equals(choice)) {
 				return 3000;
-			} else if (IStyle.CSS_THIN_VALUE.equals(choice)) {
+			} else if (CSSConstants.CSS_THIN_VALUE.equals(choice)) {
 				return 1000;
-			} else if (IStyle.CSS_THICK_VALUE.equals(choice)) {
+			} else if (CSSConstants.CSS_THICK_VALUE.equals(choice)) {
 				return 5000;
 			}
 		}
 		return 0;
 	}
 
+	/**
+	 * Get the image dimension value
+	 *
+	 * @param content
+	 * @param d
+	 * @param renderOptionDpi
+	 * @param referenceLength
+	 * @return Return image dimension value
+	 */
 	public static int getImageDimensionValue(IContent content, DimensionType d, int renderOptionDpi,
 			int referenceLength) {
 		if (d == null) {
@@ -443,6 +542,15 @@ public class PropertyUtil {
 		}
 	}
 
+	/**
+	 * Get the dimension value
+	 *
+	 * @param content
+	 * @param d
+	 * @param dpi
+	 * @param referenceLength
+	 * @return Return the dimension value
+	 */
 	public static int getDimensionValue(IContent content, DimensionType d, int dpi, int referenceLength) {
 		if (d == null) {
 			return 0;
@@ -455,10 +563,25 @@ public class PropertyUtil {
 		}
 	}
 
+	/**
+	 * Get the dimension value
+	 *
+	 * @param content
+	 * @param d
+	 * @param referenceLength
+	 * @return Return the dimension value
+	 */
 	public static int getDimensionValue(IContent content, DimensionType d, int referenceLength) {
 		return getDimensionValue(content, d, 0, referenceLength);
 	}
 
+	/**
+	 * Get int from attribute
+	 *
+	 * @param element
+	 * @param attribute
+	 * @return Return int of attribute
+	 */
 	public static int getIntAttribute(Element element, String attribute) {
 		String value = element.getAttribute(attribute);
 		int result = 1;
@@ -468,6 +591,13 @@ public class PropertyUtil {
 		return result;
 	}
 
+	/**
+	 * Get dimension type from attribute
+	 *
+	 * @param ele
+	 * @param attribute
+	 * @return Return dimension tye
+	 */
 	public static DimensionType getDimensionAttribute(Element ele, String attribute) {
 		String value = ele.getAttribute(attribute);
 		if (value == null || 0 == value.length()) {
@@ -476,6 +606,12 @@ public class PropertyUtil {
 		return DimensionType.parserUnit(value, DimensionType.UNITS_PX);
 	}
 
+	/**
+	 * Get int value
+	 *
+	 * @param value
+	 * @return Return int value
+	 */
 	public static int getIntValue(CSSValue value) {
 		if (value != null && (value instanceof FloatValue)) {
 			FloatValue fv = (FloatValue) value;
@@ -484,6 +620,12 @@ public class PropertyUtil {
 		return 0;
 	}
 
+	/**
+	 * Get percentage value
+	 *
+	 * @param value
+	 * @return Return percentage value
+	 */
 	public static float getPercentageValue(CSSValue value) {
 		if (value != null && (value instanceof FloatValue)) {
 			FloatValue fv = (FloatValue) value;
@@ -495,8 +637,14 @@ public class PropertyUtil {
 		return 0.0f;
 	}
 
+	/**
+	 * Is white space no wrap
+	 *
+	 * @param value
+	 * @return true, white space no wrap
+	 */
 	public static boolean isWhiteSpaceNoWrap(CSSValue value) {
-		return IStyle.CSS_NOWRAP_VALUE.equals(value.getCssText());
+		return CSSConstants.CSS_NOWRAP_VALUE.equals(value.getCssText());
 	}
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/AbstractArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/AbstractArea.java
@@ -81,18 +81,38 @@ public abstract class AbstractArea implements IArea {
 		this.isDummy = area.isDummy;
 	}
 
+	/**
+	 * Get the parent container
+	 *
+	 * @return Return the parent container
+	 */
 	public ContainerArea getParent() {
 		return parent;
 	}
 
+	/**
+	 * Set parent container
+	 *
+	 * @param parent
+	 */
 	public void setParent(ContainerArea parent) {
 		this.parent = parent;
 	}
 
+	/**
+	 * Get the vertical align at container
+	 *
+	 * @return Return the vertical align at container
+	 */
 	public CSSValue getVerticalAlign() {
 		return vAlign;
 	}
 
+	/**
+	 * Set vertical align of the container
+	 *
+	 * @param vAlign
+	 */
 	public void setVerticalAlign(CSSValue vAlign) {
 		this.vAlign = vAlign;
 	}
@@ -106,6 +126,11 @@ public abstract class AbstractArea implements IArea {
 		return bookmark;
 	}
 
+	/**
+	 * Set the bookmark of the container
+	 *
+	 * @param bookmark
+	 */
 	public void setBookmark(String bookmark) {
 		this.bookmark = bookmark;
 	}
@@ -115,20 +140,40 @@ public abstract class AbstractArea implements IArea {
 		return action;
 	}
 
+	/**
+	 * Set the hyperlink action of the container
+	 *
+	 * @param action
+	 */
 	public void setAction(IHyperlinkAction action) {
 		this.action = action;
 	}
 
+	/**
+	 * Set the position X of the container
+	 *
+	 * @param x X position of the container
+	 */
 	public void setX(int x) {
 		this.x = x;
 	}
 
+	/**
+	 * Set the position Y of the container
+	 *
+	 * @param y Y position of the container
+	 */
 	public void setY(int y) {
 		this.y = y;
 	}
 
 	protected IHyperlinkAction action = null;
 
+	/**
+	 * Set scale factor of the container
+	 *
+	 * @param scale scale factor of the container
+	 */
 	public void setScale(float scale) {
 		this.scale = scale;
 	}
@@ -154,20 +199,42 @@ public abstract class AbstractArea implements IArea {
 		return y;
 	}
 
+	/**
+	 * Set the position of the container
+	 *
+	 * @param x X position of the container
+	 * @param y Y position of the container
+	 */
 	public void setPosition(int x, int y) {
 		this.x = x;
 		this.y = y;
 	}
 
+	/**
+	 * Set the allocated position of the container
+	 *
+	 * @param x X position of the container
+	 * @param y Y position of the container
+	 */
 	public void setAllocatedPosition(int x, int y) {
 		this.x = x;
 		this.y = y;
 	}
 
+	/**
+	 * Set the allocated position Y of the container
+	 *
+	 * @param ay allocated position Y of the container
+	 */
 	public void setAllocatedY(int ay) {
 		y = ay;
 	}
 
+	/**
+	 * Set the allocated position X of the container
+	 *
+	 * @param ax allocated position X of the container
+	 */
 	public void setAllocatedX(int ax) {
 		x = ax;
 	}
@@ -206,10 +273,20 @@ public abstract class AbstractArea implements IArea {
 		this.height = height;
 	}
 
+	/**
+	 * Get the allocated width
+	 *
+	 * @return Return the allocated width
+	 */
 	public int getAllocatedWidth() {
 		return width;
 	}
 
+	/**
+	 * Get the allocated height
+	 *
+	 * @return Return the allocated height
+	 */
 	public int getAllocatedHeight() {
 		return height;
 	}
@@ -231,34 +308,67 @@ public abstract class AbstractArea implements IArea {
 	public int getBaseLine() {
 		if (baseLine == 0) {
 			return height;
-		} else {
-			return baseLine;
 		}
-
+		return baseLine;
 	}
 
+	/**
+	 * Get the abstract area
+	 *
+	 * @return Return the abstract area
+	 */
 	public abstract AbstractArea cloneArea();
 
+	/**
+	 * Create a deep clone of the area
+	 *
+	 * @return Return the deep clone of the area
+	 */
 	public AbstractArea deepClone() {
 		return cloneArea();
 	}
 
+	/**
+	 * Get the allocated position X
+	 *
+	 * @return Return the allocated position X
+	 */
 	public int getAllocatedX() {
 		return x;
 	}
 
+	/**
+	 * Get the allocated position Y
+	 *
+	 * @return Return the allocated position Y
+	 */
 	public int getAllocatedY() {
 		return y;
 	}
 
+	/**
+	 * Verify the reordering whether it is to ignore
+	 *
+	 * @return true, ignore reordering
+	 */
 	public boolean isIgnoreReordering() {
 		return ignoreReordering;
 	}
 
+	/**
+	 * Set the reordering ignore flag (true: ignore)
+	 *
+	 * @param ignoreReordering
+	 */
 	public void setIgnoreReordering(boolean ignoreReordering) {
 		this.ignoreReordering = ignoreReordering;
 	}
 
+	/**
+	 * Print debug information
+	 *
+	 * @param area
+	 */
 	public static void debugPrint(IArea area) {
 		if (area instanceof IContainerArea) {
 			System.out.print(area.getClass() + "||");
@@ -273,6 +383,11 @@ public abstract class AbstractArea implements IArea {
 		}
 	}
 
+	/**
+	 * Print debug information of visuals
+	 *
+	 * @param area
+	 */
 	public static void debugPrintVisual(IArea area) {
 		if (area instanceof ITextArea) {
 			System.out.println(((ITextArea) area).getText());
@@ -283,6 +398,11 @@ public abstract class AbstractArea implements IArea {
 		}
 	}
 
+	/**
+	 * Print debug information of with computed position X, Y
+	 *
+	 * @param area
+	 */
 	public static void debugPrintWithComputedXY(IArea area) {
 		debugPrint(area, 0, 0);
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/BlockContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/BlockContainerArea.java
@@ -41,7 +41,7 @@ import org.w3c.dom.css.CSSValue;
 public class BlockContainerArea extends ContainerArea implements IContainerArea {
 
 	/**
-	 * Constuctor
+	 * Constructor
 	 *
 	 * @param parent
 	 * @param context

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/CellArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/CellArea.java
@@ -21,6 +21,7 @@ import org.eclipse.birt.report.engine.content.ICellContent;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.content.impl.ReportContent;
+import org.eclipse.birt.report.engine.css.engine.StyleConstants;
 import org.eclipse.birt.report.engine.executor.ExecutionContext;
 import org.eclipse.birt.report.engine.layout.pdf.util.PropertyUtil;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
@@ -31,6 +32,12 @@ import org.eclipse.birt.report.engine.nLayout.area.style.DiagonalInfo;
 import org.eclipse.birt.report.engine.util.ResourceLocatorWrapper;
 import org.w3c.dom.css.CSSValue;
 
+/**
+ * Definition of the table cell area
+ *
+ * @since 3.3
+ *
+ */
 public class CellArea extends BlockContainerArea implements IContainerArea {
 
 	static int DEFAULT_PADDING = 1500;
@@ -49,15 +56,30 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 		CELL_DEFAULT.setPaddingLeft(DEFAULT_PADDING);
 	}
 
+	/**
+	 * Consructor container based
+	 *
+	 * @param parent
+	 * @param context
+	 * @param content
+	 */
 	public CellArea(ContainerArea parent, LayoutContext context, IContent content) {
 		super(parent, context, content);
 	}
 
+	/**
+	 * Constructor (default)
+	 */
 	public CellArea() {
 		super();
 		localProperties = CELL_DEFAULT;
 	}
 
+	/**
+	 * Constructor cell based
+	 *
+	 * @param cell
+	 */
 	public CellArea(CellArea cell) {
 		super(cell);
 		rowSpan = cell.rowSpan;
@@ -67,42 +89,92 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 		diagonalInfo = cell.diagonalInfo;
 	}
 
+	/**
+	 * Get the diagonal info
+	 *
+	 * @return Return the diagonal info
+	 */
 	public DiagonalInfo getDiagonalInfo() {
 		return diagonalInfo;
 	}
 
+	/**
+	 * Set the diagonal info
+	 *
+	 * @param diagonalInfo
+	 */
 	public void setDiagonalInfo(DiagonalInfo diagonalInfo) {
 		this.diagonalInfo = diagonalInfo;
 	}
 
+	/**
+	 * Get column id
+	 *
+	 * @return Return column id
+	 */
 	public int getColumnID() {
 		return columnID;
 	}
 
+	/**
+	 * Set the column id
+	 *
+	 * @param columnID
+	 */
 	public void setColumnID(int columnID) {
 		this.columnID = columnID;
 	}
 
+	/**
+	 * Get row id
+	 *
+	 * @return Return row id
+	 */
 	public int getRowID() {
 		return rowID;
 	}
 
+	/**
+	 * Set row id
+	 *
+	 * @param rowID
+	 */
 	public void setRowID(int rowID) {
 		this.rowID = rowID;
 	}
 
+	/**
+	 * Get colspan
+	 *
+	 * @return Return colspan
+	 */
 	public int getColSpan() {
 		return colSpan;
 	}
 
+	/**
+	 * Set colspan
+	 *
+	 * @param colSpan
+	 */
 	public void setColSpan(int colSpan) {
 		this.colSpan = colSpan;
 	}
 
+	/**
+	 * Get rowspan
+	 *
+	 * @return Return rowspan
+	 */
 	public int getRowSpan() {
 		return rowSpan;
 	}
 
+	/**
+	 * Set rowspan
+	 *
+	 * @param rowSpan
+	 */
 	public void setRowSpan(int rowSpan) {
 		this.rowSpan = rowSpan;
 	}
@@ -120,7 +192,7 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 	}
 
 	@Override
-	public void initialize() throws BirtException {
+	public void initialize() {
 		ICellContent cellContent = (ICellContent) content;
 		rowSpan = cellContent.getRowSpan();
 		columnID = cellContent.getColumn();
@@ -154,7 +226,7 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 			if (diagonalNumber > 0 && diagonalWidth > 0 && diagonalStyle != null) {
 				Color dc = PropertyUtil.getColor(cellContent.getDiagonalColor());
 				if (dc == null) {
-					dc = PropertyUtil.getColor(cellContent.getComputedStyle().getProperty(IStyle.STYLE_COLOR));
+					dc = PropertyUtil.getColor(cellContent.getComputedStyle().getProperty(StyleConstants.STYLE_COLOR));
 				}
 				diagonalInfo = new DiagonalInfo();
 				diagonalInfo.setDiagonal(diagonalNumber, diagonalStyle, diagonalWidth, dc);
@@ -169,7 +241,7 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 				}
 				Color adc = PropertyUtil.getColor(cellContent.getAntidiagonalColor());
 				if (adc == null) {
-					adc = PropertyUtil.getColor(cellContent.getComputedStyle().getProperty(IStyle.STYLE_COLOR));
+					adc = PropertyUtil.getColor(cellContent.getComputedStyle().getProperty(StyleConstants.STYLE_COLOR));
 				}
 
 				diagonalInfo.setAntiDiagonal(antidiagonalNumber, antidiagonalStyle, antidiagonalWidth, adc);
@@ -181,7 +253,7 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 	protected void buildProperties(IContent content, LayoutContext context) {
 		IStyle style = content.getComputedStyle();
 		boxStyle = new BoxStyle();
-		Color color = PropertyUtil.getColor(style.getProperty(IStyle.STYLE_BACKGROUND_COLOR));
+		Color color = PropertyUtil.getColor(style.getProperty(StyleConstants.STYLE_BACKGROUND_COLOR));
 		if (color != null) {
 			boxStyle.setBackgroundColor(color);
 		}
@@ -193,36 +265,41 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 				rl = exeContext.getResourceLocator();
 			}
 			BackgroundImageInfo backgroundImage = new BackgroundImageInfo(getImageUrl(url),
-					style.getProperty(IStyle.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl);
+					style.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl, this.getCurrentModule(),
+					style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
 			boxStyle.setBackgroundImage(backgroundImage);
 		}
 		localProperties = new LocalProperties();
 		IStyle cs = content.getStyle();
-		CSSValue padding = cs.getProperty(IStyle.STYLE_PADDING_TOP);
+		CSSValue padding = cs.getProperty(StyleConstants.STYLE_PADDING_TOP);
 		if (padding == null) {
 			localProperties.setPaddingTop(DEFAULT_PADDING);
 		} else {
-			localProperties.setPaddingTop(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_TOP), width));
+			localProperties
+					.setPaddingTop(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_TOP), width));
 		}
-		padding = cs.getProperty(IStyle.STYLE_PADDING_BOTTOM);
+		padding = cs.getProperty(StyleConstants.STYLE_PADDING_BOTTOM);
 		if (padding == null) {
 			localProperties.setPaddingBottom(DEFAULT_PADDING);
 		} else {
-			localProperties.setPaddingBottom(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_BOTTOM), width));
+			localProperties
+					.setPaddingBottom(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_BOTTOM), width));
 		}
-		padding = cs.getProperty(IStyle.STYLE_PADDING_LEFT);
+		padding = cs.getProperty(StyleConstants.STYLE_PADDING_LEFT);
 		if (padding == null) {
 			localProperties.setPaddingLeft(DEFAULT_PADDING);
 		} else {
-			localProperties.setPaddingLeft(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_LEFT), width));
+			localProperties
+					.setPaddingLeft(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_LEFT), width));
 		}
-		padding = cs.getProperty(IStyle.STYLE_PADDING_RIGHT);
+		padding = cs.getProperty(StyleConstants.STYLE_PADDING_RIGHT);
 		if (padding == null) {
 			localProperties.setPaddingRight(DEFAULT_PADDING);
 		} else {
-			localProperties.setPaddingRight(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_RIGHT), width));
+			localProperties
+					.setPaddingRight(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_RIGHT), width));
 		}
-		textAlign = content.getComputedStyle().getProperty(IStyle.STYLE_TEXT_ALIGN);
+		textAlign = content.getComputedStyle().getProperty(StyleConstants.STYLE_TEXT_ALIGN);
 	}
 
 	@Override

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ContainerArea.java
@@ -24,10 +24,11 @@ import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.content.impl.ReportContent;
+import org.eclipse.birt.report.engine.css.engine.StyleConstants;
 import org.eclipse.birt.report.engine.css.engine.value.FloatValue;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.executor.ExecutionContext;
 import org.eclipse.birt.report.engine.ir.DimensionType;
-import org.eclipse.birt.report.engine.ir.EngineIRConstants;
 import org.eclipse.birt.report.engine.layout.PDFConstants;
 import org.eclipse.birt.report.engine.layout.pdf.util.PropertyUtil;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
@@ -40,11 +41,20 @@ import org.eclipse.birt.report.engine.nLayout.area.style.BoxStyle;
 import org.eclipse.birt.report.engine.util.ResourceLocatorWrapper;
 import org.eclipse.birt.report.model.api.IResourceLocator;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
+import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
+import org.eclipse.birt.report.model.core.Module;
 import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSValue;
 
 import com.lowagie.text.Image;
 
+/**
+ *
+ * Define the container area
+ *
+ * @since 3.3
+ *
+ */
 public abstract class ContainerArea extends AbstractArea implements IContainerArea {
 
 	protected transient LocalProperties localProperties = LocalProperties.DEFAULT;
@@ -98,6 +108,13 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 
 	protected boolean isChildrenRemoved = false;
 
+	/**
+	 * Constructor
+	 *
+	 * @param parent
+	 * @param context
+	 * @param content
+	 */
 	public ContainerArea(ContainerArea parent, LayoutContext context, IContent content) {
 		this.parent = parent;
 		this.context = context;
@@ -123,6 +140,12 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		this.specifiedWidth = area.specifiedWidth;
 	}
 
+	/**
+	 * Get the enabling of automated page break
+	 *
+	 * @return Return the enabling of automated page break
+	 * @throws BirtException
+	 */
 	public boolean autoPageBreak() throws BirtException {
 		if (context.isFixedLayout() && specifiedHeight > 0
 				&& specifiedHeight + parent.getAbsoluteBP() <= context.getMaxBP()) {
@@ -134,6 +157,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return false;
 	}
 
+	/**
+	 * Get the vertical position calculated from content
+	 *
+	 * @return Return the vertical position calculated from content
+	 */
 	public int getAbsoluteBP() {
 		if (parent != null) {
 			return currentBP + getOffsetY() + parent.getAbsoluteBP();
@@ -141,66 +169,140 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return currentBP;
 	}
 
+	/**
+	 * Get the maximum height
+	 *
+	 * @return Return the maximum height
+	 */
 	public int getMaxAvaHeight() {
 		if (parent != null) {
 			return getContentHeight(parent.getMaxAvaHeight());
-		} else {
-			return context.getMaxBP();
 		}
+		return context.getMaxBP();
 	}
 
+	/**
+	 * Get the current vertical position
+	 *
+	 * @return Return the current vertical position
+	 */
 	public int getCurrentBP() {
 		return this.currentBP;
 	}
 
+	/**
+	 * Set the current vertical position
+	 *
+	 * @param currentBP the current vertical position
+	 */
 	public void setCurrentBP(int currentBP) {
 		this.currentBP = currentBP;
 	}
 
+	/**
+	 * Set the current horizontal position
+	 *
+	 * @param currentIP the current horizontal position
+	 */
 	public void setCurrentIP(int currentIP) {
 		this.currentIP = currentIP;
 	}
 
+	/**
+	 * Get the current horizontal position
+	 *
+	 * @return Return the horizontal vertical position
+	 */
 	public int getCurrentIP() {
 		return this.currentIP;
 	}
 
+	/**
+	 * Set the maximum width
+	 *
+	 * @param maxAvaWidth maximum width
+	 */
 	public void setMaxAvaWidth(int maxAvaWidth) {
 		this.maxAvaWidth = maxAvaWidth;
 	}
 
+	/**
+	 * Get the maximum width
+	 *
+	 * @return Return the maximum width
+	 */
 	public int getMaxAvaWidth() {
 		return maxAvaWidth;
 	}
 
+	/**
+	 * Get the current content
+	 *
+	 * @return Return the current content
+	 */
 	public IContent getContent() {
 		return content;
 	}
 
+	/**
+	 * Get the specific height
+	 *
+	 * @return Return the specific height
+	 */
 	public int getSpecifiedHeight() {
 		return specifiedHeight;
 	}
 
+	/**
+	 * Get the specific width
+	 *
+	 * @return Return the specific width
+	 */
 	public int getSpecifiedWidth() {
 		return specifiedWidth;
 	}
 
+	/**
+	 * Get the shrink option
+	 *
+	 * @return Return the shrink option
+	 */
 	public boolean isCanShrink() {
 		return canShrink;
 	}
 
+	/**
+	 * Get the text align
+	 *
+	 * @return Return the text align
+	 */
 	public CSSValue getTextAlign() {
 		return textAlign;
 	}
 
+	/**
+	 * Get the text indent
+	 *
+	 * @return Return the text indent
+	 */
 	public int getTextIndent() {
 		return textIndent;
 	}
 
+	/**
+	 * Set the inline stacking option
+	 *
+	 * @param isInlineStacking the inline stacking option
+	 */
 	public void setInlineStacking(boolean isInlineStacking) {
 		this.isInlineStacking = isInlineStacking;
 	}
 
+	/**
+	 * Get the inline stacking option
+	 *
+	 * @return Return the inline stacking option
+	 */
 	public boolean isInlineStacking() {
 		return isInlineStacking;
 	}
@@ -216,6 +318,12 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 
 	}
 
+	/**
+	 * Get the container child index based
+	 *
+	 * @param index index value of the child
+	 * @return Return the container children
+	 */
 	public IArea getChild(int index) {
 		if (index >= 0 && index < children.size()) {
 			return children.get(index);
@@ -223,18 +331,38 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return null;
 	}
 
+	/**
+	 * Add an area to the container
+	 *
+	 * @param index position of the area
+	 * @param area  area element
+	 */
 	public void addChild(int index, IArea area) {
 		children.add(index, area);
 	}
 
+	/**
+	 * Verify the area like child at the container
+	 *
+	 * @param area to be searched area like child
+	 * @return Return the index of an area
+	 */
 	public int indexOf(IArea area) {
 		return children.indexOf(area);
 	}
 
+	/**
+	 * Remove all child elements from the container
+	 */
 	public void removeAll() {
 		children.clear();
 	}
 
+	/**
+	 * Remove a specific element from the container
+	 *
+	 * @param area element which is to remove
+	 */
 	public void removeChild(IArea area) {
 		children.remove(area);
 	}
@@ -264,42 +392,105 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return boxStyle;
 	}
 
+	/**
+	 * Set the style of the container box
+	 *
+	 * @param boxStyle style object
+	 */
 	public void setBoxStyle(BoxStyle boxStyle) {
 		this.boxStyle = boxStyle;
 	}
 
+	/**
+	 * Get the page break after option
+	 *
+	 * @return Return the page break after option
+	 */
 	public CSSValue getPageBreakAfter() {
 		return pageBreakAfter;
 	}
 
+	/**
+	 * Set the page break after option
+	 *
+	 * @param pageBreakAfter the page break after option
+	 */
 	public void setPageBreakAfter(CSSValue pageBreakAfter) {
 		this.pageBreakAfter = pageBreakAfter;
 	}
 
+	/**
+	 * Get the page break before option
+	 *
+	 * @return Return the page break before option
+	 */
 	public CSSValue getPageBreakBefore() {
 		return pageBreakBefore;
 	}
 
+	/**
+	 * Set the page break before option
+	 *
+	 * @param pageBreakBefore the page break before option
+	 */
 	public void setPageBreakBefore(CSSValue pageBreakBefore) {
 		this.pageBreakBefore = pageBreakBefore;
 	}
 
+	/**
+	 * Get the page break inside option
+	 *
+	 * @return Return the page break inside option
+	 */
 	public CSSValue getPageBreakInside() {
 		return pageBreakInside;
 	}
 
+	/**
+	 * Set the page break inside option
+	 *
+	 * @param pageBreakInside the page break inside option
+	 */
 	public void setPageBreakInside(CSSValue pageBreakInside) {
 		this.pageBreakInside = pageBreakInside;
 	}
 
+	/**
+	 * Close the container area
+	 *
+	 * @throws BirtException
+	 */
 	public abstract void close() throws BirtException;
 
+	/**
+	 * Initialize the container area
+	 *
+	 * @throws BirtException
+	 */
 	public abstract void initialize() throws BirtException;
 
+	/**
+	 * Split container lines
+	 *
+	 * @param lineCount
+	 * @return Return the splitted results
+	 * @throws BirtException
+	 */
 	public abstract SplitResult splitLines(int lineCount) throws BirtException;
 
+	/**
+	 * Split container lines
+	 *
+	 * @param height
+	 * @param force
+	 * @return Return the splitted results
+	 * @throws BirtException
+	 */
 	public abstract SplitResult split(int height, boolean force) throws BirtException;
 
+	/**
+	 * Relayout the container area
+	 */
 	public void relayout() {
 		// FIXME to implement
 	}
@@ -328,9 +519,9 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 				float imageHeight = img.getPlainHeight() / resolutionY * 72;
 				if (content != null) {
 					IStyle style = content.getComputedStyle();
-					int ox = getDimensionValue(style.getProperty(IStyle.STYLE_BACKGROUND_POSITION_X),
+					int ox = getDimensionValue(style.getProperty(StyleConstants.STYLE_BACKGROUND_POSITION_X),
 							(width - (int) (imageWidth * PDFConstants.LAYOUT_TO_PDF_RATIO)));
-					int oy = getDimensionValue(style.getProperty(IStyle.STYLE_BACKGROUND_POSITION_Y),
+					int oy = getDimensionValue(style.getProperty(StyleConstants.STYLE_BACKGROUND_POSITION_Y),
 							(height - (int) (imageHeight * PDFConstants.LAYOUT_TO_PDF_RATIO)));
 					bgi.setXOffset(ox);
 					bgi.setYOffset(oy);
@@ -339,10 +530,15 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		}
 	}
 
+	/**
+	 * Get line height
+	 *
+	 * @return Return the line height
+	 */
 	public int getLineHeight() {
 		if (content != null) {
 			IStyle contentStyle = content.getComputedStyle();
-			return PropertyUtil.getDimensionValueConsiderDpi(contentStyle.getProperty(IStyle.STYLE_LINE_HEIGHT),
+			return PropertyUtil.getDimensionValueConsiderDpi(contentStyle.getProperty(StyleConstants.STYLE_LINE_HEIGHT),
 					content);
 		}
 		return 0;
@@ -420,16 +616,26 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		}
 	}
 
+	/**
+	 * Get content height
+	 *
+	 * @param allocatedHeight
+	 * @return Return the content height
+	 */
 	public int getContentHeight(int allocatedHeight) {
 		if (hasStyle) {
 			return allocatedHeight - localProperties.getPaddingBottom() - localProperties.getPaddingTop()
 					- localProperties.getMarginTop() - localProperties.getMarginBottom()
 					- boxStyle.getBottomBorderWidth() - boxStyle.getTopBorderWidth();
-		} else {
-			return allocatedHeight;
 		}
+		return allocatedHeight;
 	}
 
+	/**
+	 * Get the content position Y
+	 *
+	 * @return Return the content position Y
+	 */
 	public int getContentY() {
 		if (hasStyle) {
 			return localProperties.getPaddingTop() + boxStyle.getTopBorderWidth();
@@ -437,6 +643,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return 0;
 	}
 
+	/**
+	 * Get the content position X
+	 *
+	 * @return Return the content position X
+	 */
 	public int getContentX() {
 		if (hasStyle) {
 			return localProperties.getPaddingLeft() + boxStyle.getLeftBorderWidth();
@@ -444,6 +655,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return 0;
 	}
 
+	/**
+	 * Get the maximum Y position
+	 *
+	 * @return Return the maximum Y position
+	 */
 	public int getMaxYPosition() {
 		if (hasStyle) {
 			return y + height + localProperties.getMarginBottom();
@@ -451,6 +667,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return y + height;
 	}
 
+	/**
+	 * Get the minimum Y position
+	 *
+	 * @return Return the minimum Y position
+	 */
 	public int getMinYPosition() {
 		return y + height;
 	}
@@ -475,6 +696,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		}
 	}
 
+	/**
+	 * Set the content height
+	 *
+	 * @param cHeight
+	 */
 	public void setContentHeight(int cHeight) {
 		if (hasStyle) {
 			height = cHeight + localProperties.getPaddingBottom() + localProperties.getPaddingTop()
@@ -484,6 +710,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		}
 	}
 
+	/**
+	 * Set the content width
+	 *
+	 * @param cWidth
+	 */
 	public void setContentWidth(int cWidth) {
 		if (hasStyle) {
 			width = cWidth + localProperties.getPaddingLeft() + localProperties.getPaddingRight()
@@ -496,35 +727,33 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 	/**
 	 * set allocated X position
 	 *
-	 * @return
+	 * @return Return the allocated position X
 	 */
 	@Override
 	public int getAllocatedX() {
 		if (hasStyle) {
 			return x - localProperties.getMarginLeft();
-		} else {
-			return x;
 		}
+		return x;
 	}
 
 	/**
 	 * set allocated Y position
 	 *
-	 * @return
+	 * @return Return the allocated position Y
 	 */
 	@Override
 	public int getAllocatedY() {
 		if (hasStyle) {
 			return y - localProperties.getMarginTop();
-		} else {
-			return y;
 		}
+		return y;
 	}
 
 	/**
-	 * get content width
+	 * Get content width
 	 *
-	 * @return
+	 * @return Return the content width
 	 */
 	public int getContentWidth() {
 		if (hasStyle) {
@@ -534,66 +763,82 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 				localProperties.setPaddingLeft(0);
 				localProperties.setPaddingRight(0);
 				return width - totalBorderWidth;
-			} else {
-				return width - totalPaddngWidth - totalBorderWidth;
 			}
-		} else {
-			return width;
+			return width - totalPaddngWidth - totalBorderWidth;
 		}
+		return width;
 	}
 
 	/**
-	 * get content height
+	 * Get content height
 	 *
-	 * @return
+	 * @return Return the content height
 	 */
 	public int getContentHeight() {
 		if (hasStyle) {
 			return height - boxStyle.getTopBorderWidth() - boxStyle.getBottomBorderWidth()
 					- localProperties.getPaddingBottom() - localProperties.getPaddingTop();
-		} else {
-			return height;
 		}
+		return height;
 	}
 
 	/**
-	 * get allocated width
+	 * Get allocated width
 	 *
-	 * @return
+	 * @return Return allocated width
 	 */
 	@Override
 	public int getAllocatedWidth() {
 		if (hasStyle) {
 			return width + localProperties.getMarginLeft() + localProperties.getMarginRight();
-		} else {
-			return width;
 		}
+		return width;
 	}
 
 	/**
-	 * get allocated height
+	 * Get allocated height
 	 *
-	 * @return
+	 * @return Return allocated height
 	 */
 	@Override
 	public int getAllocatedHeight() {
 		if (hasStyle) {
 			return height + localProperties.getMarginBottom() + localProperties.getMarginTop();
-		} else {
-			return height;
 		}
+		return height;
 	}
 
+	/**
+	 * Get the maximum content width currently
+	 *
+	 * @return Return the maximum content width currently
+	 */
 	public int getCurrentMaxContentWidth() {
 		return maxAvaWidth - currentIP;
 	}
 
+	/**
+	 * Verify whether the container is empty
+	 *
+	 * @return Validation result of empty children
+	 */
 	public boolean isEmpty() {
 		return children.size() == 0;
 	}
 
+	/**
+	 * Update the child area of the container area
+	 *
+	 * @param area
+	 * @throws BirtException
+	 */
 	public abstract void update(AbstractArea area) throws BirtException;
 
+	/**
+	 * Add a child area to the container area
+	 *
+	 * @param area
+	 */
 	public abstract void add(AbstractArea area);
 
 	protected boolean checkPageBreak() throws BirtException {
@@ -614,6 +859,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return ret;
 	}
 
+	/**
+	 * Get the offset content position X
+	 *
+	 * @return Return the offset content position X
+	 */
 	public int getOffsetX() {
 		if (hasStyle) {
 			return localProperties.getPaddingLeft() + boxStyle.getLeftBorderWidth();
@@ -621,6 +871,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return 0;
 	}
 
+	/**
+	 * Get the offset content position Y
+	 *
+	 * @return Return the offset content position Y
+	 */
 	public int getOffsetY() {
 		if (hasStyle) {
 			return localProperties.getPaddingTop() + boxStyle.getTopBorderWidth();
@@ -646,25 +901,25 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		}
 		try {
 			String units = d.getUnits();
-			if (units.equals(EngineIRConstants.UNITS_PT) || units.equals(EngineIRConstants.UNITS_CM)
-					|| units.equals(EngineIRConstants.UNITS_MM) || units.equals(EngineIRConstants.UNITS_PC)
-					|| units.equals(EngineIRConstants.UNITS_IN)) {
-				double point = d.convertTo(EngineIRConstants.UNITS_PT) * 1000;
+			if (units.equals(DesignChoiceConstants.UNITS_PT) || units.equals(DesignChoiceConstants.UNITS_CM)
+					|| units.equals(DesignChoiceConstants.UNITS_MM) || units.equals(DesignChoiceConstants.UNITS_PC)
+					|| units.equals(DesignChoiceConstants.UNITS_IN)) {
+				double point = d.convertTo(DesignChoiceConstants.UNITS_PT) * 1000;
 				return (int) point;
-			} else if (units.equals(EngineIRConstants.UNITS_PX)) {
+			} else if (units.equals(DesignChoiceConstants.UNITS_PX)) {
 				if (dpi == 0) {
 					dpi = getResolution();
 				}
 				double point = d.getMeasure() / dpi * 72000d;
 				return (int) point;
-			} else if (units.equals(EngineIRConstants.UNITS_PERCENTAGE)) {
+			} else if (units.equals(DesignChoiceConstants.UNITS_PERCENTAGE)) {
 				double point = referenceLength * d.getMeasure() / 100.0;
 				return (int) point;
-			} else if (units.equals(EngineIRConstants.UNITS_EM) || units.equals(EngineIRConstants.UNITS_EX)) {
+			} else if (units.equals(DesignChoiceConstants.UNITS_EM) || units.equals(DesignChoiceConstants.UNITS_EX)) {
 				int size = 9000;
 				if (content != null) {
 					IStyle style = content.getComputedStyle();
-					CSSValue fontSize = style.getProperty(IStyle.STYLE_FONT_SIZE);
+					CSSValue fontSize = style.getProperty(StyleConstants.STYLE_FONT_SIZE);
 					size = getDimensionValue(fontSize);
 				}
 				double point = size * d.getMeasure();
@@ -717,30 +972,36 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 
 	protected void validateBoxProperty(IStyle style, int maxWidth, int maxHeight) {
 		// support negative margin
-		int leftMargin = getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_LEFT), maxWidth);
-		int rightMargin = getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_RIGHT), maxWidth);
-		int topMargin = getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_TOP), maxWidth);
-		int bottomMargin = getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_BOTTOM), maxWidth);
+		int leftMargin = getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_LEFT), maxWidth);
+		int rightMargin = getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_RIGHT), maxWidth);
+		int topMargin = getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_TOP), maxWidth);
+		int bottomMargin = getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_BOTTOM), maxWidth);
 
 		// do not support negative paddding
-		int leftPadding = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_LEFT), maxWidth));
-		int rightPadding = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_RIGHT), maxWidth));
-		int topPadding = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_TOP), maxWidth));
-		int bottomPadding = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_BOTTOM), maxWidth));
+		int leftPadding = Math.max(0,
+				getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_LEFT), maxWidth));
+		int rightPadding = Math.max(0,
+				getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_RIGHT), maxWidth));
+		int topPadding = Math.max(0, getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_TOP), maxWidth));
+		int bottomPadding = Math.max(0,
+				getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_BOTTOM), maxWidth));
 		// border does not support negative value, do not support pencentage
 		// dimension
-		int leftBorder = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_LEFT_WIDTH), 0));
-		int rightBorder = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_RIGHT_WIDTH), 0));
-		int topBorder = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_TOP_WIDTH), 0));
-		int bottomBorder = Math.max(0, getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_BOTTOM_WIDTH), 0));
+		int leftBorder = Math.max(0, getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_LEFT_WIDTH), 0));
+		int rightBorder = Math.max(0, getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_RIGHT_WIDTH), 0));
+		int topBorder = Math.max(0, getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_TOP_WIDTH), 0));
+		int bottomBorder = Math.max(0,
+				getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_BOTTOM_WIDTH), 0));
 
-		int[] vsStyle = { IStyle.STYLE_MARGIN_RIGHT, IStyle.STYLE_MARGIN_LEFT, IStyle.STYLE_PADDING_RIGHT,
-				IStyle.STYLE_PADDING_LEFT, IStyle.STYLE_BORDER_RIGHT_WIDTH, IStyle.STYLE_BORDER_LEFT_WIDTH };
+		int[] vsStyle = { StyleConstants.STYLE_MARGIN_RIGHT, StyleConstants.STYLE_MARGIN_LEFT,
+				StyleConstants.STYLE_PADDING_RIGHT, StyleConstants.STYLE_PADDING_LEFT,
+				StyleConstants.STYLE_BORDER_RIGHT_WIDTH, StyleConstants.STYLE_BORDER_LEFT_WIDTH };
 		int[] vs = { rightMargin, leftMargin, rightPadding, leftPadding, rightBorder, leftBorder };
 		boolean[] vsConflicted = resolveBoxConflict(vs, maxWidth);
 
-		int[] hsStyle = { IStyle.STYLE_MARGIN_BOTTOM, IStyle.STYLE_MARGIN_TOP, IStyle.STYLE_PADDING_BOTTOM,
-				IStyle.STYLE_PADDING_TOP, IStyle.STYLE_BORDER_BOTTOM_WIDTH, IStyle.STYLE_BORDER_TOP_WIDTH };
+		int[] hsStyle = { StyleConstants.STYLE_MARGIN_BOTTOM, StyleConstants.STYLE_MARGIN_TOP,
+				StyleConstants.STYLE_PADDING_BOTTOM, StyleConstants.STYLE_PADDING_TOP,
+				StyleConstants.STYLE_BORDER_BOTTOM_WIDTH, StyleConstants.STYLE_BORDER_TOP_WIDTH };
 		int[] hs = { bottomMargin, topMargin, bottomPadding, topPadding, bottomBorder, topBorder };
 		boolean[] hsConflicted = resolveBoxConflict(hs, maxHeight);
 
@@ -800,6 +1061,14 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return conflicted;
 	}
 
+	protected ReportDesignHandle getCurrentDesignHandle() {
+		return content.getReportContent().getDesign().getReportDesign();
+	}
+
+	protected Module getCurrentModule() {
+		return getCurrentDesignHandle().getModule();
+	}
+
 	protected void buildProperties(IContent content, LayoutContext context) {
 		// FIXME cache the LocalProperties and BoxStyle
 		// FIXME validate box properties
@@ -807,65 +1076,67 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		localProperties = new LocalProperties();
 		int maw = parent.getMaxAvaWidth();
 
-		localProperties.setMarginBottom(getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_BOTTOM), maw));
-		localProperties.setMarginLeft(getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_LEFT), maw));
-		localProperties.setMarginTop(getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_TOP), maw));
-		localProperties.setMarginRight(getDimensionValue(style.getProperty(IStyle.STYLE_MARGIN_RIGHT), maw));
+		localProperties.setMarginBottom(getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_BOTTOM), maw));
+		localProperties.setMarginLeft(getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_LEFT), maw));
+		localProperties.setMarginTop(getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_TOP), maw));
+		localProperties.setMarginRight(getDimensionValue(style.getProperty(StyleConstants.STYLE_MARGIN_RIGHT), maw));
 
-		localProperties.setPaddingBottom(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_BOTTOM), maw));
-		localProperties.setPaddingLeft(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_LEFT), maw));
-		localProperties.setPaddingTop(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_TOP), maw));
-		localProperties.setPaddingRight(getDimensionValue(style.getProperty(IStyle.STYLE_PADDING_RIGHT), maw));
+		localProperties
+				.setPaddingBottom(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_BOTTOM), maw));
+		localProperties.setPaddingLeft(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_LEFT), maw));
+		localProperties.setPaddingTop(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_TOP), maw));
+		localProperties.setPaddingRight(getDimensionValue(style.getProperty(StyleConstants.STYLE_PADDING_RIGHT), maw));
 
 		if (!isInlineStacking) {
-			pageBreakAfter = style.getProperty(IStyle.STYLE_PAGE_BREAK_AFTER);
+			pageBreakAfter = style.getProperty(StyleConstants.STYLE_PAGE_BREAK_AFTER);
 			if (pageBreakInside == null) {
-				pageBreakInside = style.getProperty(IStyle.STYLE_PAGE_BREAK_INSIDE);
+				pageBreakInside = style.getProperty(StyleConstants.STYLE_PAGE_BREAK_INSIDE);
 			}
-			pageBreakBefore = style.getProperty(IStyle.STYLE_PAGE_BREAK_BEFORE);
+			pageBreakBefore = style.getProperty(StyleConstants.STYLE_PAGE_BREAK_BEFORE);
 		}
 
 		this.boxStyle = new BoxStyle();
-		int borderWidth = getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_LEFT_WIDTH), maw);
+		int borderWidth = getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_LEFT_WIDTH), maw);
 		if (borderWidth > 0) {
-			boxStyle.setLeftBorder(new BorderInfo(style.getProperty(IStyle.STYLE_BORDER_LEFT_COLOR),
-					style.getProperty(IStyle.STYLE_BORDER_LEFT_STYLE), borderWidth));
+			boxStyle.setLeftBorder(new BorderInfo(style.getProperty(StyleConstants.STYLE_BORDER_LEFT_COLOR),
+					style.getProperty(StyleConstants.STYLE_BORDER_LEFT_STYLE), borderWidth));
 
 		}
 
-		borderWidth = getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_RIGHT_WIDTH), maw);
+		borderWidth = getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_RIGHT_WIDTH), maw);
 		if (borderWidth > 0) {
-			boxStyle.setRightBorder(new BorderInfo(style.getProperty(IStyle.STYLE_BORDER_RIGHT_COLOR),
-					style.getProperty(IStyle.STYLE_BORDER_RIGHT_STYLE), borderWidth));
+			boxStyle.setRightBorder(new BorderInfo(style.getProperty(StyleConstants.STYLE_BORDER_RIGHT_COLOR),
+					style.getProperty(StyleConstants.STYLE_BORDER_RIGHT_STYLE), borderWidth));
 
 		}
-		borderWidth = getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_TOP_WIDTH), maw);
+		borderWidth = getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_TOP_WIDTH), maw);
 		if (borderWidth > 0) {
-			boxStyle.setTopBorder(new BorderInfo(style.getProperty(IStyle.STYLE_BORDER_TOP_COLOR),
-					style.getProperty(IStyle.STYLE_BORDER_TOP_STYLE), borderWidth));
-
-		}
-
-		borderWidth = getDimensionValue(style.getProperty(IStyle.STYLE_BORDER_BOTTOM_WIDTH), maw);
-		if (borderWidth > 0) {
-			boxStyle.setBottomBorder(new BorderInfo(style.getProperty(IStyle.STYLE_BORDER_BOTTOM_COLOR),
-					style.getProperty(IStyle.STYLE_BORDER_BOTTOM_STYLE), borderWidth));
+			boxStyle.setTopBorder(new BorderInfo(style.getProperty(StyleConstants.STYLE_BORDER_TOP_COLOR),
+					style.getProperty(StyleConstants.STYLE_BORDER_TOP_STYLE), borderWidth));
 
 		}
 
-		Color color = PropertyUtil.getColor(style.getProperty(IStyle.STYLE_BACKGROUND_COLOR));
+		borderWidth = getDimensionValue(style.getProperty(StyleConstants.STYLE_BORDER_BOTTOM_WIDTH), maw);
+		if (borderWidth > 0) {
+			boxStyle.setBottomBorder(new BorderInfo(style.getProperty(StyleConstants.STYLE_BORDER_BOTTOM_COLOR),
+					style.getProperty(StyleConstants.STYLE_BORDER_BOTTOM_STYLE), borderWidth));
+
+		}
+
+		Color color = PropertyUtil.getColor(style.getProperty(StyleConstants.STYLE_BACKGROUND_COLOR));
 		if (color != null) {
 			boxStyle.setBackgroundColor(color);
 		}
-		CSSValue url = style.getProperty(IStyle.STYLE_BACKGROUND_IMAGE);
-		if (!IStyle.NONE_VALUE.equals(style.getProperty(IStyle.STYLE_BACKGROUND_IMAGE))) {
+		CSSValue url = style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE);
+		if (!CSSValueConstants.NONE_VALUE.equals(style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE))) {
 			ResourceLocatorWrapper rl = null;
 			ExecutionContext exeContext = ((ReportContent) content.getReportContent()).getExecutionContext();
 			if (exeContext != null) {
 				rl = exeContext.getResourceLocator();
 			}
 			BackgroundImageInfo backgroundImage = new BackgroundImageInfo(getImageUrl(url.getCssText()),
-					style.getProperty(IStyle.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl);
+					style.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl, this.getCurrentModule(),
+					style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
 			boxStyle.setBackgroundImage(backgroundImage);
 		}
 
@@ -873,12 +1144,12 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		bookmark = content.getBookmark();
 	}
 
-	protected void buildLogicContainerProperties(IContent content, LayoutContext context) {
+	protected void buildLogicContainerProperties(IContent content) {
 		IStyle style = content.getStyle();
 		if (style != null && !style.isEmpty()) {
 			boxStyle = new BoxStyle();
 			IStyle cs = content.getComputedStyle();
-			Color color = PropertyUtil.getColor(cs.getProperty(IStyle.STYLE_BACKGROUND_COLOR));
+			Color color = PropertyUtil.getColor(cs.getProperty(StyleConstants.STYLE_BACKGROUND_COLOR));
 
 			if (color != null) {
 				boxStyle.setBackgroundColor(color);
@@ -892,15 +1163,16 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 					rl = exeContext.getResourceLocator();
 				}
 				BackgroundImageInfo backgroundImage = new BackgroundImageInfo(getImageUrl(url),
-						cs.getProperty(IStyle.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl);
+						cs.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl, this.getCurrentModule(),
+						cs.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
 				boxStyle.setBackgroundImage(backgroundImage);
 			}
 			if (!isInlineStacking) {
-				pageBreakAfter = cs.getProperty(IStyle.STYLE_PAGE_BREAK_AFTER);
+				pageBreakAfter = cs.getProperty(StyleConstants.STYLE_PAGE_BREAK_AFTER);
 				if (pageBreakInside == null) {
-					pageBreakInside = cs.getProperty(IStyle.STYLE_PAGE_BREAK_INSIDE);
+					pageBreakInside = cs.getProperty(StyleConstants.STYLE_PAGE_BREAK_INSIDE);
 				}
-				pageBreakBefore = cs.getProperty(IStyle.STYLE_PAGE_BREAK_BEFORE);
+				pageBreakBefore = cs.getProperty(StyleConstants.STYLE_PAGE_BREAK_BEFORE);
 			}
 
 		} else {
@@ -912,7 +1184,10 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		action = content.getHyperlinkAction();
 	}
 
-	public abstract void updateChildrenPosition() throws BirtException;
+	/**
+	 * Update children position
+	 */
+	public abstract void updateChildrenPosition();
 
 	protected TableArea getTable() {
 		ContainerArea p = parent;
@@ -925,7 +1200,7 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 	@Override
 	public ContainerArea deepClone() {
 		ContainerArea result = (ContainerArea) cloneArea();
-		Iterator iter = children.iterator();
+		Iterator<IArea> iter = children.iterator();
 		while (iter.hasNext()) {
 			AbstractArea child = (AbstractArea) iter.next();
 			AbstractArea cloneChild = child.deepClone();
@@ -935,9 +1210,14 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return result;
 	}
 
+	/**
+	 * Get option to avoid the page break inside
+	 *
+	 * @return Return the option to avoid the page break inside
+	 */
 	public boolean isPageBreakInsideAvoid() {
 		if (pageBreakInside != null) {
-			return (IStyle.AVOID_VALUE == pageBreakInside);
+			return (CSSValueConstants.AVOID_VALUE == pageBreakInside);
 		}
 		return false;
 	}
@@ -956,9 +1236,14 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return imageUrl;
 	}
 
+	/**
+	 * Get the option to avoid the page break after
+	 *
+	 * @return Return the option to avoid the page break after
+	 */
 	public boolean isPageBreakAfterAvoid() {
 		if (localProperties != null) {
-			if (IStyle.AVOID_VALUE == pageBreakAfter) {
+			if (CSSValueConstants.AVOID_VALUE == pageBreakAfter) {
 				return true;
 			}
 		}
@@ -972,9 +1257,14 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return false;
 	}
 
+	/**
+	 * Get the option to avoid the page break before
+	 *
+	 * @return Return the option to avoid the page break before
+	 */
 	public boolean isPageBreakBeforeAvoid() {
 		if (localProperties != null) {
-			if (IStyle.AVOID_VALUE == pageBreakBefore) {
+			if (CSSValueConstants.AVOID_VALUE == pageBreakBefore) {
 				return true;
 			}
 		}
@@ -988,6 +1278,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return false;
 	}
 
+	/**
+	 * Get the last child area of the container
+	 *
+	 * @return Return the last child area of the container
+	 */
 	public IArea getLastChild() {
 		int size = children.size();
 		if (size > 0) {
@@ -996,6 +1291,11 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return null;
 	}
 
+	/**
+	 * Get the first child area of the container
+	 *
+	 * @return Return the first child area of the container
+	 */
 	public IArea getFirstChild() {
 		int size = children.size();
 		if (size > 0) {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ContainerArea.java
@@ -1061,10 +1061,26 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 		return conflicted;
 	}
 
+	/*
+	 * Get the current design handle
+	 *
+	 * Return the current design handle
+	 *
+	 * @since 4.13
+	 *
+	 */
 	protected ReportDesignHandle getCurrentDesignHandle() {
 		return content.getReportContent().getDesign().getReportDesign();
 	}
 
+	/*
+	 * Get the current container module
+	 *
+	 * Return the current container module
+	 *
+	 * @since 4.13
+	 *
+	 */
 	protected Module getCurrentModule() {
 		return getCurrentDesignHandle().getModule();
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ForeignHtmlRegionArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ForeignHtmlRegionArea.java
@@ -16,21 +16,36 @@ package org.eclipse.birt.report.engine.nLayout.area.impl;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IForeignContent;
-import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
 import org.eclipse.birt.report.engine.nLayout.area.IContainerArea;
 
+/**
+ * Definition of foreign HTML region area
+ *
+ * @since 3.3
+ *
+ */
 public class ForeignHtmlRegionArea extends RegionArea implements IContainerArea {
 
+	/**
+	 * Constructor (default)
+	 */
 	public ForeignHtmlRegionArea() {
 		super();
 	}
 
+	/**
+	 * Constructor content based
+	 *
+	 * @param content
+	 * @param context
+	 */
 	public ForeignHtmlRegionArea(IForeignContent content, LayoutContext context) {
 		super();
 		this.context = context;
 		this.content = content;
-		this.setPageBreakInside(IStyle.AVOID_VALUE);
+		this.setPageBreakInside(CSSValueConstants.AVOID_VALUE);
 	}
 
 	ForeignHtmlRegionArea(ForeignHtmlRegionArea area) {
@@ -45,7 +60,7 @@ public class ForeignHtmlRegionArea extends RegionArea implements IContainerArea 
 	}
 
 	@Override
-	public void close() throws BirtException {
+	public void close() {
 		finished = true;
 		if (specifiedHeight > 0) {
 			height = specifiedHeight;
@@ -74,7 +89,7 @@ public class ForeignHtmlRegionArea extends RegionArea implements IContainerArea 
 	}
 
 	@Override
-	public void update(AbstractArea area) throws BirtException {
+	public void update(AbstractArea area) { // throws BirtException {
 		int aHeight = area.getAllocatedHeight();
 		currentBP += aHeight;
 		if (currentIP + area.getAllocatedWidth() > maxAvaWidth) {
@@ -82,6 +97,11 @@ public class ForeignHtmlRegionArea extends RegionArea implements IContainerArea 
 		}
 	}
 
+	/**
+	 * Is the foreign HTML region finished
+	 *
+	 * @return true, foreign HTML region is finished
+	 */
 	public boolean isFinished() {
 		return finished;
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/HtmlRegionArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/HtmlRegionArea.java
@@ -17,7 +17,17 @@ package org.eclipse.birt.report.engine.nLayout.area.impl;
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.nLayout.area.IContainerArea;
 
+/**
+ * Definition of the HTML region area
+ *
+ * @since 3.3
+ *
+ */
 public class HtmlRegionArea extends RegionArea implements IContainerArea {
+
+	/**
+	 * Constructor
+	 */
 	public HtmlRegionArea() {
 		super();
 	}
@@ -27,7 +37,7 @@ public class HtmlRegionArea extends RegionArea implements IContainerArea {
 	}
 
 	@Override
-	public void close() throws BirtException {
+	public void close() {
 		if (specifiedHeight >= currentBP) {
 			finished = true;
 		} else {
@@ -45,6 +55,11 @@ public class HtmlRegionArea extends RegionArea implements IContainerArea {
 		}
 	}
 
+	/**
+	 * Verify if the HTML region is finished
+	 *
+	 * @return true, HTML region is finished
+	 */
 	public boolean isFinished() {
 		return finished;
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineStackingArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineStackingArea.java
@@ -17,26 +17,61 @@ import java.util.Iterator;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IContent;
-import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.content.ITextContent;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
+import org.eclipse.birt.report.engine.nLayout.area.IArea;
 import org.w3c.dom.css.CSSValue;
 
+/**
+ * Definition of the inline stacking area
+ *
+ * @since 3.3
+ *
+ */
 public abstract class InlineStackingArea extends ContainerArea {
 
+	/**
+	 * Constructor container based
+	 *
+	 * @param parent
+	 * @param context
+	 * @param content
+	 */
 	public InlineStackingArea(ContainerArea parent, LayoutContext context, IContent content) {
 		super(parent, context, content);
 		this.isInlineStacking = true;
 	}
 
+	/**
+	 * Constructor area based
+	 *
+	 * @param area
+	 */
 	public InlineStackingArea(InlineStackingArea area) {
 		super(area);
 	}
 
+	/**
+	 * End the line
+	 *
+	 * @param endParagraph
+	 * @throws BirtException
+	 */
 	public abstract void endLine(boolean endParagraph) throws BirtException;
 
+	/**
+	 * Is the line empty
+	 *
+	 * @return true, line is empty
+	 */
 	public abstract boolean isEmptyLine();
 
+	/**
+	 * Get the maximum line width
+	 *
+	 * @return Return maximum line width
+	 */
 	public abstract int getMaxLineWidth();
 
 	@Override
@@ -54,7 +89,7 @@ public abstract class InlineStackingArea extends ContainerArea {
 	@Override
 	public int getBaseLine() {
 		if (baseLine == 0 && children.size() > 0) {
-			Iterator iter = children.iterator();
+			Iterator<IArea> iter = children.iterator();
 			while (iter.hasNext()) {
 				AbstractArea child = (AbstractArea) iter.next();
 				baseLine = Math.max(baseLine, child.getY() + child.getBaseLine());
@@ -64,11 +99,11 @@ public abstract class InlineStackingArea extends ContainerArea {
 	}
 
 	@Override
-	public void updateChildrenPosition() throws BirtException {
+	public void updateChildrenPosition() {
 		first = false;
 		currentIP = 0;
 		if (children.size() > 0) {
-			Iterator iter = children.iterator();
+			Iterator<IArea> iter = children.iterator();
 			int x = getOffsetX();
 			int w = 0;
 			while (iter.hasNext()) {
@@ -91,17 +126,17 @@ public abstract class InlineStackingArea extends ContainerArea {
 	}
 
 	protected void verticalAlign() {
-		Iterator iter = getChildren();
+		Iterator<IArea> iter = getChildren();
 		while (iter.hasNext()) {
 			AbstractArea child = (AbstractArea) iter.next();
 			CSSValue vAlign = child.getVerticalAlign();
-			if (IStyle.TOP_VALUE.equals(vAlign)) {
+			if (CSSValueConstants.TOP_VALUE.equals(vAlign)) {
 				continue;
 			}
 			int spacing = getContentHeight() - child.getAllocatedHeight();
 
-			if ((vAlign == null && !isImageContainer(child)) || IStyle.BASELINE_VALUE.equals(vAlign)) {
-				// FIXME to implement basline alignment
+			if ((vAlign == null && !isImageContainer(child)) || CSSValueConstants.BASELINE_VALUE.equals(vAlign)) {
+				// FIXME to implement baseline alignment
 				int lineHeight = parent.getLineHeight();
 				if (lineHeight > 0) {
 					// align to middle, fix issue 164072
@@ -109,9 +144,9 @@ public abstract class InlineStackingArea extends ContainerArea {
 				} else {
 					child.setPosition(child.getX(), getBaseLine() - child.getBaseLine());
 				}
-			} else if (IStyle.BOTTOM_VALUE.equals(vAlign)) {
+			} else if (CSSValueConstants.BOTTOM_VALUE.equals(vAlign)) {
 				child.setPosition(child.getX(), child.getY() + spacing);
-			} else if (IStyle.MIDDLE_VALUE.equals(vAlign)) {
+			} else if (CSSValueConstants.MIDDLE_VALUE.equals(vAlign)) {
 				child.setPosition(child.getX(), child.getY() + spacing / 2);
 			}
 		}
@@ -120,11 +155,15 @@ public abstract class InlineStackingArea extends ContainerArea {
 	private boolean isImageContainer(AbstractArea area) {
 		if (area instanceof ImageInlineContainer || area instanceof ImageBlockContainer) {
 			return true;
-		} else {
-			return false;
 		}
+		return false;
 	}
 
+	/**
+	 * Set the text indent
+	 *
+	 * @param content
+	 */
 	public abstract void setTextIndent(ITextContent content);
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/LineArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/LineArea.java
@@ -21,6 +21,7 @@ import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.content.ITextContent;
 import org.eclipse.birt.report.engine.css.engine.StyleConstants;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.layout.pdf.util.PropertyUtil;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
 import org.eclipse.birt.report.engine.nLayout.area.IArea;
@@ -31,18 +32,35 @@ import org.w3c.dom.css.CSSValue;
 
 import com.ibm.icu.text.Bidi;
 
+/**
+ * Definition of line area
+ *
+ * @since 3.3
+ *
+ */
 public class LineArea extends InlineStackingArea {
 
 	protected byte baseLevel = Bidi.DIRECTION_LEFT_TO_RIGHT;
 
 	protected boolean setIndent = false;
 
+	/**
+	 * Constructor container absed
+	 *
+	 * @param parent
+	 * @param context
+	 */
 	public LineArea(ContainerArea parent, LayoutContext context) {
 		super(parent, context, null);
 		assert (parent != null);
 		isInInlineStacking = parent.isInInlineStacking;
 	}
 
+	/**
+	 * Constructor area based
+	 *
+	 * @param area
+	 */
 	public LineArea(LineArea area) {
 		super(area);
 		this.baseLevel = area.baseLevel;
@@ -50,6 +68,11 @@ public class LineArea extends InlineStackingArea {
 		this.isInInlineStacking = area.isInInlineStacking;
 	}
 
+	/**
+	 * Set base level
+	 *
+	 * @param baseLevel
+	 */
 	public void setBaseLevel(byte baseLevel) {
 		this.baseLevel = baseLevel;
 	}
@@ -80,6 +103,12 @@ public class LineArea extends InlineStackingArea {
 		}
 	}
 
+	/**
+	 * Generate alignment of context
+	 *
+	 * @param endParagraph
+	 * @param context
+	 */
 	public void align(boolean endParagraph, LayoutContext context) {
 		assert (parent instanceof BlockContainerArea);
 		CSSValue align = ((BlockContainerArea) parent).getTextAlign();
@@ -89,9 +118,9 @@ public class LineArea extends InlineStackingArea {
 		boolean isRightAligned = BidiAlignmentResolver.isRightAligned(parent.content, align, endParagraph);
 
 		// single line
-		if ((isRightAligned || IStyle.CENTER_VALUE.equals(align))) {
+		if ((isRightAligned || CSSValueConstants.CENTER_VALUE.equals(align))) {
 			int spacing = width - currentIP;
-			Iterator iter = getChildren();
+			Iterator<IArea> iter = getChildren();
 			while (iter.hasNext()) {
 				AbstractArea area = (AbstractArea) iter.next();
 
@@ -101,12 +130,12 @@ public class LineArea extends InlineStackingArea {
 					} else {
 						area.setPosition(spacing + area.getX() + ignoreRightMostWhiteSpace(), area.getY());
 					}
-				} else if (IStyle.CENTER_VALUE.equals(align)) {
+				} else if (CSSValueConstants.CENTER_VALUE.equals(align)) {
 					area.setPosition(spacing / 2 + area.getX(), area.getY());
 				}
 
 			}
-		} else if (IStyle.JUSTIFY_VALUE.equals(align) && !endParagraph) {
+		} else if (CSSValueConstants.JUSTIFY_VALUE.equals(align) && !endParagraph) {
 			justify();
 		}
 		if (context.getBidiProcessing()) {
@@ -118,7 +147,7 @@ public class LineArea extends InlineStackingArea {
 	private int ignoreRightMostWhiteSpace() {
 		AbstractArea area = this;
 		while (area instanceof ContainerArea) {
-			ArrayList children = ((ContainerArea) area).children;
+			ArrayList<IArea> children = ((ContainerArea) area).children;
 			if (children != null && children.size() > 0) {
 				area = (AbstractArea) children.get(children.size() - 1);
 			} else {
@@ -145,7 +174,7 @@ public class LineArea extends InlineStackingArea {
 		if (wordSpacing == 0) {
 			return 0;
 		}
-		Iterator iter = area.getChildren();
+		Iterator<IArea> iter = area.getChildren();
 		int delta = 0;
 		while (iter.hasNext()) {
 			AbstractArea child = (AbstractArea) iter.next();
@@ -175,7 +204,7 @@ public class LineArea extends InlineStackingArea {
 	}
 
 	private int adjustLetterSpacing(int letterSpacing, ContainerArea area) {
-		Iterator iter = area.getChildren();
+		Iterator<IArea> iter = area.getChildren();
 		int delta = 0;
 		while (iter.hasNext()) {
 			AbstractArea child = (AbstractArea) iter.next();
@@ -246,7 +275,7 @@ public class LineArea extends InlineStackingArea {
 	 */
 	private int getWhiteSpaceRawNumber(ContainerArea area) {
 		int count = 0;
-		Iterator iter = area.getChildren();
+		Iterator<IArea> iter = area.getChildren();
 		while (iter.hasNext()) {
 			AbstractArea child = (AbstractArea) iter.next();
 			if (child instanceof TextArea) {
@@ -269,7 +298,7 @@ public class LineArea extends InlineStackingArea {
 
 	private int getLetterNumber(ContainerArea area) {
 		int count = 0;
-		Iterator iter = area.getChildren();
+		Iterator<IArea> iter = area.getChildren();
 		while (iter.hasNext()) {
 			AbstractArea child = (AbstractArea) iter.next();
 			if (child instanceof TextArea) {
@@ -406,12 +435,12 @@ public class LineArea extends InlineStackingArea {
 			area.children = children;
 			area.context = context;
 			area.setParent(parent);
-			Iterator iter = area.getChildren();
+			Iterator<IArea> iter = area.getChildren();
 			while (iter.hasNext()) {
 				AbstractArea child = (AbstractArea) iter.next();
 				child.setParent(area);
 			}
-			children = new ArrayList();
+			children = new ArrayList<IArea>();
 			parent.add(area);
 			area.checkPageBreak();
 			parent.update(area);
@@ -450,7 +479,7 @@ public class LineArea extends InlineStackingArea {
 	public SplitResult split(int height, boolean force) throws BirtException {
 		assert (height < this.height);
 		LineArea result = null;
-		Iterator iter = children.iterator();
+		Iterator<IArea> iter = children.iterator();
 		while (iter.hasNext()) {
 			ContainerArea child = (ContainerArea) iter.next();
 
@@ -498,9 +527,8 @@ public class LineArea extends InlineStackingArea {
 		}
 		if (result != null) {
 			return new SplitResult(result, SplitResult.SPLIT_SUCCEED_WITH_PART);
-		} else {
-			return SplitResult.SUCCEED_WITH_NULL;
 		}
+		return SplitResult.SUCCEED_WITH_NULL;
 	}
 
 	@Override
@@ -509,7 +537,7 @@ public class LineArea extends InlineStackingArea {
 	}
 
 	@Override
-	public SplitResult splitLines(int lineCount) throws BirtException {
+	public SplitResult splitLines(int lineCount) {
 		return SplitResult.SUCCEED_WITH_NULL;
 	}
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/PageArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/PageArea.java
@@ -33,6 +33,7 @@ import org.eclipse.birt.report.engine.layout.pdf.emitter.LayoutEmitterAdapter;
 import org.eclipse.birt.report.engine.layout.pdf.util.PropertyUtil;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
 import org.eclipse.birt.report.engine.nLayout.RegionLayoutEngine;
+import org.eclipse.birt.report.engine.nLayout.area.IArea;
 import org.eclipse.birt.report.engine.nLayout.area.IContainerArea;
 import org.eclipse.birt.report.engine.nLayout.area.style.BackgroundImageInfo;
 import org.eclipse.birt.report.engine.nLayout.area.style.BorderInfo;
@@ -43,6 +44,12 @@ import org.eclipse.birt.report.model.core.Module;
 
 import com.lowagie.text.Image;
 
+/**
+ * Definition of the page area
+ *
+ * @since 3.3
+ *
+ */
 public class PageArea extends BlockContainerArea {
 
 	final static int DEFAULT_PAGE_WIDTH = 595275;
@@ -68,51 +75,104 @@ public class PageArea extends BlockContainerArea {
 	private transient int rootLeft;
 	private transient int rootTop;
 
+	/**
+	 * Constructor context based
+	 *
+	 * @param context
+	 * @param content
+	 * @param emitter
+	 */
 	public PageArea(LayoutContext context, IContent content, LayoutEmitterAdapter emitter) {
 		super(null, context, content);
 		this.emitter = emitter;
 		pageContent = (IPageContent) content;
 	}
 
+	/**
+	 * Constructor page area based
+	 *
+	 * @param area
+	 */
 	public PageArea(PageArea area) {
 		super(area);
 	}
 
+	/**
+	 * Get the header
+	 *
+	 * @return Return the header area
+	 */
 	public IContainerArea getHeader() {
 		return header;
 	}
 
+	/**
+	 * Verify to use multiple pages
+	 *
+	 * @return true, extend to multiple pages
+	 */
 	public boolean isExtendToMultiplePages() {
 		return extendToMultiplePages;
 	}
 
+	/**
+	 * Remove header from page
+	 */
 	public void removeHeader() {
-		((ContainerArea) root).removeChild(header);
+		root.removeChild(header);
 		header = null;
 	}
 
+	/**
+	 * Remove footer from page
+	 */
 	public void removeFooter() {
-		((ContainerArea) root).removeChild(footer);
+		root.removeChild(footer);
 		footer = null;
 	}
 
+	/**
+	 * Get the page footer
+	 *
+	 * @return Return page footer
+	 */
 	public IContainerArea getFooter() {
 		return footer;
 	}
 
+	/**
+	 * Get the page body
+	 *
+	 * @return Return page body
+	 */
 	public IContainerArea getBody() {
 		return body;
 	}
 
+	/**
+	 * Get the page root
+	 *
+	 * @return Return page root
+	 */
 	public IContainerArea getRoot() {
 		return root;
 	}
 
+	/**
+	 * Set the page root
+	 *
+	 * @param root
+	 */
 	public void setRoot(ContainerArea root) {
 		this.root = root;
 		this.children.add(root);
 	}
 
+	/**
+	 * Set the page body
+	 *
+	 * @param body
+	 */
 	public void setBody(ContainerArea body) {
 		if (this.body != null) {
 			body.setPosition(this.body.getX(), this.body.getY());
@@ -123,23 +183,46 @@ public class PageArea extends BlockContainerArea {
 		this.body = body;
 	}
 
+	/**
+	 * Remove page body
+	 */
 	public void removeBody() {
 		root.children.remove(body);
 		this.body = null;
 	}
 
+	/**
+	 * Set page header
+	 *
+	 * @param header
+	 */
 	public void setHeader(RegionArea header) {
 		this.header = header;
 	}
 
+	/**
+	 * Set page footer
+	 *
+	 * @param footer
+	 */
 	public void setFooter(RegionArea footer) {
 		this.footer = footer;
 	}
 
+	/**
+	 * Verify if the page enlarging is enabled
+	 *
+	 * @return true, enlarge page size is used
+	 */
 	public boolean isEnlargePageSize() {
 		return enlargePageSize;
 	}
 
+	/**
+	 * Set the option to enlarge the page size
+	 *
+	 * @param enlargePageSize
+	 */
 	public void setEnlargePageSize(boolean enlargePageSize) {
 		this.enlargePageSize = enlargePageSize;
 	}
@@ -155,34 +238,34 @@ public class PageArea extends BlockContainerArea {
 		if ((style != null) && !style.isEmpty()) {
 			BoxStyle boxStyle = new BoxStyle();
 			IStyle cs = pageContent.getComputedStyle();
-			int borderWidth = getDimensionValue(cs.getProperty(IStyle.STYLE_BORDER_LEFT_WIDTH), width);
+			int borderWidth = getDimensionValue(cs.getProperty(StyleConstants.STYLE_BORDER_LEFT_WIDTH), width);
 			if (borderWidth > 0) {
-				boxStyle.setLeftBorder(new BorderInfo(cs.getProperty(IStyle.STYLE_BORDER_LEFT_COLOR),
-						cs.getProperty(IStyle.STYLE_BORDER_LEFT_STYLE), borderWidth));
+				boxStyle.setLeftBorder(new BorderInfo(cs.getProperty(StyleConstants.STYLE_BORDER_LEFT_COLOR),
+						cs.getProperty(StyleConstants.STYLE_BORDER_LEFT_STYLE), borderWidth));
 
 			}
 
-			borderWidth = getDimensionValue(cs.getProperty(IStyle.STYLE_BORDER_RIGHT_WIDTH), width);
+			borderWidth = getDimensionValue(cs.getProperty(StyleConstants.STYLE_BORDER_RIGHT_WIDTH), width);
 			if (borderWidth > 0) {
-				boxStyle.setRightBorder(new BorderInfo(cs.getProperty(IStyle.STYLE_BORDER_RIGHT_COLOR),
-						cs.getProperty(IStyle.STYLE_BORDER_RIGHT_STYLE), borderWidth));
+				boxStyle.setRightBorder(new BorderInfo(cs.getProperty(StyleConstants.STYLE_BORDER_RIGHT_COLOR),
+						cs.getProperty(StyleConstants.STYLE_BORDER_RIGHT_STYLE), borderWidth));
 
 			}
-			borderWidth = getDimensionValue(cs.getProperty(IStyle.STYLE_BORDER_TOP_WIDTH), width);
+			borderWidth = getDimensionValue(cs.getProperty(StyleConstants.STYLE_BORDER_TOP_WIDTH), width);
 			if (borderWidth > 0) {
-				boxStyle.setTopBorder(new BorderInfo(cs.getProperty(IStyle.STYLE_BORDER_TOP_COLOR),
-						cs.getProperty(IStyle.STYLE_BORDER_TOP_STYLE), borderWidth));
+				boxStyle.setTopBorder(new BorderInfo(cs.getProperty(StyleConstants.STYLE_BORDER_TOP_COLOR),
+						cs.getProperty(StyleConstants.STYLE_BORDER_TOP_STYLE), borderWidth));
 
 			}
 
-			borderWidth = getDimensionValue(cs.getProperty(IStyle.STYLE_BORDER_BOTTOM_WIDTH), width);
+			borderWidth = getDimensionValue(cs.getProperty(StyleConstants.STYLE_BORDER_BOTTOM_WIDTH), width);
 			if (borderWidth > 0) {
-				boxStyle.setBottomBorder(new BorderInfo(cs.getProperty(IStyle.STYLE_BORDER_BOTTOM_COLOR),
-						cs.getProperty(IStyle.STYLE_BORDER_BOTTOM_STYLE), borderWidth));
+				boxStyle.setBottomBorder(new BorderInfo(cs.getProperty(StyleConstants.STYLE_BORDER_BOTTOM_COLOR),
+						cs.getProperty(StyleConstants.STYLE_BORDER_BOTTOM_STYLE), borderWidth));
 			}
 			return boxStyle;
 		}
-		return boxStyle.DEFAULT;
+		return BoxStyle.DEFAULT;
 	}
 
 	@Override
@@ -224,17 +307,6 @@ public class PageArea extends BlockContainerArea {
 		context.resetUnresolvedRowHints();
 	}
 
-	/*
-	 *
-	 *
-	 * public byte[] loadAsEmbeddedImage(String url, Module module) { StructureDefn
-	 * defn = (StructureDefn) MetaDataDictionary.getInstance()
-	 * .getStructure(EmbeddedImage.EMBEDDED_IMAGE_STRUCT); byte[] imageData = null;
-	 * try { EmbeddedImage ei = (EmbeddedImage)
-	 * StructureRefUtil.findStructure(module, defn, url); imageData =
-	 * ei.getData(module); } catch (Exception te) { imageData = null; } return
-	 * imageData; }
-	 */
 	protected BackgroundImageInfo createBackgroundImage(String url, Module module) {
 		ResourceLocatorWrapper rl = null;
 		ExecutionContext exeContext = ((ReportContent) content.getReportContent()).getExecutionContext();
@@ -244,8 +316,8 @@ public class PageArea extends BlockContainerArea {
 
 		IStyle cs = pageContent.getComputedStyle();
 		BackgroundImageInfo backgroundImage = null;
-		backgroundImage = new BackgroundImageInfo(url, cs.getProperty(IStyle.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl,
-				module, cs.getProperty(IStyle.STYLE_BACKGROUND_IMAGE_TYPE));
+		backgroundImage = new BackgroundImageInfo(url, cs.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0,
+				0, rl, module, cs.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
 		Image img = backgroundImage.getImageInstance();
 
 		IStyle style = pageContent.getStyle();
@@ -311,9 +383,10 @@ public class PageArea extends BlockContainerArea {
 			}
 
 			backgroundImage.setXOffset(
-					getDimensionValue(cs.getProperty(IStyle.STYLE_BACKGROUND_POSITION_X), width - actualWidth));
+					getDimensionValue(cs.getProperty(StyleConstants.STYLE_BACKGROUND_POSITION_X), width - actualWidth));
 			backgroundImage.setYOffset(
-					getDimensionValue(cs.getProperty(IStyle.STYLE_BACKGROUND_POSITION_Y), height - actualHeight));
+					getDimensionValue(cs.getProperty(StyleConstants.STYLE_BACKGROUND_POSITION_Y),
+							height - actualHeight));
 			backgroundImage.setHeight(actualHeight);
 			backgroundImage.setWidth(actualWidth);
 			return backgroundImage;
@@ -322,9 +395,7 @@ public class PageArea extends BlockContainerArea {
 	}
 
 	/**
-	 * support body auto resize, remove invalid header and footer
-	 *
-	 * @param page
+	 * Support body auto resize, remove invalid header and footer
 	 */
 	protected void updateBodySize() {
 		if (header != null && header.getHeight() >= root.getHeight()) {
@@ -401,6 +472,11 @@ public class PageArea extends BlockContainerArea {
 		}
 	}
 
+	/**
+	 * Floating footer
+	 *
+	 * @param page
+	 */
 	public void floatingFooter(PageArea page) {
 		ContainerArea footer = (ContainerArea) page.getFooter();
 		IContainerArea body = page.getBody();
@@ -555,6 +631,11 @@ public class PageArea extends BlockContainerArea {
 		finished = true;
 	}
 
+	/**
+	 * Verify if the page is empty
+	 *
+	 * @return true, the page is empty
+	 */
 	public boolean isPageEmpty() {
 		if (body.getChildrenCount() > 0) {
 			return false;
@@ -562,6 +643,12 @@ public class PageArea extends BlockContainerArea {
 		return true;
 	}
 
+	/**
+	 * Genereate the output page
+	 *
+	 * @param page
+	 * @throws BirtException
+	 */
 	public void outputPage(IPageContent page) throws BirtException {
 		FixedLayoutPageHintGenerator gen = context.getPageHintGenerator();
 		if (null != gen) {
@@ -578,7 +665,7 @@ public class PageArea extends BlockContainerArea {
 			int maxHeight = context.getMaxHeight();
 			int prefWidth = context.getPreferenceWidth();
 			int prefHeight = body.getHeight();
-			Iterator iter = page.getBody().getChildren();
+			Iterator<IArea> iter = page.getBody().getChildren();
 			while (iter.hasNext()) {
 				AbstractArea area = (AbstractArea) iter.next();
 				prefWidth = Math.max(prefWidth, area.getAllocatedX() + area.getAllocatedWidth());
@@ -612,7 +699,7 @@ public class PageArea extends BlockContainerArea {
 			int maxHeight = context.getMaxHeight();
 			int prefWidth = context.getPreferenceWidth(); // 0
 			int prefHeight = page.getBody().getHeight();
-			Iterator iter = page.getBody().getChildren();
+			Iterator<IArea> iter = page.getBody().getChildren();
 			while (iter.hasNext()) {
 				AbstractArea area = (AbstractArea) iter.next();
 				prefWidth = Math.max(prefWidth, area.getAllocatedX() + area.getAllocatedWidth());

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/PageArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/PageArea.java
@@ -39,11 +39,7 @@ import org.eclipse.birt.report.engine.nLayout.area.style.BorderInfo;
 import org.eclipse.birt.report.engine.nLayout.area.style.BoxStyle;
 import org.eclipse.birt.report.engine.util.ResourceLocatorWrapper;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
-import org.eclipse.birt.report.model.api.elements.structures.EmbeddedImage;
 import org.eclipse.birt.report.model.core.Module;
-import org.eclipse.birt.report.model.metadata.MetaDataDictionary;
-import org.eclipse.birt.report.model.metadata.StructureDefn;
-import org.eclipse.birt.report.model.util.StructureRefUtil;
 
 import com.lowagie.text.Image;
 
@@ -200,12 +196,12 @@ public class PageArea extends BlockContainerArea {
 		String imageUrl = EmitterUtil.getBackgroundImageUrl(style, designHandle,
 				pageContent.getReportContent().getReportContext() == null ? null
 						: pageContent.getReportContent().getReportContext().getAppContext());
+
 		if (backgroundColor != null || imageUrl != null) {
 			boxStyle = new BoxStyle();
 			boxStyle.setBackgroundColor(backgroundColor);
 			if (imageUrl != null) {
 				boxStyle.setBackgroundImage(createBackgroundImage(imageUrl, designHandle.getModule()));
-				// boxStyle.setBackgroundImage(createBackgroundImage(imageUrl));
 			}
 		}
 		context.setMaxHeight(root.getHeight());
@@ -228,34 +224,28 @@ public class PageArea extends BlockContainerArea {
 		context.resetUnresolvedRowHints();
 	}
 
-	public byte[] loadAsEmbeddedImage(String url, Module module) {
-		StructureDefn defn = (StructureDefn) MetaDataDictionary.getInstance()
-				.getStructure(EmbeddedImage.EMBEDDED_IMAGE_STRUCT);
-		byte[] imageData = null;
-		try {
-			EmbeddedImage ei = (EmbeddedImage) StructureRefUtil.findStructure(module, defn, url);
-			imageData = ei.getData(module);
-		} catch (Exception te) {
-			imageData = null;
-		}
-		return imageData;
-	}
-
+	/*
+	 *
+	 *
+	 * public byte[] loadAsEmbeddedImage(String url, Module module) { StructureDefn
+	 * defn = (StructureDefn) MetaDataDictionary.getInstance()
+	 * .getStructure(EmbeddedImage.EMBEDDED_IMAGE_STRUCT); byte[] imageData = null;
+	 * try { EmbeddedImage ei = (EmbeddedImage)
+	 * StructureRefUtil.findStructure(module, defn, url); imageData =
+	 * ei.getData(module); } catch (Exception te) { imageData = null; } return
+	 * imageData; }
+	 */
 	protected BackgroundImageInfo createBackgroundImage(String url, Module module) {
 		ResourceLocatorWrapper rl = null;
 		ExecutionContext exeContext = ((ReportContent) content.getReportContent()).getExecutionContext();
 		if (exeContext != null) {
 			rl = exeContext.getResourceLocator();
 		}
+
 		IStyle cs = pageContent.getComputedStyle();
 		BackgroundImageInfo backgroundImage = null;
-		byte[] imageData = loadAsEmbeddedImage( url, module );
-		if ( imageData != null ) {
-			backgroundImage = new BackgroundImageInfo( url, cs.getProperty( IStyle.STYLE_BACKGROUND_REPEAT ), 0, 0, 0, 0, rl, imageData);
-		} else {
-			backgroundImage = new BackgroundImageInfo( url, cs.getProperty( IStyle.STYLE_BACKGROUND_REPEAT ), 0, 0, 0, 0, rl );
-		}
-//		BackgroundImageInfo backgroundImage = new BackgroundImageInfo(url, cs.getProperty(IStyle.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl);
+		backgroundImage = new BackgroundImageInfo(url, cs.getProperty(IStyle.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl,
+				module, cs.getProperty(IStyle.STYLE_BACKGROUND_IMAGE_TYPE));
 		Image img = backgroundImage.getImageInstance();
 
 		IStyle style = pageContent.getStyle();

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RegionArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RegionArea.java
@@ -19,7 +19,16 @@ import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.ir.DimensionType;
 import org.eclipse.birt.report.engine.nLayout.area.IContainerArea;
 
+/**
+ * Definition of region area
+ *
+ * @since 3.3
+ *
+ */
 public class RegionArea extends BlockContainerArea implements IContainerArea {
+	/**
+	 *
+	 */
 	public RegionArea() {
 		super();
 	}
@@ -48,7 +57,7 @@ public class RegionArea extends BlockContainerArea implements IContainerArea {
 	}
 
 	@Override
-	public void close() throws BirtException {
+	public void close() {
 		if (context.isFixedLayout()) {
 			setContentHeight(specifiedHeight);
 		} else {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RepeatableArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RepeatableArea.java
@@ -23,25 +23,44 @@ import org.eclipse.birt.report.engine.content.IBandContent;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IElement;
 import org.eclipse.birt.report.engine.content.IRowContent;
-import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.ir.RowDesign;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
+import org.eclipse.birt.report.engine.nLayout.area.IArea;
 
+/**
+ * Class to define repeatable container area
+ *
+ * @since 3.3
+ *
+ */
 public abstract class RepeatableArea extends BlockContainerArea {
 
-	protected List repeatList = null;
+	protected List<AbstractArea> repeatList = null;
 
 	protected int repeatHeight = 0;
 
 	protected boolean inHeaderBand = false;
 
+	/**
+	 * Constructor
+	 *
+	 * @param parent
+	 * @param context
+	 * @param content
+	 */
 	public RepeatableArea(ContainerArea parent, LayoutContext context, IContent content) {
 		super(parent, context, content);
 		if (needRepeat()) {
-			repeatList = new ArrayList();
+			repeatList = new ArrayList<AbstractArea>();
 		}
 	}
 
+	/**
+	 * Set the flag of header band
+	 *
+	 * @param inHeaderBand
+	 */
 	public void setInHeaderBand(boolean inHeaderBand) {
 		this.inHeaderBand = inHeaderBand;
 	}
@@ -54,7 +73,6 @@ public abstract class RepeatableArea extends BlockContainerArea {
 			if (isInRepeatHeader(first)) {
 				return true;
 			}
-
 		}
 		return false;
 	}
@@ -97,7 +115,7 @@ public abstract class RepeatableArea extends BlockContainerArea {
 			return repeatHeight;
 		} else if (repeatList != null) {
 			for (int i = 0; i < repeatList.size(); i++) {
-				AbstractArea area = (AbstractArea) repeatList.get(i);
+				AbstractArea area = repeatList.get(i);
 				repeatHeight += area.getAllocatedHeight();
 			}
 			return repeatHeight;
@@ -109,17 +127,17 @@ public abstract class RepeatableArea extends BlockContainerArea {
 	public SplitResult split(int height, boolean force) throws BirtException {
 		// repeat header can not be split.
 		if (!force && repeatList != null && repeatList.size() > 0) {
-			Iterator i = children.iterator();
+			Iterator<IArea> i = children.iterator();
 			boolean firstHeaderRow = true;
 			while (i.hasNext()) {
 				ContainerArea area = (ContainerArea) i.next();
 				if (isInRepeatHeader(area)) {
 					if (firstHeaderRow) {
-						area.setPageBreakInside(IStyle.AVOID_VALUE);
+						area.setPageBreakInside(CSSValueConstants.AVOID_VALUE);
 						firstHeaderRow = false;
 					} else {
-						area.setPageBreakInside(IStyle.AVOID_VALUE);
-						area.setPageBreakBefore(IStyle.AVOID_VALUE);
+						area.setPageBreakInside(CSSValueConstants.AVOID_VALUE);
+						area.setPageBreakBefore(CSSValueConstants.AVOID_VALUE);
 					}
 				}
 			}
@@ -128,16 +146,15 @@ public abstract class RepeatableArea extends BlockContainerArea {
 	}
 
 	@Override
-	protected boolean isValidResult(List result) {
+	protected boolean isValidResult(List<ContainerArea> result) {
 		assert result != null;
 		if (repeatList != null && !repeatList.isEmpty()) {
 			if (result.size() > repeatList.size()) {
 				return true;
-			} else {
-				int index = result.indexOf(repeatList.get(repeatList.size() - 1));
-				if (index != -1 && result.size() - 1 > index) {
-					return true;
-				}
+			}
+			int index = result.indexOf(repeatList.get(repeatList.size() - 1));
+			if (index != -1 && result.size() - 1 > index) {
+				return true;
 			}
 			return false;
 		}
@@ -146,6 +163,11 @@ public abstract class RepeatableArea extends BlockContainerArea {
 
 	protected abstract boolean needRepeat();
 
+	/**
+	 * Constructor
+	 *
+	 * @param area
+	 */
 	public RepeatableArea(RepeatableArea area) {
 		super(area);
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RootArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RootArea.java
@@ -31,17 +31,35 @@ import org.eclipse.birt.report.engine.nLayout.LayoutContext;
 
 import com.ibm.icu.util.ULocale;
 
+/**
+ * Definition of the root area
+ * 
+ * @since 3.3
+ *
+ */
 public class RootArea extends BlockContainerArea {
 
 	protected transient LayoutEmitterAdapter emitter;
 
 	protected PageArea page;
 
+	/**
+	 * Constructor context based
+	 *
+	 * @param context
+	 * @param content
+	 * @param emitter
+	 */
 	public RootArea(LayoutContext context, IContent content, LayoutEmitterAdapter emitter) {
 		super(null, context, content);
 		this.emitter = emitter;
 	}
 
+	/**
+	 * Constructor based on root area
+	 *
+	 * @param area
+	 */
 	public RootArea(RootArea area) {
 		super(area);
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RowArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RowArea.java
@@ -20,9 +20,17 @@ import java.util.Iterator;
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSConstants;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
 import org.eclipse.birt.report.engine.nLayout.area.IArea;
 
+/**
+ * Definition of the table row area
+ *
+ * @since 3.3
+ *
+ */
 public class RowArea extends ContainerArea {
 
 	protected transient CellArea[] cells;
@@ -33,6 +41,13 @@ public class RowArea extends ContainerArea {
 
 	protected boolean needResolveBorder = false;
 
+	/**
+	 * Constructor
+	 *
+	 * @param parent
+	 * @param context
+	 * @param content
+	 */
 	public RowArea(ContainerArea parent, LayoutContext context, IContent content) {
 		super(parent, context, content);
 		cells = new CellArea[getTable().getColumnCount()];
@@ -50,6 +65,11 @@ public class RowArea extends ContainerArea {
 		this.cells = new CellArea[row.getColumnCount()];
 	}
 
+	/**
+	 * Get the column count
+	 *
+	 * @return Return the column count
+	 */
 	public int getColumnCount() {
 		TableArea table = getTableArea();
 		if (table != null) {
@@ -61,6 +81,11 @@ public class RowArea extends ContainerArea {
 		return 0;
 	}
 
+	/**
+	 * Set the cell object based on cell column id
+	 *
+	 * @param cell
+	 */
 	public void setCell(CellArea cell) {
 		int col = cell.getColumnID();
 		int colSpan = cell.getColSpan();
@@ -69,6 +94,12 @@ public class RowArea extends ContainerArea {
 		}
 	}
 
+	/**
+	 * Get the row cell based on the column id
+	 *
+	 * @param columnID
+	 * @return Return the cell
+	 */
 	public CellArea getCell(int columnID) {
 		if (columnID >= 0 && columnID < cells.length) {
 			return cells[columnID];
@@ -76,6 +107,12 @@ public class RowArea extends ContainerArea {
 		return null;
 	}
 
+	/**
+	 * Replace an cell through new cell
+	 *
+	 * @param origin original cell (to be replaced)
+	 * @param dest   new cell (to placed)
+	 */
 	public void replace(CellArea origin, CellArea dest) {
 		int index = children.indexOf(origin);
 		if (index >= 0) {
@@ -85,10 +122,20 @@ public class RowArea extends ContainerArea {
 		}
 	}
 
+	/**
+	 * Set the row id
+	 *
+	 * @param rowID
+	 */
 	public void setRowID(int rowID) {
 		this.rowID = rowID;
 	}
 
+	/**
+	 * Get the row id
+	 *
+	 * @return Return row id
+	 */
 	public int getRowID() {
 		return rowID;
 	}
@@ -100,11 +147,11 @@ public class RowArea extends ContainerArea {
 
 	@Override
 	public RowArea deepClone() {
-		RowArea result = (RowArea) cloneArea();
-		Iterator iter = children.iterator();
+		RowArea result = cloneArea();
+		Iterator<IArea> iter = children.iterator();
 		while (iter.hasNext()) {
 			CellArea child = (CellArea) iter.next();
-			CellArea cloneChild = (CellArea) child.deepClone();
+			CellArea cloneChild = child.deepClone();
 			result.children.add(cloneChild);
 			cloneChild.setParent(result);
 			result.setCell(cloneChild);
@@ -135,16 +182,16 @@ public class RowArea extends ContainerArea {
 	}
 
 	@Override
-	public void initialize() throws BirtException {
+	public void initialize() {
 		calculateSpecifiedHeight(content);
 		width = parent.getMaxAvaWidth();
 
-		buildLogicContainerProperties(content, context);
+		buildLogicContainerProperties(content);
 		parent.add(this);
 	}
 
 	protected boolean isRowEmpty() {
-		Iterator iter = getChildren();
+		Iterator<IArea> iter = getChildren();
 		while (iter.hasNext()) {
 			ContainerArea area = (ContainerArea) iter.next();
 			if (area.getChildrenCount() > 0) {
@@ -155,7 +202,7 @@ public class RowArea extends ContainerArea {
 	}
 
 	@Override
-	public void update(AbstractArea area) throws BirtException {
+	public void update(AbstractArea area) {
 		CellArea cArea = (CellArea) area;
 		int columnID = cArea.getColumnID();
 		// Retrieve direction from the top-level content.
@@ -191,6 +238,11 @@ public class RowArea extends ContainerArea {
 		this.setCell((CellArea) area);
 	}
 
+	/**
+	 * Add cell area to row based on column id
+	 *
+	 * @param cell
+	 */
 	public void addChildByColumnId(CellArea cell) {
 		int columnId = cell.getColumnID();
 		int index = 0;
@@ -214,14 +266,12 @@ public class RowArea extends ContainerArea {
 		} else if (isPageBreakInsideAvoid()) {
 			if (isPageBreakBeforeAvoid()) {
 				return SplitResult.BEFORE_AVOID_WITH_NULL;
-			} else {
-				_splitSpanCell(height, force);
-				needResolveBorder = true;
-				return SplitResult.SUCCEED_WITH_NULL;
 			}
-		} else {
-			return _split(height, force);
+			_splitSpanCell(height, force);
+			needResolveBorder = true;
+			return SplitResult.SUCCEED_WITH_NULL;
 		}
+		return _split(height, force);
 	}
 
 	protected void _splitSpanCell(int height, boolean force) throws BirtException {
@@ -245,7 +295,7 @@ public class RowArea extends ContainerArea {
 						CellArea cell = (CellArea) splitCell.getResult();
 						if (cell != null) {
 							CellArea oc = ((DummyCell) cells[i]).getCell();
-							ArrayList temp = cell.children;
+							ArrayList<IArea> temp = cell.children;
 							cell.children = oc.children;
 							oc.children = temp;
 							oc.updateChildrenPosition();
@@ -290,7 +340,7 @@ public class RowArea extends ContainerArea {
 						CellArea cell = (CellArea) splitCell.getResult();
 						if (cell != null) {
 							CellArea oc = ((DummyCell) cells[i]).getCell();
-							ArrayList temp = cell.children;
+							ArrayList<IArea> temp = cell.children;
 							cell.children = oc.children;
 							oc.children = temp;
 							oc.updateChildrenPosition();
@@ -330,11 +380,10 @@ public class RowArea extends ContainerArea {
 			updateRow();
 			needResolveBorder = true;
 			return new SplitResult(result, SplitResult.SPLIT_SUCCEED_WITH_PART);
-		} else {
-			updateRow();
-			needResolveBorder = true;
-			return SplitResult.SUCCEED_WITH_NULL;
 		}
+		updateRow();
+		needResolveBorder = true;
+		return SplitResult.SUCCEED_WITH_NULL;
 	}
 
 	protected void updateRow() {
@@ -351,9 +400,14 @@ public class RowArea extends ContainerArea {
 		}
 	}
 
+	/**
+	 * Update the row
+	 *
+	 * @param original row to be updated
+	 */
 	public void updateRow(RowArea original) {
 		int height = 0;
-		Iterator iter = children.iterator();
+		Iterator<IArea> iter = children.iterator();
 		while (iter.hasNext()) {
 			CellArea cell = (CellArea) iter.next();
 			height = Math.max(height, cell.getHeight());
@@ -379,25 +433,24 @@ public class RowArea extends ContainerArea {
 	public boolean isPageBreakInsideAvoid() {
 		if (getTableArea().isGridDesign()) {
 			return super.isPageBreakInsideAvoid();
-		} else {
-			// resolve 289645. Repeated row area may be set as page-break-inside: avoid.
-			if (IStyle.AVOID_VALUE == pageBreakInside) {
-				return true;
-			}
-			if (content != null) {
-				IStyle style = content.getStyle();
-				String pb = style.getPageBreakInside();
-				// auto value is set
-				if (IStyle.CSS_AUTO_VALUE.equals(pb)) {
-					return false;
-				}
-			}
+		}
+		// resolve 289645. Repeated row area may be set as page-break-inside: avoid.
+		if (CSSValueConstants.AVOID_VALUE == pageBreakInside) {
 			return true;
 		}
+		if (content != null) {
+			IStyle style = content.getStyle();
+			String pb = style.getPageBreakInside();
+			// auto value is set
+			if (CSSConstants.CSS_AUTO_VALUE.equals(pb)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override
-	public SplitResult splitLines(int lineCount) throws BirtException {
+	public SplitResult splitLines(int lineCount) {
 		if (isPageBreakBeforeAvoid()) {
 			return SplitResult.BEFORE_AVOID_WITH_NULL;
 		}
@@ -405,7 +458,7 @@ public class RowArea extends ContainerArea {
 	}
 
 	@Override
-	public void updateChildrenPosition() throws BirtException {
+	public void updateChildrenPosition() {
 
 	}
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableArea.java
@@ -34,9 +34,9 @@ import org.eclipse.birt.report.engine.content.ITableContent;
 import org.eclipse.birt.report.engine.content.impl.ReportContent;
 import org.eclipse.birt.report.engine.css.dom.StyleDeclaration;
 import org.eclipse.birt.report.engine.css.engine.StyleConstants;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.executor.ExecutionContext;
 import org.eclipse.birt.report.engine.ir.DimensionType;
-import org.eclipse.birt.report.engine.ir.EngineIRConstants;
 import org.eclipse.birt.report.engine.ir.GridItemDesign;
 import org.eclipse.birt.report.engine.layout.LayoutUtil;
 import org.eclipse.birt.report.engine.layout.pdf.util.PropertyUtil;
@@ -46,7 +46,14 @@ import org.eclipse.birt.report.engine.nLayout.area.style.BackgroundImageInfo;
 import org.eclipse.birt.report.engine.nLayout.area.style.BoxStyle;
 import org.eclipse.birt.report.engine.presentation.UnresolvedRowHint;
 import org.eclipse.birt.report.engine.util.ResourceLocatorWrapper;
+import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
 
+/**
+ * Definition of the table area
+ *
+ * @since 3.3
+ *
+ */
 public class TableArea extends RepeatableArea {
 
 	protected transient TableLayoutInfo layoutInfo;
@@ -58,6 +65,13 @@ public class TableArea extends RepeatableArea {
 	protected int startCol;
 	protected int endCol;
 
+	/**
+	 * Constructor container based
+	 *
+	 * @param parent
+	 * @param context
+	 * @param content
+	 */
 	public TableArea(ContainerArea parent, LayoutContext context, IContent content) {
 		super(parent, context, content);
 	}
@@ -68,16 +82,32 @@ public class TableArea extends RepeatableArea {
 		layoutInfo = table.layoutInfo;
 	}
 
+	/**
+	 * Verify if the row exists at the table
+	 *
+	 * @param row
+	 * @return true, row exists
+	 */
 	public boolean contains(RowArea row) {
 		return children.contains(row);
 	}
 
+	/**
+	 * Add row to the table
+	 *
+	 * @param row new row
+	 */
 	public void addRow(RowArea row) {
 		if (layout != null) {
 			layout.addRow(row, context.isFixedLayout());
 		}
 	}
 
+	/**
+	 * Get column count
+	 *
+	 * @return Return column count
+	 */
 	public int getColumnCount() {
 		if (content != null) {
 			return ((ITableContent) content).getColumnCount();
@@ -99,6 +129,12 @@ public class TableArea extends RepeatableArea {
 		return new TableArea(this);
 	}
 
+	/**
+	 * Get the position X from the layout based on column id
+	 *
+	 * @param columnID
+	 * @return Return the position X from the layout
+	 */
 	public int getXPos(int columnID) {
 		if (layoutInfo != null) {
 			return layoutInfo.getXPosition(columnID);
@@ -106,6 +142,11 @@ public class TableArea extends RepeatableArea {
 		return 0;
 	}
 
+	/**
+	 * Verify if the table use grid design (without data)
+	 *
+	 * @return true, table is grid design
+	 */
 	public boolean isGridDesign() {
 		if (content != null) {
 			Object gen = content.getGenerateBy();
@@ -120,7 +161,7 @@ public class TableArea extends RepeatableArea {
 		if (style != null && !style.isEmpty()) {
 			boxStyle = new BoxStyle();
 			IStyle cs = content.getComputedStyle();
-			Color color = PropertyUtil.getColor(cs.getProperty(IStyle.STYLE_BACKGROUND_COLOR));
+			Color color = PropertyUtil.getColor(cs.getProperty(StyleConstants.STYLE_BACKGROUND_COLOR));
 
 			if (color != null) {
 				boxStyle.setBackgroundColor(color);
@@ -134,20 +175,21 @@ public class TableArea extends RepeatableArea {
 					rl = exeContext.getResourceLocator();
 				}
 				BackgroundImageInfo backgroundImage = new BackgroundImageInfo(getImageUrl(url),
-						style.getProperty(IStyle.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl);
+						style.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl,
+						this.getCurrentModule(), style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
 				boxStyle.setBackgroundImage(backgroundImage);
 			}
 			localProperties = new LocalProperties();
 			int maw = parent.getMaxAvaWidth();
 
-			localProperties.setMarginBottom(getDimensionValue(cs.getProperty(IStyle.STYLE_MARGIN_BOTTOM), maw));
-			localProperties.setMarginLeft(getDimensionValue(cs.getProperty(IStyle.STYLE_MARGIN_LEFT), maw));
-			localProperties.setMarginTop(getDimensionValue(cs.getProperty(IStyle.STYLE_MARGIN_TOP), maw));
-			localProperties.setMarginRight(getDimensionValue(cs.getProperty(IStyle.STYLE_MARGIN_RIGHT), maw));
+			localProperties.setMarginBottom(getDimensionValue(cs.getProperty(StyleConstants.STYLE_MARGIN_BOTTOM), maw));
+			localProperties.setMarginLeft(getDimensionValue(cs.getProperty(StyleConstants.STYLE_MARGIN_LEFT), maw));
+			localProperties.setMarginTop(getDimensionValue(cs.getProperty(StyleConstants.STYLE_MARGIN_TOP), maw));
+			localProperties.setMarginRight(getDimensionValue(cs.getProperty(StyleConstants.STYLE_MARGIN_RIGHT), maw));
 			if (!isInlineStacking) {
-				pageBreakAfter = cs.getProperty(IStyle.STYLE_PAGE_BREAK_AFTER);
-				pageBreakInside = cs.getProperty(IStyle.STYLE_PAGE_BREAK_INSIDE);
-				pageBreakBefore = cs.getProperty(IStyle.STYLE_PAGE_BREAK_BEFORE);
+				pageBreakAfter = cs.getProperty(StyleConstants.STYLE_PAGE_BREAK_AFTER);
+				pageBreakInside = cs.getProperty(StyleConstants.STYLE_PAGE_BREAK_INSIDE);
+				pageBreakBefore = cs.getProperty(StyleConstants.STYLE_PAGE_BREAK_BEFORE);
 			}
 		} else {
 			hasStyle = false;
@@ -189,16 +231,16 @@ public class TableArea extends RepeatableArea {
 		cell.setColSpan(getColumnCount());
 		cell.setColumn(0);
 		StyleDeclaration cstyle = new StyleDeclaration(report.getCSSEngine());
-		cstyle.setProperty(IStyle.STYLE_BORDER_TOP_STYLE, IStyle.HIDDEN_VALUE);
-		cstyle.setProperty(IStyle.STYLE_BORDER_LEFT_STYLE, IStyle.HIDDEN_VALUE);
-		cstyle.setProperty(IStyle.STYLE_BORDER_RIGHT_STYLE, IStyle.HIDDEN_VALUE);
+		cstyle.setProperty(StyleConstants.STYLE_BORDER_TOP_STYLE, CSSValueConstants.HIDDEN_VALUE);
+		cstyle.setProperty(StyleConstants.STYLE_BORDER_LEFT_STYLE, CSSValueConstants.HIDDEN_VALUE);
+		cstyle.setProperty(StyleConstants.STYLE_BORDER_RIGHT_STYLE, CSSValueConstants.HIDDEN_VALUE);
 		cell.setInlineStyle(cstyle);
 		cell.setParent(row);
 		ILabelContent captionLabel = report.createLabelContent();
 		captionLabel.setParent(cell);
 		captionLabel.setText(caption);
 		StyleDeclaration style = new StyleDeclaration(report.getCSSEngine());
-		style.setProperty(IStyle.STYLE_TEXT_ALIGN, IStyle.CENTER_VALUE);
+		style.setProperty(StyleConstants.STYLE_TEXT_ALIGN, CSSValueConstants.CENTER_VALUE);
 		captionLabel.setInlineStyle(style);
 		RowArea captionRow = new RowArea(this, context, row);
 		captionRow.isDummy = true;
@@ -221,7 +263,7 @@ public class TableArea extends RepeatableArea {
 		captionRow.finished = true;
 		add(captionRow);
 		if (repeatList == null) {
-			repeatList = new ArrayList();
+			repeatList = new ArrayList<AbstractArea>();
 		}
 		repeatList.add(captionRow);
 		update(captionRow);
@@ -335,6 +377,9 @@ public class TableArea extends RepeatableArea {
 		return getLastRow(this);
 	}
 
+	/**
+	 * Resolve the bottom border of the table
+	 */
 	public void resolveBottomBorder() {
 		RowArea lastRow = getLastRow();
 		if (lastRow != null) {
@@ -385,6 +430,11 @@ public class TableArea extends RepeatableArea {
 		}
 	}
 
+	/**
+	 * Relayout the children of the table area
+	 *
+	 * @throws BirtException
+	 */
 	public void relayoutChildren() throws BirtException {
 		String nextRowId = null;
 		if (unresolvedRow != null) {
@@ -548,6 +598,13 @@ public class TableArea extends RepeatableArea {
 		checkDisplayNone();
 	}
 
+	/**
+	 * Get the cell width
+	 *
+	 * @param startColumn
+	 * @param endColumn
+	 * @return Return the cell width
+	 */
 	public int getCellWidth(int startColumn, int endColumn) {
 		if (layoutInfo != null) {
 			return layoutInfo.getCellWidth(startColumn, endColumn);
@@ -555,6 +612,12 @@ public class TableArea extends RepeatableArea {
 		return 0;
 	}
 
+	/**
+	 * Resolve the border conflict
+	 *
+	 * @param cellArea
+	 * @param isFirst
+	 */
 	public void resolveBorderConflict(CellArea cellArea, boolean isFirst) {
 		if (layout != null) {
 			layout.resolveBorderConflict(cellArea, isFirst);
@@ -611,20 +674,20 @@ public class TableArea extends RepeatableArea {
 		 * @return each column width in point.
 		 */
 		protected int[] formalize(DimensionType[] columns, int tableWidth, boolean isTableWidthDefined) {
-			ArrayList percentageList = new ArrayList();
-			ArrayList unsetList = new ArrayList();
-			ArrayList preFixedList = new ArrayList();
+			ArrayList<Integer> percentageList = new ArrayList<Integer>();
+			ArrayList<Integer> unsetList = new ArrayList<Integer>();
+			ArrayList<Integer> preFixedList = new ArrayList<Integer>();
 			int[] resolvedColumnWidth = new int[columns.length];
 			double total = 0.0f;
 			int fixedLength = 0;
 			for (int i = 0; i < columns.length; i++) {
 				if (columns[i] == null) {
 					unsetList.add(Integer.valueOf(i));
-				} else if (EngineIRConstants.UNITS_PERCENTAGE.equals(columns[i].getUnits())) {
+				} else if (DesignChoiceConstants.UNITS_PERCENTAGE.equals(columns[i].getUnits())) {
 					percentageList.add(Integer.valueOf(i));
 					total += columns[i].getMeasure();
-				} else if (EngineIRConstants.UNITS_EM.equals(columns[i].getUnits())
-						|| EngineIRConstants.UNITS_EX.equals(columns[i].getUnits())) {
+				} else if (DesignChoiceConstants.UNITS_EM.equals(columns[i].getUnits())
+						|| DesignChoiceConstants.UNITS_EX.equals(columns[i].getUnits())) {
 					int len = getDimensionValue(table, columns[i],
 							getDimensionValue(table.getComputedStyle().getProperty(StyleConstants.STYLE_FONT_SIZE)));
 					resolvedColumnWidth[i] = len;
@@ -644,11 +707,11 @@ public class TableArea extends RepeatableArea {
 
 			if (fixedLength >= tableWidth) {
 				for (int i = 0; i < unsetList.size(); i++) {
-					Integer index = (Integer) unsetList.get(i);
+					Integer index = unsetList.get(i);
 					resolvedColumnWidth[index.intValue()] = 0;
 				}
 				for (int i = 0; i < percentageList.size(); i++) {
-					Integer index = (Integer) percentageList.get(i);
+					Integer index = percentageList.get(i);
 					resolvedColumnWidth[index.intValue()] = 0;
 				}
 				return resolvedColumnWidth;
@@ -660,7 +723,7 @@ public class TableArea extends RepeatableArea {
 					if (!preFixedList.isEmpty()) {
 						int delta = left / preFixedList.size();
 						for (int i = 0; i < preFixedList.size(); i++) {
-							Integer index = (Integer) preFixedList.get(i);
+							Integer index = preFixedList.get(i);
 							resolvedColumnWidth[index.intValue()] += delta;
 						}
 					}
@@ -668,7 +731,7 @@ public class TableArea extends RepeatableArea {
 					float leftPercentage = (((float) (tableWidth - fixedLength)) / tableWidth) * 100.0f;
 					double ratio = leftPercentage / total;
 					for (int i = 0; i < percentageList.size(); i++) {
-						Integer index = (Integer) percentageList.get(i);
+						Integer index = percentageList.get(i);
 						columns[index.intValue()] = new DimensionType(columns[index.intValue()].getMeasure() * ratio,
 								columns[index.intValue()].getUnits());
 						resolvedColumnWidth[index.intValue()] = getDimensionValue(table, columns[index.intValue()],
@@ -679,7 +742,7 @@ public class TableArea extends RepeatableArea {
 				int left = tableWidth - fixedLength;
 				int eachWidth = left / unsetList.size();
 				for (int i = 0; i < unsetList.size(); i++) {
-					Integer index = (Integer) unsetList.get(i);
+					Integer index = unsetList.get(i);
 					resolvedColumnWidth[index.intValue()] = eachWidth;
 				}
 			} else {
@@ -687,11 +750,11 @@ public class TableArea extends RepeatableArea {
 				if (leftPercentage <= total) {
 					double ratio = leftPercentage / total;
 					for (int i = 0; i < unsetList.size(); i++) {
-						Integer index = (Integer) unsetList.get(i);
+						Integer index = unsetList.get(i);
 						resolvedColumnWidth[index.intValue()] = 0;
 					}
 					for (int i = 0; i < percentageList.size(); i++) {
-						Integer index = (Integer) percentageList.get(i);
+						Integer index = percentageList.get(i);
 						columns[index.intValue()] = new DimensionType(columns[index.intValue()].getMeasure() * ratio,
 								columns[index.intValue()].getUnits());
 						resolvedColumnWidth[index.intValue()] = getDimensionValue(table, columns[index.intValue()],
@@ -700,7 +763,7 @@ public class TableArea extends RepeatableArea {
 				} else {
 					int usedLength = fixedLength;
 					for (int i = 0; i < percentageList.size(); i++) {
-						Integer index = (Integer) percentageList.get(i);
+						Integer index = percentageList.get(i);
 						int width = getDimensionValue(table, columns[index.intValue()], tableWidth);
 						usedLength += width;
 						resolvedColumnWidth[index.intValue()] = width;
@@ -709,7 +772,7 @@ public class TableArea extends RepeatableArea {
 					int left = tableWidth - usedLength;
 					int eachWidth = left / unsetList.size();
 					for (int i = 0; i < unsetList.size(); i++) {
-						Integer index = (Integer) unsetList.get(i);
+						Integer index = unsetList.get(i);
 						resolvedColumnWidth[index.intValue()] = eachWidth;
 					}
 				}
@@ -756,32 +819,26 @@ public class TableArea extends RepeatableArea {
 			return formalize(columns, tableWidth, isTableWidthDefined);
 		}
 
-		private void redistributeWidth(int cols[], int delta, int sum, int currentSum) {
-			int avaWidth = sum / cols.length;
-			for (int i = 0; i < cols.length; i++) {
-				if (cols[i] < 0) {
-					cols[i] = avaWidth;
-				} else {
-					cols[i] -= (int) (((float) cols[i]) * delta / currentSum);
-				}
-			}
-
-		}
-
-		private void distributeLeftWidth(int cols[], int avaWidth) {
-			for (int i = 0; i < cols.length; i++) {
-				if (cols[i] < 0) {
-					cols[i] = avaWidth;
-				}
-			}
-		}
 	}
 
+	/**
+	 * Definition of table layout info
+	 *
+	 * @since 3.3
+	 *
+	 */
 	public static class TableLayoutInfo {
 
 		ITableContent tableContent;
 		LayoutContext context;
 
+		/**
+		 * Constructor
+		 *
+		 * @param tableContent
+		 * @param context
+		 * @param colWidth
+		 */
 		public TableLayoutInfo(ITableContent tableContent, LayoutContext context, int[] colWidth) {
 			this.tableContent = tableContent;
 			this.context = context;
@@ -796,20 +853,31 @@ public class TableArea extends RepeatableArea {
 			}
 		}
 
+		/**
+		 * Get the table width
+		 *
+		 * @return Return the table width
+		 */
 		public int getTableWidth() {
 			return this.tableWidth;
 		}
 
+		/**
+		 * Get the position X
+		 *
+		 * @param index
+		 * @return Return the position X
+		 */
 		public int getXPosition(int index) {
 			return xPositions[index];
 		}
 
 		/**
-		 * get cell width
+		 * Get cell width
 		 *
 		 * @param startColumn
 		 * @param endColumn
-		 * @return
+		 * @return Return the cell width
 		 */
 		public int getCellWidth(int startColumn, int endColumn) {
 			assert (startColumn < endColumn);

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextLineArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextLineArea.java
@@ -13,18 +13,34 @@
  ***********************************************************************/
 package org.eclipse.birt.report.engine.nLayout.area.impl;
 
-import org.eclipse.birt.core.exception.BirtException;
-import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
 
+/**
+ * Definition of text line area
+ *
+ * @since 3.3
+ *
+ */
 public class TextLineArea extends LineArea {
 
+	/**
+	 * Constructor container based
+	 *
+	 * @param parent
+	 * @param context
+	 */
 	public TextLineArea(ContainerArea parent, LayoutContext context) {
 		super(parent, context);
 		// support widow and orphans, do not auto-pagebreak in textlineArea
 		isInInlineStacking = true;
 	}
 
+	/**
+	 * Constructor area based
+	 *
+	 * @param area
+	 */
 	public TextLineArea(TextLineArea area) {
 		super(area);
 	}
@@ -35,15 +51,15 @@ public class TextLineArea extends LineArea {
 	}
 
 	@Override
-	public SplitResult splitLines(int lineCount) throws BirtException {
-		if (pageBreakBefore == IStyle.AVOID_VALUE) {
+	public SplitResult splitLines(int lineCount) {
+		if (pageBreakBefore == CSSValueConstants.AVOID_VALUE) {
 			return SplitResult.BEFORE_AVOID_WITH_NULL;
 		}
 		return SplitResult.SUCCEED_WITH_NULL;
 	}
 
 	@Override
-	public SplitResult split(int height, boolean force) throws BirtException {
+	public SplitResult split(int height, boolean force) {
 		if (force) {
 			TextLineArea newArea = cloneArea();
 			newArea.children.addAll(children);
@@ -51,7 +67,7 @@ public class TextLineArea extends LineArea {
 			this.height = 0;
 			return new SplitResult(newArea, SplitResult.SPLIT_SUCCEED_WITH_PART);
 		}
-		if (pageBreakBefore == IStyle.AVOID_VALUE) {
+		if (pageBreakBefore == CSSValueConstants.AVOID_VALUE) {
 			return SplitResult.BEFORE_AVOID_WITH_NULL;
 		}
 		return SplitResult.SUCCEED_WITH_NULL;

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/AreaConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/AreaConstants.java
@@ -14,30 +14,68 @@ package org.eclipse.birt.report.engine.nLayout.area.style;
 
 import java.util.HashMap;
 
-import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSConstants;
+import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.w3c.dom.css.CSSValue;
 
+/**
+ * Definition of area constants
+ *
+ * @since 3.3
+ *
+ */
 public abstract class AreaConstants {
-	public final static int NO_REPEAT = 0;
-	public final static int REPEAT_X = 1;
-	public final static int REPEAT_Y = 2;
-	public final static int REPEAT = 3;
-	public final static String URL = "url";
-	public final static String EMBED = "embed";
 
+	/**
+	 * repeat background image "none"
+	 */
+	public final static int NO_REPEAT = 0;
+
+	/**
+	 * repeat background image "horizontal"
+	 */
+	public final static int REPEAT_X = 1;
+
+	/**
+	 * repeat background image "vertical"
+	 */
+	public final static int REPEAT_Y = 2;
+
+	/**
+	 * repeat background image "horizontal" & "vertical"
+	 */
+	public final static int REPEAT = 3;
+
+	/**
+	 * source type of background images "URL"
+	 */
+	public final static String BGI_SRC_TYPE_URL = "url";
+
+	/**
+	 * source type of background images "EMBED"
+	 */
+	public final static String BGI_SRC_TYPE_EMBED = "embed";
+
+	/**
+	 * mapping list of repeat values
+	 */
 	public static HashMap<CSSValue, Integer> repeatMap = new HashMap<>();
+
+	/**
+	 * mapping list of bgi source type values
+	 */
 	public static HashMap<CSSValue, String> bgiSourceTypeMap = new HashMap<>();
 
 	static {
-		repeatMap.put(IStyle.NO_REPEAT_VALUE, NO_REPEAT);
-		repeatMap.put(IStyle.REPEAT_X_VALUE, REPEAT_X);
-		repeatMap.put(IStyle.REPEAT_Y_VALUE, REPEAT_Y);
-		repeatMap.put(IStyle.REPEAT_VALUE, REPEAT);
+		repeatMap.put(CSSValueConstants.NO_REPEAT_VALUE, NO_REPEAT);
+		repeatMap.put(CSSValueConstants.REPEAT_X_VALUE, REPEAT_X);
+		repeatMap.put(CSSValueConstants.REPEAT_Y_VALUE, REPEAT_Y);
+		repeatMap.put(CSSValueConstants.REPEAT_VALUE, REPEAT);
 	}
 
 	static {
-		bgiSourceTypeMap.put(IStyle.URL_VALUE, URL);
-		bgiSourceTypeMap.put(IStyle.EMBED_VALUE, EMBED);
+		bgiSourceTypeMap.put(CSSValueConstants.URL_VALUE, BGI_SRC_TYPE_URL);
+		bgiSourceTypeMap.put(CSSValueConstants.EMBED_VALUE, BGI_SRC_TYPE_EMBED);
 	}
 
 	/**
@@ -83,37 +121,49 @@ public abstract class AreaConstants {
 	 */
 	public final static int BORDER_STYLE_HIDDEN = 29;
 
+	/**
+	 * Mapping from CCS value to area constants
+	 */
 	public static HashMap<CSSValue, Integer> valueStyleMap = new HashMap<>();
 	static {
-		valueStyleMap.put(IStyle.DOTTED_VALUE, BORDER_STYLE_DOTTED);
-		valueStyleMap.put(IStyle.SOLID_VALUE, BORDER_STYLE_SOLID);
-		valueStyleMap.put(IStyle.DASHED_VALUE, BORDER_STYLE_DASHED);
-		valueStyleMap.put(IStyle.DOUBLE_VALUE, BORDER_STYLE_DOUBLE);
-		valueStyleMap.put(IStyle.GROOVE_VALUE, BORDER_STYLE_GROOVE);
-		valueStyleMap.put(IStyle.RIDGE_VALUE, BORDER_STYLE_RIDGE);
-		valueStyleMap.put(IStyle.INSET_VALUE, BORDER_STYLE_INSET);
-		valueStyleMap.put(IStyle.OUTSET_VALUE, BORDER_STYLE_OUTSET);
-		valueStyleMap.put(IStyle.NONE_VALUE, BORDER_STYLE_NONE);
-		valueStyleMap.put(IStyle.HIDDEN_VALUE, BORDER_STYLE_HIDDEN);
+		valueStyleMap.put(CSSValueConstants.DOTTED_VALUE, AreaConstants.BORDER_STYLE_DOTTED);
+		valueStyleMap.put(CSSValueConstants.SOLID_VALUE, AreaConstants.BORDER_STYLE_SOLID);
+		valueStyleMap.put(CSSValueConstants.DASHED_VALUE, AreaConstants.BORDER_STYLE_DASHED);
+		valueStyleMap.put(CSSValueConstants.DOUBLE_VALUE, AreaConstants.BORDER_STYLE_DOUBLE);
+		valueStyleMap.put(CSSValueConstants.GROOVE_VALUE, AreaConstants.BORDER_STYLE_GROOVE);
+		valueStyleMap.put(CSSValueConstants.RIDGE_VALUE, AreaConstants.BORDER_STYLE_RIDGE);
+		valueStyleMap.put(CSSValueConstants.INSET_VALUE, AreaConstants.BORDER_STYLE_INSET);
+		valueStyleMap.put(CSSValueConstants.OUTSET_VALUE, AreaConstants.BORDER_STYLE_OUTSET);
+		valueStyleMap.put(CSSValueConstants.NONE_VALUE, AreaConstants.BORDER_STYLE_NONE);
+		valueStyleMap.put(CSSValueConstants.HIDDEN_VALUE, AreaConstants.BORDER_STYLE_HIDDEN);
 
 	}
 
+	/**
+	 * Mapping from CCS style to area constants
+	 */
 	public static HashMap<String, Integer> stringStyleMap = new HashMap<>();
 	static {
-		stringStyleMap.put(IStyle.CSS_DOTTED_VALUE, BORDER_STYLE_DOTTED);
-		stringStyleMap.put(IStyle.CSS_SOLID_VALUE, BORDER_STYLE_SOLID);
-		stringStyleMap.put(IStyle.CSS_DASHED_VALUE, BORDER_STYLE_DASHED);
-		stringStyleMap.put(IStyle.CSS_DOUBLE_VALUE, BORDER_STYLE_DOUBLE);
-		stringStyleMap.put(IStyle.CSS_GROOVE_VALUE, BORDER_STYLE_GROOVE);
-		stringStyleMap.put(IStyle.CSS_RIDGE_VALUE, BORDER_STYLE_RIDGE);
-		stringStyleMap.put(IStyle.CSS_INSET_VALUE, BORDER_STYLE_INSET);
-		stringStyleMap.put(IStyle.CSS_OUTSET_VALUE, BORDER_STYLE_OUTSET);
-		stringStyleMap.put(IStyle.CSS_NONE_VALUE, BORDER_STYLE_NONE);
-		stringStyleMap.put(IStyle.CSS_HIDDEN_VALUE, BORDER_STYLE_HIDDEN);
-
+		stringStyleMap.put(CSSConstants.CSS_DOTTED_VALUE, AreaConstants.BORDER_STYLE_DOTTED);
+		stringStyleMap.put(CSSConstants.CSS_SOLID_VALUE, AreaConstants.BORDER_STYLE_SOLID);
+		stringStyleMap.put(CSSConstants.CSS_DASHED_VALUE, AreaConstants.BORDER_STYLE_DASHED);
+		stringStyleMap.put(CSSConstants.CSS_DOUBLE_VALUE, AreaConstants.BORDER_STYLE_DOUBLE);
+		stringStyleMap.put(CSSConstants.CSS_GROOVE_VALUE, AreaConstants.BORDER_STYLE_GROOVE);
+		stringStyleMap.put(CSSConstants.CSS_RIDGE_VALUE, AreaConstants.BORDER_STYLE_RIDGE);
+		stringStyleMap.put(CSSConstants.CSS_INSET_VALUE, AreaConstants.BORDER_STYLE_INSET);
+		stringStyleMap.put(CSSConstants.CSS_OUTSET_VALUE, AreaConstants.BORDER_STYLE_OUTSET);
+		stringStyleMap.put(CSSConstants.CSS_NONE_VALUE, AreaConstants.BORDER_STYLE_NONE);
+		stringStyleMap.put(CSSConstants.CSS_HIDDEN_VALUE, AreaConstants.BORDER_STYLE_HIDDEN);
 	}
 
+	/**
+	 * The value of direction left-to-right "LTR"
+	 */
 	public final static int DIRECTION_LTR = 40;
+
+	/**
+	 * The value of direction right-to-left "RTL"
+	 */
 	public final static int DIRECTION_RTL = 41;
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/AreaConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/AreaConstants.java
@@ -22,14 +22,22 @@ public abstract class AreaConstants {
 	public final static int REPEAT_X = 1;
 	public final static int REPEAT_Y = 2;
 	public final static int REPEAT = 3;
+	public final static String URL = "url";
+	public final static String EMBED = "embed";
 
 	public static HashMap<CSSValue, Integer> repeatMap = new HashMap<>();
+	public static HashMap<CSSValue, String> bgiSourceTypeMap = new HashMap<>();
 
 	static {
 		repeatMap.put(IStyle.NO_REPEAT_VALUE, NO_REPEAT);
 		repeatMap.put(IStyle.REPEAT_X_VALUE, REPEAT_X);
 		repeatMap.put(IStyle.REPEAT_Y_VALUE, REPEAT_Y);
 		repeatMap.put(IStyle.REPEAT_VALUE, REPEAT);
+	}
+
+	static {
+		bgiSourceTypeMap.put(IStyle.URL_VALUE, URL);
+		bgiSourceTypeMap.put(IStyle.EMBED_VALUE, EMBED);
 	}
 
 	/**

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64.Decoder;
 import java.util.Base64.Encoder;
 
-import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.util.ResourceLocatorWrapper;
 import org.eclipse.birt.report.engine.util.SvgFile;
 import org.eclipse.birt.report.model.api.elements.structures.EmbeddedImage;
@@ -58,16 +57,14 @@ public class BackgroundImageInfo extends AreaConstants {
 
 	private final static String DATA_PROTOCOL = "data:";
 
+	private final static String DATA_URL_BASE64 = ";base64,";
+
 	// mapping based on image extension: to MIME-type to default extension
 	private final static String[][] SUPPORTED_MIME_TYPES = { { ".jpg", "image/jpeg", "jpg" },
 			{ ".jpe", "image/jpeg", "jpg" }, { ".jpeg", "image/jpeg", "jpg" }, { ".tiff", "image/tiff", "tiff" },
 			{ ".svg", "image/svg+xml", "svg" }, { ".png", "image/png", "png" }, { ".gif", "image/gif", "gif" } };
-	/**
-	 * <img src=
-	 * "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9YGARc5KB0XV+IAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAF1JREFUGNO9zL0NglAAxPEfdLTs4BZM4DIO4C7OwQg2JoQ9LE1exdlYvBBeZ7jqch9//q1uH4TLzw4d6+ErXMMcXuHWxId3KOETnnXXV6MJpcq2MLaI97CER3N0vr4MkhoXe0rZigAAAABJRU5ErkJggg=="
-	 * alt="Roter Punkt" />
-	 */
-	protected final static String BGI_SOURCE_TYPE_DEFAULT = "url";
+
+	protected final static String BGI_SRC_TYPE_DEFAULT = BGI_SRC_TYPE_URL;
 
 	private Module module = null;
 
@@ -77,35 +74,6 @@ public class BackgroundImageInfo extends AreaConstants {
 
 	/**
 	 * constructor 01 of background image
-	 *
-	 * @param url
-	 * @param repeatedMode
-	 * @param xOffset
-	 * @param yOffset
-	 * @param height
-	 * @param width
-	 * @param rl
-	 * @param sourceType
-	 */
-	public BackgroundImageInfo(String url, int repeatedMode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl, String sourceType) {
-		this.xOffset = xOffset;
-		this.yOffset = yOffset;
-		this.repeatedMode = repeatedMode;
-		this.width = width;
-		this.height = height;
-		this.url = url;
-		this.rl = rl;
-		if (sourceType != null) {
-			this.sourceType = sourceType;
-		} else {
-			this.sourceType = BGI_SOURCE_TYPE_DEFAULT;
-		}
-		prepareImageByteArray();
-	}
-
-	/**
-	 * constructor 02 of background image
 	 *
 	 * @param url
 	 * @param repeatedMode
@@ -130,17 +98,13 @@ public class BackgroundImageInfo extends AreaConstants {
 		if (sourceType != null) {
 			this.sourceType = sourceType;
 		} else {
-			this.sourceType = BGI_SOURCE_TYPE_DEFAULT;
+			this.sourceType = BGI_SRC_TYPE_DEFAULT;
 		}
 		prepareImageByteArray();
-		/*
-		 * this.imageData = imageData; try { this.image = Image.getInstance(imageData);
-		 * } catch (Exception e) { prepareImageByteArray(); }
-		 */
 	}
 
 	/**
-	 * constructor 03 of background image
+	 * constructor 02 of background image
 	 *
 	 * @param bgi
 	 */
@@ -157,41 +121,12 @@ public class BackgroundImageInfo extends AreaConstants {
 		if (bgi.sourceType != null) {
 			this.sourceType = bgi.sourceType;
 		} else {
-			this.sourceType = BGI_SOURCE_TYPE_DEFAULT;
+			this.sourceType = BGI_SRC_TYPE_DEFAULT;
 		}
 	}
 
 	/**
-	 * constructor 04 of background image
-	 *
-	 * @param url
-	 * @param mode
-	 * @param xOffset
-	 * @param yOffset
-	 * @param height
-	 * @param width
-	 * @param rl
-	 */
-	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl) {
-		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl,
-				BGI_SOURCE_TYPE_DEFAULT);
-	}
-
-	/**
-	 * constructor 05 of background image
-	 *
-	 * @param url
-	 * @param height
-	 * @param width
-	 * @param rl
-	 */
-	public BackgroundImageInfo(String url, int height, int width, ResourceLocatorWrapper rl) {
-		this(url, 0, 0, 0, height, width, rl, BGI_SOURCE_TYPE_DEFAULT);
-	}
-
-	/**
-	 * constructor 06 of background image
+	 * constructor 03 of background image
 	 *
 	 * @param url
 	 * @param mode
@@ -205,28 +140,11 @@ public class BackgroundImageInfo extends AreaConstants {
 	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
 			ResourceLocatorWrapper rl, Module module) {
 		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, module,
-				BGI_SOURCE_TYPE_DEFAULT);
+				BGI_SRC_TYPE_DEFAULT);
 	}
 
 	/**
-	 * constructor 07 of background image
-	 *
-	 * @param url
-	 * @param mode
-	 * @param xOffset
-	 * @param yOffset
-	 * @param height
-	 * @param width
-	 * @param rl
-	 * @param sourceType
-	 */
-	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl, String sourceType) {
-		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, sourceType);
-	}
-
-	/**
-	 * constructor 08 of background image
+	 * constructor 04 of background image
 	 *
 	 * @param url
 	 * @param mode
@@ -241,7 +159,8 @@ public class BackgroundImageInfo extends AreaConstants {
 	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
 			ResourceLocatorWrapper rl, Module module, CSSValue sourceType) {
 		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, module,
-				sourceType.toString());
+				sourceType != null ? bgiSourceTypeMap.get(sourceType)
+						: BGI_SRC_TYPE_URL);
 	}
 
 	/**
@@ -253,6 +172,9 @@ public class BackgroundImageInfo extends AreaConstants {
 		this.rl = rl;
 	}
 
+	/**
+	 * Create the data URL of the image
+	 */
 	private void createDataUrl() {
 
 		if (this.url != null && this.url.contains(DATA_PROTOCOL)) {
@@ -260,29 +182,39 @@ public class BackgroundImageInfo extends AreaConstants {
 
 		} else if (this.imageData != null) {
 			Encoder encoder = java.util.Base64.getEncoder();
-			this.dataUrl = DATA_PROTOCOL + this.mimeType + ";base64,"
+			this.dataUrl = DATA_PROTOCOL + this.mimeType + DATA_URL_BASE64
 					+ (new String(encoder.encode(this.imageData), StandardCharsets.UTF_8));
 		}
 	}
 
 	/**
-	 * Get the data url of the image
+	 * Get the data URL of the image
 	 *
-	 * @return Return the data url of the image
+	 * @return Return the data URL of the image
 	 */
 	public String getDataUrl() {
 		return this.dataUrl;
 	}
 
+	/**
+	 * Set the image mime type
+	 *
+	 * @param mimeType
+	 */
 	private void setMimeType(String mimeType) {
 
 		if (mimeType != null) {
 			this.mimeType = mimeType;
 
 		} else if (this.url.contains(DATA_PROTOCOL)) {
-			String partMimeType = url.split(";")[1];
-			this.mimeType = partMimeType.split(DATA_PROTOCOL)[0];
-
+			try {
+				if (url.contains(";") && url.contains(DATA_PROTOCOL)) {
+					String partMimeType = url.split(";")[1];
+					this.mimeType = partMimeType.split(DATA_PROTOCOL)[0];
+				}
+			} catch (IndexOutOfBoundsException ioobe) {
+				this.mimeType = null;
+			}
 		} else {
 			for (int index = 0; index < SUPPORTED_MIME_TYPES.length; index++) {
 				if (this.url.toLowerCase().contains(SUPPORTED_MIME_TYPES[index][0])) {
@@ -294,70 +226,91 @@ public class BackgroundImageInfo extends AreaConstants {
 		}
 	}
 
+	/**
+	 * Create the image byte data of the image
+	 */
 	private void prepareImageByteArray() {
 		String mimeType = null;
 
-		// get embedded image on report level
-		if (this.sourceType.equals(IStyle.EMBED_VALUE.getCssText()) && !this.url.contains(DATA_PROTOCOL)) {
+		// get image URL based or from data-URL
+		if (this.sourceType.equals(BGI_SRC_TYPE_URL)) {
+
+			if (this.url.contains(DATA_PROTOCOL)) {
+				String[] imageDataArray = this.url.split(DATA_URL_BASE64);
+				if (imageDataArray.length == 2 && this.url.contains(DATA_PROTOCOL)) {
+					try {
+						String imageDataBase64 = imageDataArray[1];
+						Decoder decoder = java.util.Base64.getDecoder();
+						this.imageData = decoder.decode(imageDataBase64);
+						this.mimeType = imageDataArray[0].split(DATA_PROTOCOL)[1];
+					} catch (IndexOutOfBoundsException ioobe) {
+						this.imageData = null;
+						this.image = null;
+						this.mimeType = null;
+					}
+				} else {
+					this.imageData = null;
+					this.image = null;
+					this.mimeType = null;
+				}
+			} else {
+				if (this.rl == null) {
+					InputStream in = null;
+					try {
+						in = new URL(this.url).openStream();
+						ByteArrayOutputStream out = new ByteArrayOutputStream();
+						byte[] buffer = new byte[1024];
+						int size = in.read(buffer);
+						while (size != -1) {
+							out.write(buffer, 0, size);
+							size = in.read(buffer);
+						}
+						this.imageData = out.toByteArray();
+						out.close();
+					} catch (IOException ioe) {
+						this.imageData = null;
+						this.image = null;
+						this.mimeType = null;
+					} finally {
+						if (in != null) {
+							try {
+								in.close();
+							} catch (IOException e) {
+							}
+						}
+					}
+				} else {
+					try {
+						this.imageData = this.rl.findResource(new URL(this.url));
+					} catch (MalformedURLException mue) {
+						this.imageData = null;
+						this.image = null;
+						this.mimeType = null;
+					}
+				}
+			}
+		}
+
+		// get embedded image from report
+		if (this.sourceType.equals(BGI_SRC_TYPE_EMBED) || this.imageData == null) {
 			StructureDefn defn = (StructureDefn) MetaDataDictionary.getInstance()
 					.getStructure(EmbeddedImage.EMBEDDED_IMAGE_STRUCT);
+
 			byte[] imageData = null;
 			try {
 				EmbeddedImage ei = (EmbeddedImage) StructureRefUtil.findStructure(this.module, defn, this.url);
 				imageData = ei.getData(this.module);
 				mimeType = ei.getType(this.module);
+				if (this.sourceType.equals(BGI_SRC_TYPE_URL))
+					this.sourceType = BGI_SRC_TYPE_EMBED;
 			} catch (Exception te) {
 				this.imageData = null;
 				this.image = null;
 				this.mimeType = null;
-				return;
 			}
 			this.imageData = imageData;
-
-		} else if (this.rl == null) {
-			InputStream in = null;
-			try {
-				in = new URL(this.url).openStream();
-				ByteArrayOutputStream out = new ByteArrayOutputStream();
-				byte[] buffer = new byte[1024];
-				int size = in.read(buffer);
-				while (size != -1) {
-					out.write(buffer, 0, size);
-					size = in.read(buffer);
-				}
-				this.imageData = out.toByteArray();
-				out.close();
-			} catch (IOException ioe) {
-				this.imageData = null;
-				this.image = null;
-				this.mimeType = null;
-				return;
-			} finally {
-				if (in != null) {
-					try {
-						in.close();
-					} catch (IOException e) {
-					}
-				}
-			}
-
-		} else {
-			if (this.url.contains(DATA_PROTOCOL)) {
-				String[] imageDataArray = this.url.split(";base64,");
-				String imageDataBase64 = imageDataArray[1];
-				Decoder decoder = java.util.Base64.getDecoder();
-				this.imageData = decoder.decode(imageDataBase64);
-				this.mimeType = this.url.split(";base64,")[0].split(DATA_PROTOCOL)[1];
-			} else {
-				try {
-					this.imageData = this.rl.findResource(new URL(this.url));
-				} catch (MalformedURLException mue) {
-					this.imageData = null;
-					this.image = null;
-					this.mimeType = null;
-				}
-			}
 		}
+
 		if (this.imageData != null) {
 			try {
 				this.image = Image.getInstance(this.imageData);
@@ -375,7 +328,6 @@ public class BackgroundImageInfo extends AreaConstants {
 		this.setMimeType(mimeType);
 		this.createDataUrl();
 	}
-//	setMIMEType
 
 	/**
 	 * Get the image instance
@@ -473,7 +425,7 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * @param sourceType String of the image source type
 	 */
 	public void setSourceType(String sourceType) {
-		this.sourceType = bgiSourceTypeMap.get(sourceType);
+		this.sourceType = sourceType;
 	}
 
 	/**

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
@@ -84,6 +84,8 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * @param rl
 	 * @param module
 	 * @param sourceType
+	 *
+	 * @since 4.13
 	 */
 	public BackgroundImageInfo(String url, int repeatedMode, int xOffset, int yOffset, int height, int width,
 			ResourceLocatorWrapper rl, Module module, String sourceType) {
@@ -174,6 +176,8 @@ public class BackgroundImageInfo extends AreaConstants {
 
 	/**
 	 * Create the data URL of the image
+	 *
+	 * @since 4.13
 	 */
 	private void createDataUrl() {
 
@@ -423,6 +427,7 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * Set the source type of the background image
 	 *
 	 * @param sourceType String of the image source type
+	 * @since 4.13
 	 */
 	public void setSourceType(String sourceType) {
 		this.sourceType = sourceType;
@@ -432,6 +437,7 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * Get the source type of the background image
 	 *
 	 * @return Returned the source type of the image
+	 * @since 4.13
 	 */
 	public String getSourceType() {
 		return this.sourceType;
@@ -440,6 +446,7 @@ public class BackgroundImageInfo extends AreaConstants {
 	/**
 	 * Get the extension of the image file
 	 *
+	 * @since 4.13
 	 * @return Returned the extension of the image file
 	 */
 	public String getFileExtension() {
@@ -450,6 +457,7 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * Get the image mime type
 	 *
 	 * @return Returned the image mime type
+	 * @since 4.13
 	 */
 	public String getMimeType() {
 		return this.mimeType;

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
@@ -20,13 +20,29 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64.Decoder;
+import java.util.Base64.Encoder;
 
+import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.util.ResourceLocatorWrapper;
 import org.eclipse.birt.report.engine.util.SvgFile;
+import org.eclipse.birt.report.model.api.elements.structures.EmbeddedImage;
+import org.eclipse.birt.report.model.core.Module;
+import org.eclipse.birt.report.model.metadata.MetaDataDictionary;
+import org.eclipse.birt.report.model.metadata.StructureDefn;
+import org.eclipse.birt.report.model.util.StructureRefUtil;
 import org.w3c.dom.css.CSSValue;
 
 import com.lowagie.text.Image;
 
+/**
+ * Representation of the background image information includes attributes and
+ * image data to build the images
+ *
+ * @since 3.3
+ *
+ */
 public class BackgroundImageInfo extends AreaConstants {
 	protected int xOffset = 0;
 	protected int yOffset = 0;
@@ -34,14 +50,45 @@ public class BackgroundImageInfo extends AreaConstants {
 	protected int width = 0;
 	protected int height = 0;
 	protected String url;
+	protected String dataUrl;
 	protected byte[] imageData;
+	protected String sourceType;
+	protected String mimeType;
+	protected String fileExtension;
 
-	private Image image;
+	private final static String DATA_PROTOCOL = "data:";
+
+	// mapping based on image extension: to MIME-type to default extension
+	private final static String[][] SUPPORTED_MIME_TYPES = { { ".jpg", "image/jpeg", "jpg" },
+			{ ".jpe", "image/jpeg", "jpg" }, { ".jpeg", "image/jpeg", "jpg" }, { ".tiff", "image/tiff", "tiff" },
+			{ ".svg", "image/svg+xml", "svg" }, { ".png", "image/png", "png" }, { ".gif", "image/gif", "gif" } };
+	/**
+	 * <img src=
+	 * "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9YGARc5KB0XV+IAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAF1JREFUGNO9zL0NglAAxPEfdLTs4BZM4DIO4C7OwQg2JoQ9LE1exdlYvBBeZ7jqch9//q1uH4TLzw4d6+ErXMMcXuHWxId3KOETnnXXV6MJpcq2MLaI97CER3N0vr4MkhoXe0rZigAAAABJRU5ErkJggg=="
+	 * alt="Roter Punkt" />
+	 */
+	protected final static String BGI_SOURCE_TYPE_DEFAULT = "url";
+
+	private Module module = null;
+
+	private Image image = null;
 
 	private ResourceLocatorWrapper rl = null;
 
+	/**
+	 * constructor 01 of background image
+	 *
+	 * @param url
+	 * @param repeatedMode
+	 * @param xOffset
+	 * @param yOffset
+	 * @param height
+	 * @param width
+	 * @param rl
+	 * @param sourceType
+	 */
 	public BackgroundImageInfo(String url, int repeatedMode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl) {
+			ResourceLocatorWrapper rl, String sourceType) {
 		this.xOffset = xOffset;
 		this.yOffset = yOffset;
 		this.repeatedMode = repeatedMode;
@@ -49,11 +96,29 @@ public class BackgroundImageInfo extends AreaConstants {
 		this.height = height;
 		this.url = url;
 		this.rl = rl;
+		if (sourceType != null) {
+			this.sourceType = sourceType;
+		} else {
+			this.sourceType = BGI_SOURCE_TYPE_DEFAULT;
+		}
 		prepareImageByteArray();
 	}
 
+	/**
+	 * constructor 02 of background image
+	 *
+	 * @param url
+	 * @param repeatedMode
+	 * @param xOffset
+	 * @param yOffset
+	 * @param height
+	 * @param width
+	 * @param rl
+	 * @param module
+	 * @param sourceType
+	 */
 	public BackgroundImageInfo(String url, int repeatedMode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl, byte[] imageData) {
+			ResourceLocatorWrapper rl, Module module, String sourceType) {
 		this.xOffset = xOffset;
 		this.yOffset = yOffset;
 		this.repeatedMode = repeatedMode;
@@ -61,14 +126,24 @@ public class BackgroundImageInfo extends AreaConstants {
 		this.height = height;
 		this.url = url;
 		this.rl = rl;
-		this.imageData = imageData;
-		try {
-			this.image = Image.getInstance(imageData);
-		} catch (Exception e) {
-			prepareImageByteArray();
+		this.module = module;
+		if (sourceType != null) {
+			this.sourceType = sourceType;
+		} else {
+			this.sourceType = BGI_SOURCE_TYPE_DEFAULT;
 		}
+		prepareImageByteArray();
+		/*
+		 * this.imageData = imageData; try { this.image = Image.getInstance(imageData);
+		 * } catch (Exception e) { prepareImageByteArray(); }
+		 */
 	}
 
+	/**
+	 * constructor 03 of background image
+	 *
+	 * @param bgi
+	 */
 	public BackgroundImageInfo(BackgroundImageInfo bgi) {
 		this.xOffset = bgi.xOffset;
 		this.yOffset = bgi.yOffset;
@@ -79,32 +154,170 @@ public class BackgroundImageInfo extends AreaConstants {
 		this.imageData = bgi.imageData;
 		this.image = bgi.image;
 		this.rl = bgi.rl;
+		if (bgi.sourceType != null) {
+			this.sourceType = bgi.sourceType;
+		} else {
+			this.sourceType = BGI_SOURCE_TYPE_DEFAULT;
+		}
 	}
 
+	/**
+	 * constructor 04 of background image
+	 *
+	 * @param url
+	 * @param mode
+	 * @param xOffset
+	 * @param yOffset
+	 * @param height
+	 * @param width
+	 * @param rl
+	 */
 	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
 			ResourceLocatorWrapper rl) {
-		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl);
+		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl,
+				BGI_SOURCE_TYPE_DEFAULT);
 	}
 
-	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl, byte[] imageData) {
-		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, imageData);
-
-	}
-
+	/**
+	 * constructor 05 of background image
+	 *
+	 * @param url
+	 * @param height
+	 * @param width
+	 * @param rl
+	 */
 	public BackgroundImageInfo(String url, int height, int width, ResourceLocatorWrapper rl) {
-		this(url, 0, 0, 0, height, width, rl);
+		this(url, 0, 0, 0, height, width, rl, BGI_SOURCE_TYPE_DEFAULT);
 	}
 
+	/**
+	 * constructor 06 of background image
+	 *
+	 * @param url
+	 * @param mode
+	 * @param xOffset
+	 * @param yOffset
+	 * @param height
+	 * @param width
+	 * @param rl
+	 * @param module
+	 */
+	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
+			ResourceLocatorWrapper rl, Module module) {
+		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, module,
+				BGI_SOURCE_TYPE_DEFAULT);
+	}
+
+	/**
+	 * constructor 07 of background image
+	 *
+	 * @param url
+	 * @param mode
+	 * @param xOffset
+	 * @param yOffset
+	 * @param height
+	 * @param width
+	 * @param rl
+	 * @param sourceType
+	 */
+	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
+			ResourceLocatorWrapper rl, String sourceType) {
+		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, sourceType);
+	}
+
+	/**
+	 * constructor 08 of background image
+	 *
+	 * @param url
+	 * @param mode
+	 * @param xOffset
+	 * @param yOffset
+	 * @param height
+	 * @param width
+	 * @param rl
+	 * @param module
+	 * @param sourceType
+	 */
+	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
+			ResourceLocatorWrapper rl, Module module, CSSValue sourceType) {
+		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, module,
+				sourceType.toString());
+	}
+
+	/**
+	 * Set the resource locator
+	 *
+	 * @param rl set the resource locator
+	 */
 	public void setResourceLocator(ResourceLocatorWrapper rl) {
 		this.rl = rl;
 	}
 
+	private void createDataUrl() {
+
+		if (this.url != null && this.url.contains(DATA_PROTOCOL)) {
+			this.dataUrl = this.url;
+
+		} else if (this.imageData != null) {
+			Encoder encoder = java.util.Base64.getEncoder();
+			this.dataUrl = DATA_PROTOCOL + this.mimeType + ";base64,"
+					+ (new String(encoder.encode(this.imageData), StandardCharsets.UTF_8));
+		}
+	}
+
+	/**
+	 * Get the data url of the image
+	 *
+	 * @return Return the data url of the image
+	 */
+	public String getDataUrl() {
+		return this.dataUrl;
+	}
+
+	private void setMimeType(String mimeType) {
+
+		if (mimeType != null) {
+			this.mimeType = mimeType;
+
+		} else if (this.url.contains(DATA_PROTOCOL)) {
+			String partMimeType = url.split(";")[1];
+			this.mimeType = partMimeType.split(DATA_PROTOCOL)[0];
+
+		} else {
+			for (int index = 0; index < SUPPORTED_MIME_TYPES.length; index++) {
+				if (this.url.toLowerCase().contains(SUPPORTED_MIME_TYPES[index][0])) {
+					this.mimeType = SUPPORTED_MIME_TYPES[index][1];
+					this.fileExtension = SUPPORTED_MIME_TYPES[index][2];
+					break;
+				}
+			}
+		}
+	}
+
 	private void prepareImageByteArray() {
-		if (rl == null) {
+		String mimeType = null;
+
+		// get embedded image on report level
+		if (this.sourceType.equals(IStyle.EMBED_VALUE.getCssText()) && !this.url.contains(DATA_PROTOCOL)) {
+			StructureDefn defn = (StructureDefn) MetaDataDictionary.getInstance()
+					.getStructure(EmbeddedImage.EMBEDDED_IMAGE_STRUCT);
+			byte[] imageData = null;
+			try {
+				EmbeddedImage ei = (EmbeddedImage) StructureRefUtil.findStructure(this.module, defn, this.url);
+				imageData = ei.getData(this.module);
+				mimeType = ei.getType(this.module);
+			} catch (Exception te) {
+				this.imageData = null;
+				this.image = null;
+				this.mimeType = null;
+				return;
+			}
+			this.imageData = imageData;
+
+		} else if (this.rl == null) {
 			InputStream in = null;
 			try {
-				in = new URL(url).openStream();
+				in = new URL(this.url).openStream();
 				ByteArrayOutputStream out = new ByteArrayOutputStream();
 				byte[] buffer = new byte[1024];
 				int size = in.read(buffer);
@@ -112,11 +325,12 @@ public class BackgroundImageInfo extends AreaConstants {
 					out.write(buffer, 0, size);
 					size = in.read(buffer);
 				}
-				imageData = out.toByteArray();
+				this.imageData = out.toByteArray();
 				out.close();
 			} catch (IOException ioe) {
-				imageData = null;
-				image = null;
+				this.imageData = null;
+				this.image = null;
+				this.mimeType = null;
 				return;
 			} finally {
 				if (in != null) {
@@ -126,77 +340,185 @@ public class BackgroundImageInfo extends AreaConstants {
 					}
 				}
 			}
+
 		} else {
-			try {
-				imageData = rl.findResource(new URL(url));
-			} catch (MalformedURLException mue) {
-				imageData = null;
-				image = null;
-				return;
+			if (this.url.contains(DATA_PROTOCOL)) {
+				String[] imageDataArray = this.url.split(";base64,");
+				String imageDataBase64 = imageDataArray[1];
+				Decoder decoder = java.util.Base64.getDecoder();
+				this.imageData = decoder.decode(imageDataBase64);
+				this.mimeType = this.url.split(";base64,")[0].split(DATA_PROTOCOL)[1];
+			} else {
+				try {
+					this.imageData = this.rl.findResource(new URL(this.url));
+				} catch (MalformedURLException mue) {
+					this.imageData = null;
+					this.image = null;
+					this.mimeType = null;
+				}
 			}
 		}
-
-		try {
-
-			image = Image.getInstance(imageData);
-		} catch (Exception e) {
+		if (this.imageData != null) {
 			try {
-				imageData = SvgFile.transSvgToArray(new ByteArrayInputStream(imageData));
-				image = Image.getInstance(imageData);
-			} catch (Exception te) {
-				imageData = null;
-				image = null;
+				this.image = Image.getInstance(this.imageData);
+			} catch (Exception e) {
+				try {
+					this.imageData = SvgFile.transSvgToArray(new ByteArrayInputStream(this.imageData));
+					this.image = Image.getInstance(this.imageData);
+				} catch (Exception te) {
+					this.imageData = null;
+					this.image = null;
+					this.mimeType = null;
+				}
 			}
 		}
-
+		this.setMimeType(mimeType);
+		this.createDataUrl();
 	}
+//	setMIMEType
 
+	/**
+	 * Get the image instance
+	 *
+	 * @return Return the image instance
+	 */
 	public Image getImageInstance() {
 		return image;
 	}
 
+	/**
+	 * Get the background image offset position X
+	 *
+	 * @return Return the background image offset position X
+	 */
 	public int getXOffset() {
 		return xOffset;
 	}
 
-	public void setYOffset(int y) {
-		this.yOffset = y;
-	}
-
+	/**
+	 * Set the background image offset position X
+	 *
+	 * @param x set the background image offset position X
+	 */
 	public void setXOffset(int x) {
 		this.xOffset = x;
 	}
 
+	/**
+	 * Get the background image offset position Y
+	 *
+	 * @return Return the background image offset position Y
+	 */
 	public int getYOffset() {
 		return yOffset;
 	}
 
+	/**
+	 * Set the background image offset position Y
+	 *
+	 * @param y set the background image offset position Y
+	 */
+	public void setYOffset(int y) {
+		this.yOffset = y;
+	}
+
+	/**
+	 * Get the background image height
+	 *
+	 * @return Return the background image height
+	 */
 	public int getHeight() {
 		return height;
 	}
 
+	/**
+	 * Set the background image height
+	 *
+	 * @param height height of the background image
+	 */
 	public void setHeight(int height) {
 		this.height = height;
 	}
 
+	/**
+	 * Get the background image width
+	 *
+	 * @return Return the background image width
+	 */
 	public int getWidth() {
 		return width;
 	}
 
+	/**
+	 * Set the background image width
+	 *
+	 * @param width width of the background image
+	 */
 	public void setWidth(int width) {
 		this.width = width;
 	}
 
+	/**
+	 * Get the background image repeat mode
+	 *
+	 * @return Return the background image repeat mode
+	 */
 	public int getRepeatedMode() {
 		return repeatedMode;
 	}
 
-	public String getUrl() {
-		return url;
+	/**
+	 * Set the source type of the background image
+	 *
+	 * @param sourceType String of the image source type
+	 */
+	public void setSourceType(String sourceType) {
+		this.sourceType = bgiSourceTypeMap.get(sourceType);
 	}
 
+	/**
+	 * Get the source type of the background image
+	 *
+	 * @return Returned the source type of the image
+	 */
+	public String getSourceType() {
+		return this.sourceType;
+	}
+
+	/**
+	 * Get the extension of the image file
+	 *
+	 * @return Returned the extension of the image file
+	 */
+	public String getFileExtension() {
+		return this.fileExtension;
+	}
+
+	/**
+	 * Get the image mime type
+	 *
+	 * @return Returned the image mime type
+	 */
+	public String getMimeType() {
+		return this.mimeType;
+	}
+
+	/**
+	 * Get the url string
+	 *
+	 * @return Return the url string
+	 */
+	public String getUrl() {
+		return this.url;
+	}
+
+	/**
+	 * Get the image byte array
+	 *
+	 * @return Return the image data ByteArray
+	 */
 	public byte[] getImageData() {
-		return imageData;
+		return this.imageData;
 	}
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
@@ -52,6 +52,23 @@ public class BackgroundImageInfo extends AreaConstants {
 		prepareImageByteArray();
 	}
 
+	public BackgroundImageInfo(String url, int repeatedMode, int xOffset, int yOffset, int height, int width,
+			ResourceLocatorWrapper rl, byte[] imageData) {
+		this.xOffset = xOffset;
+		this.yOffset = yOffset;
+		this.repeatedMode = repeatedMode;
+		this.width = width;
+		this.height = height;
+		this.url = url;
+		this.rl = rl;
+		this.imageData = imageData;
+		try {
+			this.image = Image.getInstance(imageData);
+		} catch (Exception e) {
+			prepareImageByteArray();
+		}
+	}
+
 	public BackgroundImageInfo(BackgroundImageInfo bgi) {
 		this.xOffset = bgi.xOffset;
 		this.yOffset = bgi.yOffset;
@@ -67,6 +84,12 @@ public class BackgroundImageInfo extends AreaConstants {
 	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
 			ResourceLocatorWrapper rl) {
 		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl);
+	}
+
+	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
+			ResourceLocatorWrapper rl, byte[] imageData) {
+		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, imageData);
+
 	}
 
 	public BackgroundImageInfo(String url, int height, int width, ResourceLocatorWrapper rl) {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BoxStyle.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BoxStyle.java
@@ -16,6 +16,12 @@ package org.eclipse.birt.report.engine.nLayout.area.style;
 
 import java.awt.Color;
 
+/**
+ * Define class of box style
+ *
+ * @since 3.3
+ *
+ */
 public class BoxStyle extends AreaConstants {
 
 	/**
@@ -47,10 +53,18 @@ public class BoxStyle extends AreaConstants {
 
 	protected BorderInfo bottomBorder = null;
 
+	/**
+	 * Get Background color
+	 *
+	 * @return Return the background color
+	 */
 	public Color getBackgroundColor() {
 		return backgroundColor;
 	}
 
+	/**
+	 * Constructor
+	 */
 	public BoxStyle() {
 
 	}
@@ -87,6 +101,11 @@ public class BoxStyle extends AreaConstants {
 		}
 	}
 
+	/**
+	 * Constructor with box style (border info)
+	 *
+	 * @param bs
+	 */
 	public BoxStyle(BoxStyle bs) {
 		this.backgroundColor = bs.backgroundColor;
 		if (bs.topBorder != null) {
@@ -106,6 +125,9 @@ public class BoxStyle extends AreaConstants {
 		}
 	}
 
+	/**
+	 * CLear the border
+	 */
 	public void clearBorder() {
 		topBorder = null;
 		leftBorder = null;
@@ -113,26 +135,56 @@ public class BoxStyle extends AreaConstants {
 		bottomBorder = null;
 	}
 
+	/**
+	 * Get the background image info
+	 *
+	 * @return Return the background image info
+	 */
 	public BackgroundImageInfo getBackgroundImage() {
 		return backgroundImage;
 	}
 
+	/**
+	 * Get the top border info
+	 *
+	 * @return Return the top border info
+	 */
 	public BorderInfo getTopBorder() {
 		return topBorder;
 	}
 
+	/**
+	 * Get the left border info
+	 *
+	 * @return Return the left border info
+	 */
 	public BorderInfo getLeftBorder() {
 		return leftBorder;
 	}
 
+	/**
+	 * Get the right border info
+	 *
+	 * @return Return the right border info
+	 */
 	public BorderInfo getRightBorder() {
 		return rightBorder;
 	}
 
+	/**
+	 * Get the bottom border info
+	 *
+	 * @return Return the bottm border info
+	 */
 	public BorderInfo getBottomBorder() {
 		return bottomBorder;
 	}
 
+	/**
+	 * Get the left border width
+	 *
+	 * @return Return the left border width
+	 */
 	public int getLeftBorderWidth() {
 		if (leftBorder != null) {
 			return leftBorder.getWidth();
@@ -140,6 +192,11 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Get the right border width
+	 *
+	 * @return Return the right border width
+	 */
 	public int getRightBorderWidth() {
 		if (rightBorder != null) {
 			return rightBorder.getWidth();
@@ -147,6 +204,11 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Get the top border width
+	 *
+	 * @return Return the top border width
+	 */
 	public int getTopBorderWidth() {
 		if (topBorder != null) {
 			return topBorder.getWidth();
@@ -154,6 +216,11 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Get the bottom border width
+	 *
+	 * @return Return the bottom border width
+	 */
 	public int getBottomBorderWidth() {
 		if (bottomBorder != null) {
 			return bottomBorder.getWidth();
@@ -161,6 +228,11 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Get the left border color
+	 *
+	 * @return Return the left border color
+	 */
 	public Color getLeftBorderColor() {
 		if (leftBorder != null) {
 			return leftBorder.getColor();
@@ -168,6 +240,11 @@ public class BoxStyle extends AreaConstants {
 		return null;
 	}
 
+	/**
+	 * Get the right border color
+	 *
+	 * @return Return the right border color
+	 */
 	public Color getRightBorderColor() {
 		if (rightBorder != null) {
 			return rightBorder.getColor();
@@ -175,6 +252,11 @@ public class BoxStyle extends AreaConstants {
 		return null;
 	}
 
+	/**
+	 * Get the top border color
+	 *
+	 * @return Return the top border color
+	 */
 	public Color getTopBorderColor() {
 		if (topBorder != null) {
 			return topBorder.getColor();
@@ -182,6 +264,11 @@ public class BoxStyle extends AreaConstants {
 		return null;
 	}
 
+	/**
+	 * Get the bottom border color
+	 *
+	 * @return Return the bottom border color
+	 */
 	public Color getBottomBorderColor() {
 		if (bottomBorder != null) {
 			return bottomBorder.getColor();
@@ -189,6 +276,11 @@ public class BoxStyle extends AreaConstants {
 		return null;
 	}
 
+	/**
+	 * Get the left border style
+	 *
+	 * @return Return the left border style
+	 */
 	public int getLeftBorderStyle() {
 		if (leftBorder != null) {
 			return leftBorder.getStyle();
@@ -196,6 +288,11 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Get the right border style
+	 *
+	 * @return Return the right border style
+	 */
 	public int getRightBorderStyle() {
 		if (rightBorder != null) {
 			return rightBorder.getStyle();
@@ -203,6 +300,11 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Get the top border style
+	 *
+	 * @return Return the top border style
+	 */
 	public int getTopBorderStyle() {
 		if (topBorder != null) {
 			return topBorder.getStyle();
@@ -210,6 +312,11 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Get the bottom border style
+	 *
+	 * @return Return the bottom border style
+	 */
 	public int getBottomBorderStyle() {
 		if (bottomBorder != null) {
 			return bottomBorder.getStyle();
@@ -217,26 +324,56 @@ public class BoxStyle extends AreaConstants {
 		return 0;
 	}
 
+	/**
+	 * Set the background color
+	 *
+	 * @param backgroundColor
+	 */
 	public void setBackgroundColor(Color backgroundColor) {
 		this.backgroundColor = backgroundColor;
 	}
 
+	/**
+	 * Set the background image
+	 *
+	 * @param backgroundImage
+	 */
 	public void setBackgroundImage(BackgroundImageInfo backgroundImage) {
 		this.backgroundImage = backgroundImage;
 	}
 
+	/**
+	 * Set the top border
+	 *
+	 * @param topBorder
+	 */
 	public void setTopBorder(BorderInfo topBorder) {
 		this.topBorder = topBorder;
 	}
 
+	/**
+	 * Set the left border
+	 *
+	 * @param leftBorder
+	 */
 	public void setLeftBorder(BorderInfo leftBorder) {
 		this.leftBorder = leftBorder;
 	}
 
+	/**
+	 * Set the right border
+	 *
+	 * @param rightBorder
+	 */
 	public void setRightBorder(BorderInfo rightBorder) {
 		this.rightBorder = rightBorder;
 	}
 
+	/**
+	 * Set the bottom border
+	 *
+	 * @param bottomBorder
+	 */
 	public void setBottomBorder(BorderInfo bottomBorder) {
 		this.bottomBorder = bottomBorder;
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/EngineIRVisitor.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/EngineIRVisitor.java
@@ -2079,10 +2079,10 @@ public class EngineIRVisitor extends DesignVisitor {
 			String propertyName) {
 		boolean isColorProperty = StyleUtil.colorProperties.contains(propertyName);
 		String elementProperty = getElementProperty(handle, propertyName, isColorProperty);
-		populateStyle(design, style, propertyName, elementProperty);
+		populateStyle(style, propertyName, elementProperty);
 	}
 
-	private void populateStyle(StyledElementDesign design, IStyle style, String propertyName, String elementProperty) {
+	private void populateStyle(IStyle style, String propertyName, String elementProperty) {
 		int propertyIndex = StyleUtil.styleName2Index.get(propertyName);
 		// TODO need support the expression style
 		// if ( elementProperty.isExpression( ) )
@@ -2182,7 +2182,7 @@ public class EngineIRVisitor extends DesignVisitor {
 			String propertyName) {
 		Module module = design.getHandle().getModule();
 		String property = getMemberProperty(module, highlight, propertyName);
-		populateStyle(design, style, propertyName, property);
+		populateStyle(style, propertyName, property);
 	}
 
 	protected DimensionType createDimension(DimensionHandle handle, boolean useDefault) {
@@ -2262,6 +2262,7 @@ public class EngineIRVisitor extends DesignVisitor {
 		addReportDefaultPropertyValue(Style.BACKGROUND_POSITION_X_PROP, handle);
 		addReportDefaultPropertyValue(Style.BACKGROUND_POSITION_Y_PROP, handle);
 		addReportDefaultPropertyValue(Style.BACKGROUND_REPEAT_PROP, handle);
+		addReportDefaultPropertyValue(Style.BACKGROUND_IMAGE_TYPE_PROP, handle);
 
 		// bidi_hcg: Bidi related.
 		addReportDefaultPropertyValue(Style.TEXT_DIRECTION_PROP, handle);

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/StylePropertyMapping.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/StylePropertyMapping.java
@@ -44,6 +44,8 @@ public class StylePropertyMapping {
 		nameMapping.put(IStyleModel.COLOR_PROP, Integer.valueOf(StyleConstants.STYLE_COLOR));
 		nameMapping.put(IStyleModel.BACKGROUND_COLOR_PROP, Integer.valueOf(StyleConstants.STYLE_BACKGROUND_COLOR));
 		nameMapping.put(IStyleModel.BACKGROUND_IMAGE_PROP, Integer.valueOf(StyleConstants.STYLE_BACKGROUND_IMAGE));
+		nameMapping.put(IStyleModel.BACKGROUND_IMAGE_TYPE_PROP,
+				Integer.valueOf(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
 		nameMapping.put(IStyleModel.BACKGROUND_REPEAT_PROP, Integer.valueOf(StyleConstants.STYLE_BACKGROUND_REPEAT));
 		nameMapping.put(IStyleModel.BACKGROUND_ATTACHMENT_PROP,
 				Integer.valueOf(StyleConstants.STYLE_BACKGROUND_ATTACHMENT));

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/StyleUtil.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/StyleUtil.java
@@ -46,6 +46,7 @@ public class StyleUtil {
 		styleName2Index.put(Style.BACKGROUND_ATTACHMENT_PROP, StyleConstants.STYLE_BACKGROUND_ATTACHMENT);
 		styleName2Index.put(Style.BACKGROUND_COLOR_PROP, StyleConstants.STYLE_BACKGROUND_COLOR);
 		styleName2Index.put(Style.BACKGROUND_IMAGE_PROP, StyleConstants.STYLE_BACKGROUND_IMAGE);
+		styleName2Index.put(Style.BACKGROUND_IMAGE_TYPE_PROP, StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE);
 		styleName2Index.put(Style.BACKGROUND_SIZE_HEIGHT, StyleConstants.STYLE_BACKGROUND_HEIGHT);
 		styleName2Index.put(Style.BACKGROUND_SIZE_WIDTH, StyleConstants.STYLE_BACKGROUND_WIDTH);
 		styleName2Index.put(Style.BACKGROUND_POSITION_X_PROP, StyleConstants.STYLE_BACKGROUND_POSITION_X);

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/script/internal/instance/StyleInstance.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/script/internal/instance/StyleInstance.java
@@ -29,6 +29,12 @@ public class StyleInstance implements IScriptStyle {
 	private IStyle style;
 	private RunningState runningState;
 
+	/**
+	 * Constructor
+	 *
+	 * @param style
+	 * @param runningState
+	 */
 	public StyleInstance(IStyle style, RunningState runningState) {
 		this.style = style;
 		this.runningState = runningState;
@@ -275,6 +281,23 @@ public class StyleInstance implements IScriptStyle {
 	public void setBackgroundImage(String imageURI) {
 		checkWritable();
 		style.setBackgroundImage(imageURI);
+	}
+
+	/**
+	 * Get the background image URI
+	 */
+	@Override
+	public String getBackgroundImageType() {
+		return style.getBackgroundImage();
+	}
+
+	/**
+	 * Set the background image URI
+	 */
+	@Override
+	public void setBackgroundImageType(String imageType) {
+		checkWritable();
+		style.setBackgroundImageType(imageType);
 	}
 
 	/**
@@ -1016,6 +1039,12 @@ public class StyleInstance implements IScriptStyle {
 		}
 	}
 
+	/**
+	 * Get the CSS value of property
+	 *
+	 * @param index
+	 * @return Return the CSS value of property
+	 */
 	public CSSValue getProperty(int index) {
 		return style.getProperty(index);
 	}
@@ -1024,6 +1053,7 @@ public class StyleInstance implements IScriptStyle {
 	 * Get the text direction. Valid return types are LTR and RTL.
 	 *
 	 * @author bidi_hcg
+	 * @return Return the text direction
 	 */
 	public String getDirection() {
 		return style.getDirection();
@@ -1033,6 +1063,7 @@ public class StyleInstance implements IScriptStyle {
 	 * Set the text direction. Valid return types are LTR and RTL.
 	 *
 	 * @author bidi_hcg
+	 * @param dir
 	 */
 	public void setDirection(String dir) {
 		checkWritable();

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/elements/DesignChoiceConstants.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/elements/DesignChoiceConstants.java
@@ -24,525 +24,1068 @@ package org.eclipse.birt.report.model.api.elements;
 public interface DesignChoiceConstants {
 
 	// fontFamily
-
+	/** design constant: choice font family */
 	String CHOICE_FONT_FAMILY = "fontFamily"; //$NON-NLS-1$
+
+	/** design constant: font family serif */
 	String FONT_FAMILY_SERIF = "serif"; //$NON-NLS-1$
+
+	/** design constant: font family sans serif */
 	String FONT_FAMILY_SANS_SERIF = "sans-serif"; //$NON-NLS-1$
+
+	/** design constant: font family cursive */
 	String FONT_FAMILY_CURSIVE = "cursive"; //$NON-NLS-1$
+
+	/** design constant: font family fantasy */
 	String FONT_FAMILY_FANTASY = "fantasy"; //$NON-NLS-1$
+
+	/** design constant: font family monospace */
 	String FONT_FAMILY_MONOSPACE = "monospace"; //$NON-NLS-1$
 
-	// fontStyle
 
+	// fontStyle
+	/** design constant: choice font style */
 	String CHOICE_FONT_STYLE = "fontStyle"; //$NON-NLS-1$
+
+	/** design constant: font style normal */
 	String FONT_STYLE_NORMAL = "normal"; //$NON-NLS-1$
+
+	/** design constant: font style italic */
 	String FONT_STYLE_ITALIC = "italic"; //$NON-NLS-1$
+
+	/** design constant: font style oblique */
 	String FONT_STYLE_OBLIQUE = "oblique"; //$NON-NLS-1$
 
-	// fontWeight
 
+	// fontWeight
+	/** design constant: choice font weight */
 	String CHOICE_FONT_WEIGHT = "fontWeight"; //$NON-NLS-1$
+
+	/** design constant: font weight normal */
 	String FONT_WEIGHT_NORMAL = "normal"; //$NON-NLS-1$
+
+	/** design constant: font weight bold */
 	String FONT_WEIGHT_BOLD = "bold"; //$NON-NLS-1$
+
+	/** design constant: font weight bolder */
 	String FONT_WEIGHT_BOLDER = "bolder"; //$NON-NLS-1$
+
+	/** design constant: font weight lighter */
 	String FONT_WEIGHT_LIGHTER = "lighter"; //$NON-NLS-1$
+
+	/** design constant: font weight 100 */
 	String FONT_WEIGHT_100 = "100"; //$NON-NLS-1$
+
+	/** design constant: font weight 200 */
 	String FONT_WEIGHT_200 = "200"; //$NON-NLS-1$
+
+	/** design constant: font weight 300 */
 	String FONT_WEIGHT_300 = "300"; //$NON-NLS-1$
+
+	/** design constant: font weight 400 */
 	String FONT_WEIGHT_400 = "400"; //$NON-NLS-1$
+
+	/** design constant: font weight 500 */
 	String FONT_WEIGHT_500 = "500"; //$NON-NLS-1$
+
+	/** design constant: font weight 600 */
 	String FONT_WEIGHT_600 = "600"; //$NON-NLS-1$
+
+	/** design constant: font weight 700 */
 	String FONT_WEIGHT_700 = "700"; //$NON-NLS-1$
+
+	/** design constant: font weight 800 */
 	String FONT_WEIGHT_800 = "800"; //$NON-NLS-1$
+
+	/** design constant: font weight 900 */
 	String FONT_WEIGHT_900 = "900"; //$NON-NLS-1$
 
-	// fontSize
 
+	// fontSize
+	/** design constant: choice font size */
 	String CHOICE_FONT_SIZE = "fontSize"; //$NON-NLS-1$
+
+	/** design constant: font size xx small */
 	String FONT_SIZE_XX_SMALL = "xx-small"; //$NON-NLS-1$
+
+	/** design constant: font size x small */
 	String FONT_SIZE_X_SMALL = "x-small"; //$NON-NLS-1$
+
+	/** design constant: font size small */
 	String FONT_SIZE_SMALL = "small"; //$NON-NLS-1$
+
+	/** design constant: font size medium */
 	String FONT_SIZE_MEDIUM = "medium"; //$NON-NLS-1$
+
+	/** design constant: font size large */
 	String FONT_SIZE_LARGE = "large"; //$NON-NLS-1$
+
+	/** design constant: font size x large */
 	String FONT_SIZE_X_LARGE = "x-large"; //$NON-NLS-1$
+
+	/** design constant: font size xx large */
 	String FONT_SIZE_XX_LARGE = "xx-large"; //$NON-NLS-1$
+
+	/** design constant: font size larger */
 	String FONT_SIZE_LARGER = "larger"; //$NON-NLS-1$
+
+	/** design constant: font size smaller */
 	String FONT_SIZE_SMALLER = "smaller"; //$NON-NLS-1$
 
-	// fontVariant
 
+	// fontVariant
+	/** design constant: choice font variant */
 	String CHOICE_FONT_VARIANT = "fontVariant"; //$NON-NLS-1$
+
+	/** design constant: font variant normal */
 	String FONT_VARIANT_NORMAL = "normal"; //$NON-NLS-1$
+
+	/** design constant: font variant small caps */
 	String FONT_VARIANT_SMALL_CAPS = "small-caps"; //$NON-NLS-1$
 
-	// backgroundRepeat
 
+	// backgroundRepeat
+	/** design constant: choice background repeat */
 	String CHOICE_BACKGROUND_REPEAT = "backgroundRepeat"; //$NON-NLS-1$
+
+	/** design constant: background repeat repeat */
 	String BACKGROUND_REPEAT_REPEAT = "repeat"; //$NON-NLS-1$
+
+	/** design constant: background repeat repeat x */
 	String BACKGROUND_REPEAT_REPEAT_X = "repeat-x"; //$NON-NLS-1$
+
+	/** design constant: background repeat repeat y */
 	String BACKGROUND_REPEAT_REPEAT_Y = "repeat-y"; //$NON-NLS-1$
+
+	/** design constant: background repeat no repeat */
 	String BACKGROUND_REPEAT_NO_REPEAT = "no-repeat"; //$NON-NLS-1$
 
-	// backgroundAttachment
 
+	// backgroundAttachment
+	/** design constant: choice background attachment */
 	String CHOICE_BACKGROUND_ATTACHMENT = "backgroundAttachment"; //$NON-NLS-1$
+
+	/** design constant: background attachment scroll */
 	String BACKGROUND_ATTACHMENT_SCROLL = "scroll"; //$NON-NLS-1$
+
+	/** design constant: background attachment fixed */
 	String BACKGROUND_ATTACHMENT_FIXED = "fixed"; //$NON-NLS-1$
 
-	// backgroundPositionX
 
+	// backgroundPositionX
+	/** design constant: choice background position x */
 	String CHOICE_BACKGROUND_POSITION_X = "backgroundPositionX"; //$NON-NLS-1$
+
+	/** design constant: background position left */
 	String BACKGROUND_POSITION_LEFT = "left"; //$NON-NLS-1$
+
+	/** design constant: background position right */
 	String BACKGROUND_POSITION_RIGHT = "right"; //$NON-NLS-1$
+
+	/** design constant: background position center */
 	String BACKGROUND_POSITION_CENTER = "center"; //$NON-NLS-1$
 
 	// backgroundPositionY(BACKGROUND_POSITION_CENTER is already defined)
 
+	/** design constant: choice background position y */
 	String CHOICE_BACKGROUND_POSITION_Y = "backgroundPositionY"; //$NON-NLS-1$
+	/** design constant: background position top */
 	String BACKGROUND_POSITION_TOP = "top"; //$NON-NLS-1$
+
+	/** design constant: background position bottom */
 	String BACKGROUND_POSITION_BOTTOM = "bottom"; //$NON-NLS-1$
 
+
 	// backgroundSize
+	/** design constant: choice background size */
 	String CHOICE_BACKGROUND_SIZE = "backgroundSize"; //$NON-NLS-1$
+
+	/** design constant: background size auto */
 	String BACKGROUND_SIZE_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: background size contain */
 	String BACKGROUND_SIZE_CONTAIN = "contain"; //$NON-NLS-1$
+
+	/** design constant: background size cover */
 	String BACKGROUND_SIZE_COVER = "cover"; //$NON-NLS-1$
 
-	// transform
 
+	// transform
+	/** design constant: choice transform */
 	String CHOICE_TRANSFORM = "transform"; //$NON-NLS-1$
+
+	/** design constant: transform capitalize */
 	String TRANSFORM_CAPITALIZE = "capitalize"; //$NON-NLS-1$
+
+	/** design constant: transform uppercase */
 	String TRANSFORM_UPPERCASE = "uppercase"; //$NON-NLS-1$
+
+	/** design constant: transform lowercase */
 	String TRANSFORM_LOWERCASE = "lowercase"; //$NON-NLS-1$
+
+	/** design constant: transform none */
 	String TRANSFORM_NONE = "none"; //$NON-NLS-1$
 
-	// normal
 
+	// normal
+	/** design constant: choice normal */
 	String CHOICE_NORMAL = "normal"; //$NON-NLS-1$
+
+	/** design constant: normal normal */
 	String NORMAL_NORMAL = "normal"; //$NON-NLS-1$
 
-	// verticalAlign
 
+	// verticalAlign
+	/** design constant: choice vertical align */
 	String CHOICE_VERTICAL_ALIGN = "verticalAlign"; //$NON-NLS-1$
 
+
 	/**
 	 * @deprecated Now Engine is not support it.
 	 */
-
 	@Deprecated
+	/** design constant: vertical align baseline */
 	String VERTICAL_ALIGN_BASELINE = "baseline"; //$NON-NLS-1$
 
+
 	/**
 	 * @deprecated Now Engine is not support it.
 	 */
-
 	@Deprecated
+	/** design constant: vertical align sub */
 	String VERTICAL_ALIGN_SUB = "sub"; //$NON-NLS-1$
 
+
 	/**
 	 * @deprecated Now Engine is not support it.
 	 */
-
 	@Deprecated
+	/** design constant: vertical align super */
 	String VERTICAL_ALIGN_SUPER = "super"; //$NON-NLS-1$
+
+	/** design constant: vertical align top */
 	String VERTICAL_ALIGN_TOP = "top"; //$NON-NLS-1$
 
+
 	/**
 	 * @deprecated Now Engine is not support it.
 	 */
-
 	@Deprecated
+	/** design constant: vertical align text top */
 	String VERTICAL_ALIGN_TEXT_TOP = "text-top"; //$NON-NLS-1$
+
+	/** design constant: vertical align middle */
 	String VERTICAL_ALIGN_MIDDLE = "middle"; //$NON-NLS-1$
+
+	/** design constant: vertical align bottom */
 	String VERTICAL_ALIGN_BOTTOM = "bottom"; //$NON-NLS-1$
 
+
 	/**
 	 * @deprecated Now Engine is not support it.
 	 */
-
 	@Deprecated
+	/** design constant: vertical align text bottom */
 	String VERTICAL_ALIGN_TEXT_BOTTOM = "text-bottom"; //$NON-NLS-1$
 
-	// whiteSpace
 
+	// whiteSpace
+	/** design constant: choice white space */
 	String CHOICE_WHITE_SPACE = "whiteSpace"; //$NON-NLS-1$
+
+	/** design constant: white space normal */
 	String WHITE_SPACE_NORMAL = "normal"; //$NON-NLS-1$
+
+	/** design constant: white space pre */
 	String WHITE_SPACE_PRE = "pre"; //$NON-NLS-1$
+
+	/** design constant: white space nowrap */
 	String WHITE_SPACE_NOWRAP = "nowrap"; //$NON-NLS-1$
 
-	// display
 
+	// display
+	/** design constant: choice display */
 	String CHOICE_DISPLAY = "display"; //$NON-NLS-1$
+
+	/** design constant: display block */
 	String DISPLAY_BLOCK = "block"; //$NON-NLS-1$
+
+	/** design constant: display inline */
 	String DISPLAY_INLINE = "inline"; //$NON-NLS-1$
+
+	/** design constant: display none */
 	String DISPLAY_NONE = "none"; //$NON-NLS-1$
 
-	// pageBreakAfter
 
+	// pageBreakAfter
+	/** design constant: choice page break after */
 	String CHOICE_PAGE_BREAK_AFTER = "pageBreakAfter"; //$NON-NLS-1$
+
+	/** design constant: page break after auto */
 	String PAGE_BREAK_AFTER_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: page break after always */
 	String PAGE_BREAK_AFTER_ALWAYS = "always"; //$NON-NLS-1$
+
+	/** design constant: page break after avoid */
 	String PAGE_BREAK_AFTER_AVOID = "avoid"; //$NON-NLS-1$
+
+	/** design constant: page break after always excluding last */
 	String PAGE_BREAK_AFTER_ALWAYS_EXCLUDING_LAST = "always-excluding-last"; //$NON-NLS-1$
 
-	// pageBreakBefore
 
+	// pageBreakBefore
+	/** design constant: choice page break before */
 	String CHOICE_PAGE_BREAK_BEFORE = "pageBreakBefore"; //$NON-NLS-1$
+
+	/** design constant: page break before auto */
 	String PAGE_BREAK_BEFORE_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: page break before always */
 	String PAGE_BREAK_BEFORE_ALWAYS = "always"; //$NON-NLS-1$
+
+	/** design constant: page break before avoid */
 	String PAGE_BREAK_BEFORE_AVOID = "avoid"; //$NON-NLS-1$
+
+	/** design constant: page break before always excluding first */
 	String PAGE_BREAK_BEFORE_ALWAYS_EXCLUDING_FIRST = "always-excluding-first"; //$NON-NLS-1$
 
-	// pageBreakInside
 
+	// pageBreakInside
+	/** design constant: choice page break inside */
 	String CHOICE_PAGE_BREAK_INSIDE = "pageBreakInside"; //$NON-NLS-1$
+
+	/** design constant: page break inside avoid */
 	String PAGE_BREAK_INSIDE_AVOID = "avoid"; //$NON-NLS-1$
+
+	/** design constant: page break inside auto */
 	String PAGE_BREAK_INSIDE_AUTO = "auto"; //$NON-NLS-1$
 
-	// margin
 
+	// margin
+	/** design constant: choice margin */
 	String CHOICE_MARGIN = "margin"; //$NON-NLS-1$
+	/** design constant: margin auto */
 	String MARGIN_AUTO = "auto"; //$NON-NLS-1$
 
 	// textUnderline
-
+	/** design constant: choice text underline */
 	String CHOICE_TEXT_UNDERLINE = "textUnderline"; //$NON-NLS-1$
+
+	/** design constant: text underline none */
 	String TEXT_UNDERLINE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: text underline underline */
 	String TEXT_UNDERLINE_UNDERLINE = "underline"; //$NON-NLS-1$
 
-	// textOverline
 
+	// textOverline
+	/** design constant: choice text overline */
 	String CHOICE_TEXT_OVERLINE = "textOverline"; //$NON-NLS-1$
+
+	/** design constant: text overline none */
 	String TEXT_OVERLINE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: text overline overline */
 	String TEXT_OVERLINE_OVERLINE = "overline"; //$NON-NLS-1$
 
-	// textLineThrough
 
+	// textLineThrough
+	/** design constant: choice text line through */
 	String CHOICE_TEXT_LINE_THROUGH = "textLineThrough"; //$NON-NLS-1$
+
+	/** design constant: text line through none */
 	String TEXT_LINE_THROUGH_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: text line through line through */
 	String TEXT_LINE_THROUGH_LINE_THROUGH = "line-through"; //$NON-NLS-1$
 
-	// lineWidth
 
+	// lineWidth
+	/** design constant: choice line width */
 	String CHOICE_LINE_WIDTH = "lineWidth"; //$NON-NLS-1$
+
+	/** design constant: line width thin */
 	String LINE_WIDTH_THIN = "thin"; //$NON-NLS-1$
+
+	/** design constant: line width medium */
 	String LINE_WIDTH_MEDIUM = "medium"; //$NON-NLS-1$
+
+	/** design constant: line width thick */
 	String LINE_WIDTH_THICK = "thick"; //$NON-NLS-1$
 
-	// lineStyle
 
+	// lineStyle
+	/** design constant: choice line style */
 	String CHOICE_LINE_STYLE = "lineStyle"; //$NON-NLS-1$
+
+	/** design constant: line style none */
 	String LINE_STYLE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: line style solid */
 	String LINE_STYLE_SOLID = "solid"; //$NON-NLS-1$
+
+	/** design constant: line style dotted */
 	String LINE_STYLE_DOTTED = "dotted"; //$NON-NLS-1$
+
+	/** design constant: line style dashed */
 	String LINE_STYLE_DASHED = "dashed"; //$NON-NLS-1$
+
+	/** design constant: line style double */
 	String LINE_STYLE_DOUBLE = "double"; //$NON-NLS-1$
+
+	/** design constant: line style groove */
 	String LINE_STYLE_GROOVE = "groove"; //$NON-NLS-1$
+
+	/** design constant: line style ridge */
 	String LINE_STYLE_RIDGE = "ridge"; //$NON-NLS-1$
+
+	/** design constant: line style inset */
 	String LINE_STYLE_INSET = "inset"; //$NON-NLS-1$
+
+	/** design constant: line style outset */
 	String LINE_STYLE_OUTSET = "outset"; //$NON-NLS-1$
 
 	// units
-
+	/** design constant: choice units */
 	String CHOICE_UNITS = "units"; //$NON-NLS-1$
+
+	/** design constant: units in */
 	String UNITS_IN = "in"; //$NON-NLS-1$
+
+	/** design constant: units cm */
 	String UNITS_CM = "cm"; //$NON-NLS-1$
+
+	/** design constant: units mm */
 	String UNITS_MM = "mm"; //$NON-NLS-1$
+
+	/** design constant: units pt */
 	String UNITS_PT = "pt"; //$NON-NLS-1$
+
+	/** design constant: units pc */
 	String UNITS_PC = "pc"; //$NON-NLS-1$
+
+	/** design constant: units em */
 	String UNITS_EM = "em"; //$NON-NLS-1$
+
+	/** design constant: units ex */
 	String UNITS_EX = "ex"; //$NON-NLS-1$
+
+	/** design constant: units px */
 	String UNITS_PX = "px"; //$NON-NLS-1$
+
+	/** design constant: units percentage */
 	String UNITS_PERCENTAGE = "%"; //$NON-NLS-1$
 
-	// paramType
 
+	// paramType
+	/** design constant: choice param type */
 	String CHOICE_PARAM_TYPE = "paramType"; //$NON-NLS-1$
+
+	/** design constant: param type string */
 	String PARAM_TYPE_STRING = "string"; //$NON-NLS-1$
+
+	/** design constant: param type float */
 	String PARAM_TYPE_FLOAT = "float"; //$NON-NLS-1$
+
+	/** design constant: param type decimal */
 	String PARAM_TYPE_DECIMAL = "decimal"; //$NON-NLS-1$
+
+	/** design constant: param type datetime */
 	String PARAM_TYPE_DATETIME = "dateTime"; //$NON-NLS-1$
+
+	/** design constant: param type boolean */
 	String PARAM_TYPE_BOOLEAN = "boolean"; //$NON-NLS-1$
+
+	/** design constant: param type integer */
 	String PARAM_TYPE_INTEGER = "integer"; //$NON-NLS-1$
+
+	/** design constant: param type java object */
 	String PARAM_TYPE_JAVA_OBJECT = "javaObject"; //$NON-NLS-1$
+
 	/**
 	 * @deprecated Now any is not supported.
 	 */
 	@Deprecated
+	/** design constant: param type any */
 	String PARAM_TYPE_ANY = "any"; //$NON-NLS-1$
+
+	/** design constant: param type date */
 	String PARAM_TYPE_DATE = "date"; //$NON-NLS-1$
+
+	/** design constant: param type time */
 	String PARAM_TYPE_TIME = "time"; //$NON-NLS-1$
 
 	// paramValueType
-
+	/** design constant: choice param value type */
 	String CHOICE_PARAM_VALUE_TYPE = "paramType"; //$NON-NLS-1$
+
+	/** design constant: param value type static */
 	String PARAM_VALUE_TYPE_STATIC = "static"; //$NON-NLS-1$
+
+	/** design constant: param value type dynamic */
 	String PARAM_VALUE_TYPE_DYNAMIC = "dynamic"; //$NON-NLS-1$
 
-	// paramControl
 
+	// paramControl
+	/** design constant: choice param control */
 	String CHOICE_PARAM_CONTROL = "paramControl"; //$NON-NLS-1$
+
+	/** design constant: param control text box */
 	String PARAM_CONTROL_TEXT_BOX = "text-box"; //$NON-NLS-1$
+
+	/** design constant: param control list box */
 	String PARAM_CONTROL_LIST_BOX = "list-box"; //$NON-NLS-1$
+
+	/** design constant: param control radio button */
 	String PARAM_CONTROL_RADIO_BUTTON = "radio-button"; //$NON-NLS-1$
+
+	/** design constant: param control check box */
 	String PARAM_CONTROL_CHECK_BOX = "check-box"; //$NON-NLS-1$
+
+	/** design constant: param control auto suggest */
 	String PARAM_CONTROL_AUTO_SUGGEST = "auto-suggest"; //$NON-NLS-1$
 
-	// textAlign
 
+	// textAlign
+	/** design constant: choice text align */
 	String CHOICE_TEXT_ALIGN = "textAlign"; //$NON-NLS-1$
+
+	/** design constant: text align left */
 	String TEXT_ALIGN_LEFT = "left"; //$NON-NLS-1$
+
+	/** design constant: text align center */
 	String TEXT_ALIGN_CENTER = "center"; //$NON-NLS-1$
+
+	/** design constant: text align right */
 	String TEXT_ALIGN_RIGHT = "right"; //$NON-NLS-1$
+
+	/** design constant: text align justify */
 	String TEXT_ALIGN_JUSTIFY = "justify"; //$NON-NLS-1$
 
-	// pageSize
 
+	// pageSize
+	/** design constant: choice page size */
 	String CHOICE_PAGE_SIZE = "pageSize"; //$NON-NLS-1$
+
+	/** design constant: page size custom */
 	String PAGE_SIZE_CUSTOM = "custom"; //$NON-NLS-1$
+
+	/** design constant: page size us letter */
 	String PAGE_SIZE_US_LETTER = "us-letter"; //$NON-NLS-1$
+
+	/** design constant: page size us legal */
 	String PAGE_SIZE_US_LEGAL = "us-legal"; //$NON-NLS-1$
+
+	/** design constant: page size a4 */
 	String PAGE_SIZE_A4 = "a4"; //$NON-NLS-1$
+
+	/** design constant: page size a3 */
 	String PAGE_SIZE_A3 = "a3"; //$NON-NLS-1$
+
+	/** design constant: page size a5 */
 	String PAGE_SIZE_A5 = "a5"; //$NON-NLS-1$
+
+	/** design constant: page size us ledger */
 	String PAGE_SIZE_US_LEDGER = "us-ledger"; //$NON-NLS-1$
+
+	/** design constant: page size us super b */
 	String PAGE_SIZE_US_SUPER_B = "us-super-b"; //$NON-NLS-1$
 
-	// pageOrientation
 
+	// pageOrientation
+	/** design constant: choice page orientation */
 	String CHOICE_PAGE_ORIENTATION = "pageOrientation"; //$NON-NLS-1$
+
+	/** design constant: page orientation auto */
 	String PAGE_ORIENTATION_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: page orientation portrait */
 	String PAGE_ORIENTATION_PORTRAIT = "portrait"; //$NON-NLS-1$
+
+	/** design constant: page orientation landscape */
 	String PAGE_ORIENTATION_LANDSCAPE = "landscape"; //$NON-NLS-1$
 
-	// interval
 
+	// interval
+	/** design constant: choice interval */
 	String CHOICE_INTERVAL = "interval"; //$NON-NLS-1$
+
+	/** design constant: interval none */
 	String INTERVAL_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: interval prefix */
 	String INTERVAL_PREFIX = "prefix"; //$NON-NLS-1$
+
+	/** design constant: interval year */
 	String INTERVAL_YEAR = "year"; //$NON-NLS-1$
+
+	/** design constant: interval quarter */
 	String INTERVAL_QUARTER = "quarter"; //$NON-NLS-1$
+
+	/** design constant: interval month */
 	String INTERVAL_MONTH = "month"; //$NON-NLS-1$
+
+	/** design constant: interval week */
 	String INTERVAL_WEEK = "week"; //$NON-NLS-1$
+
+	/** design constant: interval day */
 	String INTERVAL_DAY = "day"; //$NON-NLS-1$
+
+	/** design constant: interval hour */
 	String INTERVAL_HOUR = "hour"; //$NON-NLS-1$
+
+	/** design constant: interval minute */
 	String INTERVAL_MINUTE = "minute"; //$NON-NLS-1$
+
+	/** design constant: interval second */
 	String INTERVAL_SECOND = "second"; //$NON-NLS-1$
+
+	/** design constant: interval interval */
 	String INTERVAL_INTERVAL = "interval"; //$NON-NLS-1$
 
-	// intervalType
 
+	// intervalType
+	/** design constant: choice interval type */
 	String CHOICE_INTERVAL_TYPE = "intervalType"; //$NON-NLS-1$
+
+	/** design constant: interval type none */
 	String INTERVAL_TYPE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: interval type prefix */
 	String INTERVAL_TYPE_PREFIX = "prefix"; //$NON-NLS-1$
+
+	/** design constant: interval type interval */
 	String INTERVAL_TYPE_INTERVAL = "interval"; //$NON-NLS-1$
 
-	// sortDirection
 
+	// sortDirection
+	/** design constant: choice sort direction */
 	String CHOICE_SORT_DIRECTION = "sortDirection"; //$NON-NLS-1$
+
+	/** design constant: sort direction asc */
 	String SORT_DIRECTION_ASC = "asc"; //$NON-NLS-1$
+
+	/** design constant: sort direction desc */
 	String SORT_DIRECTION_DESC = "desc"; //$NON-NLS-1$
 
-	// mapOperator
 
+	// mapOperator
+	/** design constant: choice map operator */
 	String CHOICE_MAP_OPERATOR = "mapOperator"; //$NON-NLS-1$
+
+	/** design constant: map operator eq */
 	String MAP_OPERATOR_EQ = "eq"; //$NON-NLS-1$
+
+	/** design constant: map operator ne */
 	String MAP_OPERATOR_NE = "ne"; //$NON-NLS-1$
+
+	/** design constant: map operator lt */
 	String MAP_OPERATOR_LT = "lt"; //$NON-NLS-1$
+
+	/** design constant: map operator le */
 	String MAP_OPERATOR_LE = "le"; //$NON-NLS-1$
+
+	/** design constant: map operator ge */
 	String MAP_OPERATOR_GE = "ge"; //$NON-NLS-1$
+
+	/** design constant: map operator gt */
 	String MAP_OPERATOR_GT = "gt"; //$NON-NLS-1$
+
+	/** design constant: map operator between */
 	String MAP_OPERATOR_BETWEEN = "between"; //$NON-NLS-1$
+
+	/** design constant: map operator not between */
 	String MAP_OPERATOR_NOT_BETWEEN = "not-between"; //$NON-NLS-1$
+
+	/** design constant: map operator null */
 	String MAP_OPERATOR_NULL = "is-null"; //$NON-NLS-1$
+
+	/** design constant: map operator not null */
 	String MAP_OPERATOR_NOT_NULL = "is-not-null"; //$NON-NLS-1$
+
+	/** design constant: map operator true */
 	String MAP_OPERATOR_TRUE = "is-true"; //$NON-NLS-1$
+
+	/** design constant: map operator false */
 	String MAP_OPERATOR_FALSE = "is-false"; //$NON-NLS-1$
+
+	/** design constant: map operator like */
 	String MAP_OPERATOR_LIKE = "like"; //$NON-NLS-1$
+
+	/** design constant: map operator match */
 	String MAP_OPERATOR_MATCH = "match"; //$NON-NLS-1$
+
+	/** design constant: map operator top n */
 	String MAP_OPERATOR_TOP_N = "top-n"; //$NON-NLS-1$
+
+	/** design constant: map operator bottom n */
 	String MAP_OPERATOR_BOTTOM_N = "bottom-n"; //$NON-NLS-1$
+
+	/** design constant: map operator top percent */
 	String MAP_OPERATOR_TOP_PERCENT = "top-percent"; //$NON-NLS-1$
+
+	/** design constant: map operator bottom percent */
 	String MAP_OPERATOR_BOTTOM_PERCENT = "bottom-percent"; //$NON-NLS-1$
+
+	/** design constant: map operator not like */
 	String MAP_OPERATOR_NOT_LIKE = "not-like"; //$NON-NLS-1$
+
+	/** design constant: map operator not match */
 	String MAP_OPERATOR_NOT_MATCH = "not-match"; //$NON-NLS-1$
 
+	/** design constant: map operator any */
 	String MAP_OPERATOR_ANY = "any"; //$NON-NLS-1$
+
+	/** design constant: map operator not in */
 	String MAP_OPERATOR_NOT_IN = "not-in"; //$NON-NLS-1$
+
+	/** design constant: map operator in */
 	String MAP_OPERATOR_IN = "in"; //$NON-NLS-1$
 
-	// imageSize
 
+	// imageSize
+	/** design constant: choice image size */
 	String CHOICE_IMAGE_SIZE = "imageSize"; //$NON-NLS-1$
+
+	/** design constant: image size size to image */
 	String IMAGE_SIZE_SIZE_TO_IMAGE = "size-to-image"; //$NON-NLS-1$
+
+	/** design constant: image size scale to item */
 	String IMAGE_SIZE_SCALE_TO_ITEM = "scale-to-item"; //$NON-NLS-1$
+
+	/** design constant: image size clip */
 	String IMAGE_SIZE_CLIP = "clip"; //$NON-NLS-1$
 
-	// lineOrientation
 
+	// lineOrientation
+	/** design constant: choice line orientation */
 	String CHOICE_LINE_ORIENTATION = "lineOrientation"; //$NON-NLS-1$
+
+	/** design constant: line orientation horizontal */
 	String LINE_ORIENTATION_HORIZONTAL = "horizontal"; //$NON-NLS-1$
+
+	/** design constant: line orientation vertical */
 	String LINE_ORIENTATION_VERTICAL = "vertical"; //$NON-NLS-1$
 
-	// sectionAlign
 
+	// sectionAlign
+	/** design constant: choice section align */
 	String CHOICE_SECTION_ALIGN = "sectionAlign"; //$NON-NLS-1$
+
+	/** design constant: section align left */
 	String SECTION_ALIGN_LEFT = "left"; //$NON-NLS-1$
+
+	/** design constant: section align center */
 	String SECTION_ALIGN_CENTER = "center"; //$NON-NLS-1$
+
+	/** design constant: section align right */
 	String SECTION_ALIGN_RIGHT = "right"; //$NON-NLS-1$
 
-	// dropType
 
+	// dropType
+	/** design constant: choice drop type */
 	String CHOICE_DROP_TYPE = "dropType"; //$NON-NLS-1$
+
+	/** design constant: drop type none */
 	String DROP_TYPE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: drop type detail */
 	String DROP_TYPE_DETAIL = "detail"; //$NON-NLS-1$
+
+	/** design constant: drop type all */
 	String DROP_TYPE_ALL = "all"; //$NON-NLS-1$
 
-	// imageType
 
+	// imageType
+	/** design constant: choice image type */
 	String CHOICE_IMAGE_TYPE = "imageType"; //$NON-NLS-1$
+
+	/** design constant: image type image bmp */
 	String IMAGE_TYPE_IMAGE_BMP = "image/bmp"; //$NON-NLS-1$
+
+	/** design constant: image type image gif */
 	String IMAGE_TYPE_IMAGE_GIF = "image/gif"; //$NON-NLS-1$
+
+	/** design constant: image type image png */
 	String IMAGE_TYPE_IMAGE_PNG = "image/png"; //$NON-NLS-1$
+
+	/** design constant: image type image x png */
 	String IMAGE_TYPE_IMAGE_X_PNG = "image/x-png"; //$NON-NLS-1$
+
+	/** design constant: image type image jpeg */
 	String IMAGE_TYPE_IMAGE_JPEG = "image/jpeg"; //$NON-NLS-1$
+
+	/** design constant: image type image ico */
 	String IMAGE_TYPE_IMAGE_ICO = "image/ico"; //$NON-NLS-1$
+
+	/** design constant: image type image tiff */
 	String IMAGE_TYPE_IMAGE_TIFF = "image/tiff"; //$NON-NLS-1$
+
+	/** design constant: image type image svg */
 	String IMAGE_TYPE_IMAGE_SVG = "image/svg+xml"; //$NON-NLS-1$
+
+	/** design constant: image type image x icon */
 	String IMAGE_TYPE_IMAGE_X_ICON = "image/x-icon"; //$NON-NLS-1$
 
-	// lineSpacing
 
+	// lineSpacing
+	/** design constant: choice line spacing */
 	String CHOICE_LINE_SPACING = "lineSpacing"; //$NON-NLS-1$
+
+	/** design constant: line spacing lines */
 	String LINE_SPACING_LINES = "lines"; //$NON-NLS-1$
+
+	/** design constant: line spacing exact */
 	String LINE_SPACING_EXACT = "exact"; //$NON-NLS-1$
 
-	// actionLinkTyp
 
+	// actionLinkTyp
+	/** design constant: choice action link type */
 	String CHOICE_ACTION_LINK_TYPE = "actionLinkType"; //$NON-NLS-1$
+
+	/** design constant: action link type none */
 	String ACTION_LINK_TYPE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: action link type hyperlink */
 	String ACTION_LINK_TYPE_HYPERLINK = "hyperlink"; //$NON-NLS-1$
+
+	/** design constant: action link type drill through */
 	String ACTION_LINK_TYPE_DRILL_THROUGH = "drill-through"; //$NON-NLS-1$
+
+	/** design constant: action link type bookmark link */
 	String ACTION_LINK_TYPE_BOOKMARK_LINK = "bookmark-link"; //$NON-NLS-1$
 
-	// actionFormatType
 
+	// actionFormatType
+	/** design constant: choice action format type */
 	String CHOICE_ACTION_FORMAT_TYPE = "actionFormatType"; //$NON-NLS-1$
+
+	/** design constant: action format type html */
 	String ACTION_FORMAT_TYPE_HTML = "html"; //$NON-NLS-1$
+
+	/** design constant: action format type pdf */
 	String ACTION_FORMAT_TYPE_PDF = "pdf"; //$NON-NLS-1$
 
-	// ContentType for TextItem
 
+	// ContentType for TextItem
+	/** design constant: choice text content type */
 	String CHOICE_TEXT_CONTENT_TYPE = "textContentType"; //$NON-NLS-1$
+
+	/** design constant: text content type auto */
 	String TEXT_CONTENT_TYPE_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: text content type plain */
 	String TEXT_CONTENT_TYPE_PLAIN = "plain"; //$NON-NLS-1$
+
+	/** design constant: text content type html */
 	String TEXT_CONTENT_TYPE_HTML = "html"; //$NON-NLS-1$
+
+	/** design constant: text content type rtf */
 	String TEXT_CONTENT_TYPE_RTF = "rtf"; //$NON-NLS-1$
 
-	// ContentType for TextDataItem
 
+	// ContentType for TextDataItem
+	/** design constant: choice text data content type */
 	String CHOICE_TEXT_DATA_CONTENT_TYPE = "textDataContentType"; //$NON-NLS-1$
+
+	/** design constant: text data content type auto */
 	String TEXT_DATA_CONTENT_TYPE_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: text data content type plain */
 	String TEXT_DATA_CONTENT_TYPE_PLAIN = "plain"; //$NON-NLS-1$
+
+	/** design constant: text data content type html */
 	String TEXT_DATA_CONTENT_TYPE_HTML = "html"; //$NON-NLS-1$
+
+	/** design constant: text data content type rtf */
 	String TEXT_DATA_CONTENT_TYPE_RTF = "rtf"; //$NON-NLS-1$
 
-	// Pagination orphans
 
+	// Pagination orphans
+	/** design constant: choice oprhans */
 	String CHOICE_OPRHANS = "orphans"; //$NON-NLS-1$
+
+	/** design constant: orphans inherit */
 	String ORPHANS_INHERIT = "inherit"; //$NON-NLS-1$
 
-	// Pagination widows
 
+	// Pagination widows
+	/** design constant: choice widows */
 	String CHOICE_WIDOWS = "widows"; //$NON-NLS-1$
+
+	/** design constant: widows inherit */
 	String WIDOWS_INHERIT = "inherit"; //$NON-NLS-1$
+
 
 	/**
 	 * FormatType -- The target output format. The first constant is the name of
 	 * FormatType choice. The followed constants are valid choice values of
 	 * FormatType.
 	 */
-
+	/** design constant: choice format type */
 	String CHOICE_FORMAT_TYPE = "formatType"; //$NON-NLS-1$
+
+	/** design constant: format type all */
 	String FORMAT_TYPE_ALL = "all"; //$NON-NLS-1$
+
+	/** design constant: format type viewer */
 	String FORMAT_TYPE_VIEWER = "viewer"; //$NON-NLS-1$
+
+	/** design constant: format type email */
 	String FORMAT_TYPE_EMAIL = "email"; //$NON-NLS-1$
+
+	/** design constant: format type print */
 	String FORMAT_TYPE_PRINT = "print"; //$NON-NLS-1$
+
+	/** design constant: format type pdf */
 	String FORMAT_TYPE_PDF = "pdf"; //$NON-NLS-1$
+
+	/** design constant: format type rtf */
 	String FORMAT_TYPE_RTF = "rtf"; //$NON-NLS-1$
+
+	/** design constant: format type reportlet */
 	String FORMAT_TYPE_REPORTLET = "reportlet"; //$NON-NLS-1$
+
+	/** design constant: format type excel */
 	String FORMAT_TYPE_EXCEL = "excel"; //$NON-NLS-1$
+
+	/** design constant: format type word */
 	String FORMAT_TYPE_WORD = "word"; //$NON-NLS-1$
+
+	/** design constant: format type powerpoint */
 	String FORMAT_TYPE_POWERPOINT = "powerpoint"; //$NON-NLS-1$
+
+	/** design constant: format type doc */
 	String FORMAT_TYPE_DOC = "doc"; //$NON-NLS-1$
+
+
 	/**
 	 * ImageRefType -- The image reference type. The first constant is the name of
 	 * ImageRefType choice. The followed constants are valid choice values of
 	 * ImageRefType.
 	 */
-
+	/** design constant: choice image ref type */
 	String CHOICE_IMAGE_REF_TYPE = "imageRefType"; //$NON-NLS-1$
+
+	/** design constant: image ref type none */
 	String IMAGE_REF_TYPE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: image ref type file */
 	String IMAGE_REF_TYPE_FILE = "file"; //$NON-NLS-1$
+
+	/** design constant: image ref type url */
 	String IMAGE_REF_TYPE_URL = "url"; //$NON-NLS-1$
+
+	/** design constant: image ref type expr */
 	String IMAGE_REF_TYPE_EXPR = "expr"; //$NON-NLS-1$
+
+	/** design constant: image ref type embed */
 	String IMAGE_REF_TYPE_EMBED = "embed"; //$NON-NLS-1$
+
 
 	/**
 	 * propertyMaskType -- The choice for the property mask. The first constant is
 	 * the name of propertyMaskType choice. The followed constants are valid choice
 	 * values of propertyMaskType.
 	 */
-
+	/** design constant: choice property mask type */
 	String CHOICE_PROPERTY_MASK_TYPE = "propertyMaskType"; //$NON-NLS-1$
+
+	/** design constant: property mask type change */
 	String PROPERTY_MASK_TYPE_CHANGE = "change"; //$NON-NLS-1$
+
+	/** design constant: property mask type lock */
 	String PROPERTY_MASK_TYPE_LOCK = "lock"; //$NON-NLS-1$
+
+	/** design constant: property mask type hide */
 	String PROPERTY_MASK_TYPE_HIDE = "hide"; //$NON-NLS-1$
+
 
 	/**
 	 * scalarParamAlign -- The choice for the scalarParamter alignment. The first
 	 * constant is the name of scalarParamAlign choice. The followed constants are
 	 * valid choice values of scalarParamAlign.
 	 */
-
+	/** design constant: choice scalar param align */
 	String CHOICE_SCALAR_PARAM_ALIGN = "scalarParamAlign"; //$NON-NLS-1$
+
+	/** design constant: scalar param align auto */
 	String SCALAR_PARAM_ALIGN_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: scalar param align left */
 	String SCALAR_PARAM_ALIGN_LEFT = "left"; //$NON-NLS-1$
+
+	/** design constant: scalar param align center */
 	String SCALAR_PARAM_ALIGN_CENTER = "center"; //$NON-NLS-1$
+
+	/** design constant: scalar param align right */
 	String SCALAR_PARAM_ALIGN_RIGHT = "right"; //$NON-NLS-1$
 
+
 	/*
+	 *
 	 * columnDataType -- The column data type The first constant is the name of
 	 * columnDataType choice. The followed constants are valid choice values of
 	 * columnDataType.
+	 *
 	 */
-
+	/** design constant: choice column data type */
 	String CHOICE_COLUMN_DATA_TYPE = "columnDataType"; //$NON-NLS-1$
+
 	/**
 	 * @deprecated this choice is removed since 2.3
 	 */
 	@Deprecated
+	/** design constant: column data type any */
 	String COLUMN_DATA_TYPE_ANY = "any"; //$NON-NLS-1$
+
+	/** design constant: column data type integer */
 	String COLUMN_DATA_TYPE_INTEGER = "integer"; //$NON-NLS-1$
+
+	/** design constant: column data type string */
 	String COLUMN_DATA_TYPE_STRING = "string"; //$NON-NLS-1$
+
+	/** design constant: column data type datetime */
 	String COLUMN_DATA_TYPE_DATETIME = "date-time"; //$NON-NLS-1$
+
+	/** design constant: column data type decimal */
 	String COLUMN_DATA_TYPE_DECIMAL = "decimal"; //$NON-NLS-1$
+
+	/** design constant: column data type float */
 	String COLUMN_DATA_TYPE_FLOAT = "float"; //$NON-NLS-1$
+
+	/** design constant: column data type boolean */
 	String COLUMN_DATA_TYPE_BOOLEAN = "boolean"; //$NON-NLS-1$
+
+	/** design constant: column data type date */
 	String COLUMN_DATA_TYPE_DATE = "date";//$NON-NLS-1$
+
+	/** design constant: column data type time */
 	String COLUMN_DATA_TYPE_TIME = "time";//$NON-NLS-1$
+
+	/** design constant: column data type blob */
 	String COLUMN_DATA_TYPE_BLOB = "blob";//$NON-NLS-1$
+
+	/** design constant: column data type java object */
 	String COLUMN_DATA_TYPE_JAVA_OBJECT = "javaObject";//$NON-NLS-1$
+
 
 	/**
 	 * searchType -- The search type for column hint The first constant is the name
 	 * of searchType choice. The followed constants are valid choice values of
 	 * searchType.
 	 */
-
+	/** design constant: choice search type */
 	String CHOICE_SEARCH_TYPE = "searchType"; //$NON-NLS-1$
+
+	/** design constant: search type any */
 	String SEARCH_TYPE_ANY = "any"; //$NON-NLS-1$
+
+	/** design constant: search type indexed */
 	String SEARCH_TYPE_INDEXED = "indexed"; //$NON-NLS-1$
+
+	/** design constant: search type none */
 	String SEARCH_TYPE_NONE = "none"; //$NON-NLS-1$
 
 	/**
@@ -550,85 +1093,158 @@ public interface DesignChoiceConstants {
 	 * of exportType choice. The followed constants are valid choice values of
 	 * exportType.
 	 */
-
+	/** design constant: choice export type */
 	String CHOICE_EXPORT_TYPE = "exportType"; //$NON-NLS-1$
+
+	/** design constant: export type none */
 	String EXPORT_TYPE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: export type if realized */
 	String EXPORT_TYPE_IF_REALIZED = "if-realized"; //$NON-NLS-1$
+
+	/** design constant: export type always */
 	String EXPORT_TYPE_ALWAYS = "always"; //$NON-NLS-1$
+
 
 	/**
 	 * analysisType -- The analysis type for column hint The first constant is the
 	 * name of analysisType choice. The followed constants are valid choice values
 	 * of analysisType.
 	 */
-
+	/** design constant: choice analysis type */
 	String CHOICE_ANALYSIS_TYPE = "analysisType"; //$NON-NLS-1$
 
+
 	/**
 	 * @deprecated in 2.5.1: this choice is not supported
 	 */
 	@Deprecated
+	/** design constant: analysis type auto */
 	String ANALYSIS_TYPE_AUTO = "auto"; //$NON-NLS-1$
+
+	/** design constant: analysis type dimension */
 	String ANALYSIS_TYPE_DIMENSION = "dimension"; //$NON-NLS-1$
+
+	/** design constant: analysis type attribute */
 	String ANALYSIS_TYPE_ATTRIBUTE = "attribute"; //$NON-NLS-1$
+
+	/** design constant: analysis type measure */
 	String ANALYSIS_TYPE_MEASURE = "measure"; //$NON-NLS-1$
+
 	/**
 	 * @deprecated in 2.5.1: this choice is not supported
 	 */
 	@Deprecated
+	/** design constant: analysis type detail */
 	String ANALYSIS_TYPE_DETAIL = "detail"; //$NON-NLS-1$
+
+
 	/**
 	 * @deprecated in 2.5.1: this choice is not supported
 	 */
 	@Deprecated
+	/** design constant: analysis type none */
 	String ANALYSIS_TYPE_NONE = "none"; //$NON-NLS-1$
+
 
 	/**
 	 * filterOperator -- The filter operator for filter condition The first constant
 	 * is the name of filterOperator choice. The followed constants are valid choice
 	 * values of filterOperator.
 	 */
-
+	/** design constant: choice filter operator */
 	String CHOICE_FILTER_OPERATOR = "filterOperator"; //$NON-NLS-1$
+
+	/** design constant: filter operator eq */
 	String FILTER_OPERATOR_EQ = "eq"; //$NON-NLS-1$
+
+	/** design constant: filter operator ne */
 	String FILTER_OPERATOR_NE = "ne"; //$NON-NLS-1$
+
+	/** design constant: filter operator lt */
 	String FILTER_OPERATOR_LT = "lt"; //$NON-NLS-1$
+
+	/** design constant: filter operator le */
 	String FILTER_OPERATOR_LE = "le"; //$NON-NLS-1$
+
+	/** design constant: filter operator ge */
 	String FILTER_OPERATOR_GE = "ge"; //$NON-NLS-1$
+
+	/** design constant: filter operator gt */
 	String FILTER_OPERATOR_GT = "gt"; //$NON-NLS-1$
+
+	/** design constant: filter operator between */
 	String FILTER_OPERATOR_BETWEEN = "between"; //$NON-NLS-1$
+
+	/** design constant: filter operator not between */
 	String FILTER_OPERATOR_NOT_BETWEEN = "not-between"; //$NON-NLS-1$
+
+	/** design constant: filter operator null */
 	String FILTER_OPERATOR_NULL = "is-null"; //$NON-NLS-1$
+
+	/** design constant: filter operator not null */
 	String FILTER_OPERATOR_NOT_NULL = "is-not-null"; //$NON-NLS-1$
+
+	/** design constant: filter operator true */
 	String FILTER_OPERATOR_TRUE = "is-true"; //$NON-NLS-1$
+
+	/** design constant: filter operator false */
 	String FILTER_OPERATOR_FALSE = "is-false"; //$NON-NLS-1$
+
+	/** design constant: filter operator like */
 	String FILTER_OPERATOR_LIKE = "like"; //$NON-NLS-1$
+
+	/** design constant: filter operator top n */
 	String FILTER_OPERATOR_TOP_N = "top-n"; //$NON-NLS-1$
+
+	/** design constant: filter operator bottom n */
 	String FILTER_OPERATOR_BOTTOM_N = "bottom-n"; //$NON-NLS-1$
+
+	/** design constant: filter operator top percent */
 	String FILTER_OPERATOR_TOP_PERCENT = "top-percent"; //$NON-NLS-1$
+
+	/** design constant: filter operator bottom percent */
 	String FILTER_OPERATOR_BOTTOM_PERCENT = "bottom-percent"; //$NON-NLS-1$
+
+	/** design constant: filter operator not in */
 	String FILTER_OPERATOR_NOT_IN = "not-in"; //$NON-NLS-1$
+
 
 	/**
 	 * @deprecated in BIRT 2.1. This operator is not supported.
 	 */
-
 	@Deprecated
+	/** design constant: filter operator any */
 	String FILTER_OPERATOR_ANY = "any"; //$NON-NLS-1$
+
+	/** design constant: filter operator match */
 	String FILTER_OPERATOR_MATCH = "match"; //$NON-NLS-1$
+
+	/** design constant: filter operator not like */
 	String FILTER_OPERATOR_NOT_LIKE = "not-like"; //$NON-NLS-1$
+
+	/** design constant: filter operator not match */
 	String FILTER_OPERATOR_NOT_MATCH = "not-match"; //$NON-NLS-1$
+
+	/** design constant: filter operator in */
 	String FILTER_OPERATOR_IN = "in"; //$NON-NLS-1$
+
 
 	/**
 	 * columnAlign -- The column alignment The first constant is the name of
 	 * columnAlign choice. The followed constants are valid choice values of
 	 * columnAlign.
 	 */
-
+	/** design constant: choice column align */
 	String CHOICE_COLUMN_ALIGN = "columnAlign"; //$NON-NLS-1$
+
+	/** design constant: column align left */
 	String COLUMN_ALIGN_LEFT = "left"; //$NON-NLS-1$
+
+	/** design constant: column align center */
 	String COLUMN_ALIGN_CENTER = "center"; //$NON-NLS-1$
+
+	/** design constant: column align right */
 	String COLUMN_ALIGN_RIGHT = "right"; //$NON-NLS-1$
 
 	/**
@@ -636,30 +1252,55 @@ public interface DesignChoiceConstants {
 	 * queryFrom choice. The followed constants are valid choice values of
 	 * queryFrom.
 	 */
-
+	/** design constant: choice query choice type */
 	String CHOICE_QUERY_CHOICE_TYPE = "queryChoiceType"; //$NON-NLS-1$
+
+	/** design constant: query choice type none */
 	String QUERY_CHOICE_TYPE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: query choice type text */
 	String QUERY_CHOICE_TYPE_TEXT = "text"; //$NON-NLS-1$
+
+	/** design constant: query choice type script */
 	String QUERY_CHOICE_TYPE_SCRIPT = "script"; //$NON-NLS-1$
 
 	/**
 	 * Common format type "Custom"
 	 */
+	/** design constant: value format type custom */
 	String VALUE_FORMAT_TYPE_CUSTOM = "Custom"; //$NON-NLS-1$
+
+
 	/**
 	 * numberFormat -- the number format The first constant is the name of
 	 * numberFormat choice. The followed constants are valid choice values of
 	 * numberFormat.
 	 */
-
+	/** design constant: choice number format type */
 	String CHOICE_NUMBER_FORMAT_TYPE = "numberFormat"; //$NON-NLS-1$
+
+	/** design constant: number format type unformatted */
 	String NUMBER_FORMAT_TYPE_UNFORMATTED = "Unformatted"; //$NON-NLS-1$
+
+	/** design constant: number format type general number */
 	String NUMBER_FORMAT_TYPE_GENERAL_NUMBER = "General Number"; //$NON-NLS-1$
+
+	/** design constant: number format type currency */
 	String NUMBER_FORMAT_TYPE_CURRENCY = "Currency"; //$NON-NLS-1$
+
+	/** design constant: number format type fixed */
 	String NUMBER_FORMAT_TYPE_FIXED = "Fixed"; //$NON-NLS-1$
+
+	/** design constant: number format type percent */
 	String NUMBER_FORMAT_TYPE_PERCENT = "Percent"; //$NON-NLS-1$
+
+	/** design constant: number format type scientific */
 	String NUMBER_FORMAT_TYPE_SCIENTIFIC = "Scientific"; //$NON-NLS-1$
+
+	/** design constant: number format type standard */
 	String NUMBER_FORMAT_TYPE_STANDARD = "Standard"; //$NON-NLS-1$
+
+	/** design constant: number format type custom */
 	String NUMBER_FORMAT_TYPE_CUSTOM = VALUE_FORMAT_TYPE_CUSTOM;
 
 	/**
@@ -667,434 +1308,896 @@ public interface DesignChoiceConstants {
 	 * dateTimeFormat choice. The followed constants are valid choice values of
 	 * dateTimeFormat.
 	 */
-
+	/** design constant: choice datetime format type */
 	String CHOICE_DATETIME_FORMAT_TYPE = "dateTimeFormat"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type unformatted */
 	String DATETIEM_FORMAT_TYPE_UNFORMATTED = "Unformatted"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type general date */
 	String DATETIEM_FORMAT_TYPE_GENERAL_DATE = "General Date"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type long date */
 	String DATETIEM_FORMAT_TYPE_LONG_DATE = "Long Date"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type mudium date */
 	String DATETIEM_FORMAT_TYPE_MUDIUM_DATE = "Medium Date"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type short date */
 	String DATETIEM_FORMAT_TYPE_SHORT_DATE = "Short Date"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type long time */
 	String DATETIEM_FORMAT_TYPE_LONG_TIME = "Long Time"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type medium time */
 	String DATETIEM_FORMAT_TYPE_MEDIUM_TIME = "Medium Time"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type short time */
 	String DATETIEM_FORMAT_TYPE_SHORT_TIME = "Short Time"; //$NON-NLS-1$
+
+	/** design constant: datetiem format type custom */
 	String DATETIEM_FORMAT_TYPE_CUSTOM = VALUE_FORMAT_TYPE_CUSTOM;
+
 
 	/**
 	 * dateFormat choice.
 	 */
-
+	/** design constant: choice date format type */
 	String CHOICE_DATE_FORMAT_TYPE = "dateFormat"; //$NON-NLS-1$
+
+	/** design constant: date format type unformatted */
 	String DATE_FORMAT_TYPE_UNFORMATTED = "Unformatted"; //$NON-NLS-1$
+
+	/** design constant: date format type general date */
 	String DATE_FORMAT_TYPE_GENERAL_DATE = "General Date"; //$NON-NLS-1$
+
+	/** design constant: date format type long date */
 	String DATE_FORMAT_TYPE_LONG_DATE = "Long Date"; //$NON-NLS-1$
+
+	/** design constant: date format type mudium date */
 	String DATE_FORMAT_TYPE_MUDIUM_DATE = "Medium Date"; //$NON-NLS-1$
+
+	/** design constant: date format type short date */
 	String DATE_FORMAT_TYPE_SHORT_DATE = "Short Date"; //$NON-NLS-1$
+
+	/** design constant: date format type custom */
 	String DATE_FORMAT_TYPE_CUSTOM = VALUE_FORMAT_TYPE_CUSTOM;
+
 
 	/**
 	 * timeFormat choice
 	 */
-
+	/** design constant: choice time format type */
 	String CHOICE_TIME_FORMAT_TYPE = "timeFormat"; //$NON-NLS-1$
+
+	/** design constant: time format type long time */
 	String TIME_FORMAT_TYPE_LONG_TIME = "Long Time"; //$NON-NLS-1$
+
+	/** design constant: time format type medium time */
 	String TIME_FORMAT_TYPE_MEDIUM_TIME = "Medium Time"; //$NON-NLS-1$
+
+	/** design constant: time format type short time */
 	String TIME_FORMAT_TYPE_SHORT_TIME = "Short Time"; //$NON-NLS-1$
+
+	/** design constant: time format type custom */
 	String TIME_FORMAT_TYPE_CUSTOM = VALUE_FORMAT_TYPE_CUSTOM;
+
 
 	/**
 	 * stringFormat -- the string format The first constant is the name of
 	 * stringFormat choice. The followed constants are valid choice values of
 	 * stringFormat.
 	 */
-
+	/** design constant: choice string format type */
 	String CHOICE_STRING_FORMAT_TYPE = "stringFormat"; //$NON-NLS-1$
+
+	/** design constant: string format type unformatted */
 	String STRING_FORMAT_TYPE_UNFORMATTED = "Unformatted"; //$NON-NLS-1$
+
+	/** design constant: string format type uppercase */
 	String STRING_FORMAT_TYPE_UPPERCASE = ">"; //$NON-NLS-1$
+
+	/** design constant: string format type lowercase */
 	String STRING_FORMAT_TYPE_LOWERCASE = "<"; //$NON-NLS-1$
+
+	/** design constant: string format type custom */
 	String STRING_FORMAT_TYPE_CUSTOM = VALUE_FORMAT_TYPE_CUSTOM;
+
+	/** design constant: string format type zip code */
 	String STRING_FORMAT_TYPE_ZIP_CODE = "Zip Code"; //$NON-NLS-1$
+
+	/** design constant: string format type zip code 4 */
 	String STRING_FORMAT_TYPE_ZIP_CODE_4 = "Zip Code + 4"; //$NON-NLS-1$
+
+	/** design constant: string format type phone number */
 	String STRING_FORMAT_TYPE_PHONE_NUMBER = "Phone Number"; //$NON-NLS-1$
+
+	/** design constant: string format type social security number */
 	String STRING_FORMAT_TYPE_SOCIAL_SECURITY_NUMBER = "Social Security Number"; //$NON-NLS-1$
 
-	// targetNames
 
+	// targetNames
+	/** design constant: choice target names type */
 	String CHOICE_TARGET_NAMES_TYPE = "targetNames"; //$NON-NLS-1$
+
+	/** design constant: target names type blank */
 	String TARGET_NAMES_TYPE_BLANK = "_blank"; //$NON-NLS-1$
+
+	/** design constant: target names type self */
 	String TARGET_NAMES_TYPE_SELF = "_self"; //$NON-NLS-1$
+
+	/** design constant: target names type parent */
 	String TARGET_NAMES_TYPE_PARENT = "_parent"; //$NON-NLS-1$
+
+	/** design constant: target names type top */
 	String TARGET_NAMES_TYPE_TOP = "_top"; //$NON-NLS-1$
+
 
 	/**
 	 * templateElementType -- the template element type The first constant is the
 	 * name of the templateElementType choice set. The followed constants are valid
 	 * choice values of the templateElementType.
 	 */
-
+	/** design constant: choice template element type */
 	String CHOICE_TEMPLATE_ELEMENT_TYPE = "templateElementType"; //$NON-NLS-1$
+
+	/** design constant: template element type table */
 	String TEMPLATE_ELEMENT_TYPE_TABLE = "Table"; //$NON-NLS-1$
+
+	/** design constant: template element type freeform */
 	String TEMPLATE_ELEMENT_TYPE_FREEFORM = "FreeForm"; //$NON-NLS-1$
+
+	/** design constant: template element type data */
 	String TEMPLATE_ELEMENT_TYPE_DATA = "Data"; //$NON-NLS-1$
+
+	/** design constant: template element type grid */
 	String TEMPLATE_ELEMENT_TYPE_GRID = "Grid"; //$NON-NLS-1$
+
+	/** design constant: template element type image */
 	String TEMPLATE_ELEMENT_TYPE_IMAGE = "Image"; //$NON-NLS-1$
+
+	/** design constant: template element type label */
 	String TEMPLATE_ELEMENT_TYPE_LABEL = "Label"; //$NON-NLS-1$
+
+	/** design constant: template element type list */
 	String TEMPLATE_ELEMENT_TYPE_LIST = "List"; //$NON-NLS-1$
+
+	/** design constant: template element type text */
 	String TEMPLATE_ELEMENT_TYPE_TEXT = "Text"; //$NON-NLS-1$
+
+	/** design constant: template element type extended item */
 	String TEMPLATE_ELEMENT_TYPE_EXTENDED_ITEM = "ExtendedItem"; //$NON-NLS-1$
+
+	/** design constant: template element type text data */
 	String TEMPLATE_ELEMENT_TYPE_TEXT_DATA = "TextData"; //$NON-NLS-1$
+
+	/** design constant: template element type data set */
 	String TEMPLATE_ELEMENT_TYPE_DATA_SET = "DataSet"; //$NON-NLS-1$
+
 
 	/**
 	 * sortType -- the sort type. The first constant is the name of the sortType
 	 * choice set. The followed constants are valid choice values of the sortType.
 	 */
-
+	/** design constant: choice sort type */
 	String CHOICE_SORT_TYPE = "sortType"; //$NON-NLS-1$
+
+	/** design constant: sort type none */
 	String SORT_TYPE_NONE = "none"; //$NON-NLS-1$
+
+	/** design constant: sort type sort on group key */
 	String SORT_TYPE_SORT_ON_GROUP_KEY = "sort-on-group-key"; //$NON-NLS-1$
+
+	/** design constant: sort type complex sort */
 	String SORT_TYPE_COMPLEX_SORT = "complex-sort"; //$NON-NLS-1$
+
 
 	/**
 	 * joinType -- join type of join condition.
 	 */
-
+	/** design constant: choice join type */
 	String CHOICE_JOIN_TYPE = "joinType"; //$NON-NLS-1$
+
+	/** design constant: join type inner */
 	String JOIN_TYPE_INNER = "inner"; //$NON-NLS-1$
+
+	/** design constant: join type left out */
 	String JOIN_TYPE_LEFT_OUT = "left-out"; //$NON-NLS-1$
+
+	/** design constant: join type right out */
 	String JOIN_TYPE_RIGHT_OUT = "right-out"; //$NON-NLS-1$
+
+	/** design constant: join type full out */
 	String JOIN_TYPE_FULL_OUT = "full-out"; //$NON-NLS-1$
+
 
 	/**
 	 * joinOperator -- join operator of join condition.
 	 */
-
+	/** design constant: choice join operator */
 	String CHOICE_JOIN_OPERATOR = "joinOperator"; //$NON-NLS-1$
+
+	/** design constant: join operator eqals */
 	String JOIN_OPERATOR_EQALS = "eq"; //$NON-NLS-1$
+
 
 	/**
 	 * actionTargetFileType -- target type of the linked file
 	 */
-
+	/** design constant: choice action target file type */
 	String CHOICE_ACTION_TARGET_FILE_TYPE = "actionTargetFileType"; //$NON-NLS-1$
+
+	/** design constant: action target file type report design */
 	String ACTION_TARGET_FILE_TYPE_REPORT_DESIGN = "report-design"; //$NON-NLS-1$
+
+	/** design constant: action target file type report document */
 	String ACTION_TARGET_FILE_TYPE_REPORT_DOCUMENT = "report-document"; //$NON-NLS-1$
+
 
 	/**
 	 * actionBookmarkType -- target bookmark type
 	 */
-
+	/** design constant: choice action bookmark type */
 	String CHOICE_ACTION_BOOKMARK_TYPE = "actionBookmarkType"; //$NON-NLS-1$
+
+	/** design constant: action bookmark type bookmark */
 	String ACTION_BOOKMARK_TYPE_BOOKMARK = "bookmark"; //$NON-NLS-1$
+
+	/** design constant: action bookmark type toc */
 	String ACTION_BOOKMARK_TYPE_TOC = "toc"; //$NON-NLS-1$
+
 
 	/**
 	 * autotextType -- type of auto text
 	 */
-
+	/** design constant: choice auto text type */
 	String CHOICE_AUTO_TEXT_TYPE = "autoTextType"; //$NON-NLS-1$
+
+	/** design constant: auto text page number */
 	String AUTO_TEXT_PAGE_NUMBER = "page-number"; //$NON-NLS-1$
+
+	/** design constant: auto text total page */
 	String AUTO_TEXT_TOTAL_PAGE = "total-page"; //$NON-NLS-1$
+
+	/** design constant: auto text page number unfiltered */
 	String AUTO_TEXT_PAGE_NUMBER_UNFILTERED = "page-number-unfiltered"; //$NON-NLS-1$
+
+	/** design constant: auto text total page unfiltered */
 	String AUTO_TEXT_TOTAL_PAGE_UNFILTERED = "total-page-unfiltered"; //$NON-NLS-1$
+
+	/** design constant: auto text page variable */
 	String AUTO_TEXT_PAGE_VARIABLE = "page-variable"; //$NON-NLS-1$
+
 
 	/**
 	 * dataSetMode -- the mode to support data sets. Can be single data set and
 	 */
-
+	/** design constant: choice data set mode type */
 	String CHOICE_DATA_SET_MODE_TYPE = "dataSetMode"; //$NON-NLS-1$
+
+	/** design constant: data set mode single */
 	String DATA_SET_MODE_SINGLE = "single"; //$NON-NLS-1$
+
+	/** design constant: data set mode multiple */
 	String DATA_SET_MODE_MULTIPLE = "multiple"; //$NON-NLS-1$
+
 
 	/**
 	 * filterTarget -- filter target type.
 	 */
-
+	/** design constant: choice filter target */
 	String CHOICE_FILTER_TARGET = "filterTarget"; //$NON-NLS-1$
+
+	/** design constant: filter target data set */
 	String FILTER_TARGET_DATA_SET = "DataSet"; //$NON-NLS-1$
+
+	/** design constant: filter target result set */
 	String FILTER_TARGET_RESULT_SET = "ResultSet"; //$NON-NLS-1$
+
 
 	/**
 	 * View action --view action type.
 	 */
-
+	/** design constant: choice view action */
 	String CHOICE_VIEW_ACTION = "viewAction"; //$NON-NLS-1$
+
+	/** design constant: view action no change */
 	String VIEW_ACTION_NO_CHANGE = "NoChange"; //$NON-NLS-1$
+
+	/** design constant: view action changed */
 	String VIEW_ACTION_CHANGED = "Changed"; //$NON-NLS-1$
+
+	/** design constant: view action added */
 	String VIEW_ACTION_ADDED = "Added"; //$NON-NLS-1$
+
+	/** design constant: view action deleted */
 	String VIEW_ACTION_DELETED = "Deleted"; //$NON-NLS-1$
 
+
 	/**
 	 * measure Function -- measure function type.
 	 */
-
+	/** design constant: choice aggregation function */
 	String CHOICE_AGGREGATION_FUNCTION = "aggregationFunction"; //$NON-NLS-1$
+
+	/** design constant: aggregation function sum */
 	String AGGREGATION_FUNCTION_SUM = "sum"; //$NON-NLS-1$
+
+	/** design constant: aggregation function count */
 	String AGGREGATION_FUNCTION_COUNT = "count"; //$NON-NLS-1$
+
+	/** design constant: aggregation function min */
 	String AGGREGATION_FUNCTION_MIN = "min"; //$NON-NLS-1$
+
+	/** design constant: aggregation function max */
 	String AGGREGATION_FUNCTION_MAX = "max"; //$NON-NLS-1$
+
+	/** design constant: aggregation function average */
 	String AGGREGATION_FUNCTION_AVERAGE = "average"; //$NON-NLS-1$
+
+	/** design constant: aggregation function weightedavg */
 	String AGGREGATION_FUNCTION_WEIGHTEDAVG = "weighted-avg"; //$NON-NLS-1$
+
+	/** design constant: aggregation function stddev */
 	String AGGREGATION_FUNCTION_STDDEV = "stddev"; //$NON-NLS-1$
+
+	/** design constant: aggregation function first */
 	String AGGREGATION_FUNCTION_FIRST = "first"; //$NON-NLS-1$
+
+	/** design constant: aggregation function last */
 	String AGGREGATION_FUNCTION_LAST = "last"; //$NON-NLS-1$
+
+	/** design constant: aggregation function mode */
 	String AGGREGATION_FUNCTION_MODE = "mode"; //$NON-NLS-1$
+
+	/** design constant: aggregation function movingave */
 	String AGGREGATION_FUNCTION_MOVINGAVE = "moving-ave"; //$NON-NLS-1$
+
+	/** design constant: aggregation function median */
 	String AGGREGATION_FUNCTION_MEDIAN = "median"; //$NON-NLS-1$
+
+	/** design constant: aggregation function variance */
 	String AGGREGATION_FUNCTION_VARIANCE = "variance"; //$NON-NLS-1$
+
+	/** design constant: aggregation function runningsum */
 	String AGGREGATION_FUNCTION_RUNNINGSUM = "running-sum"; //$NON-NLS-1$
+
+	/** design constant: aggregation function irr */
 	String AGGREGATION_FUNCTION_IRR = "irr"; //$NON-NLS-1$
+
+	/** design constant: aggregation function mirr */
 	String AGGREGATION_FUNCTION_MIRR = "mirr"; //$NON-NLS-1$
+
+	/** design constant: aggregation function npv */
 	String AGGREGATION_FUNCTION_NPV = "npv"; //$NON-NLS-1$
+
+	/** design constant: aggregation function runningnpv */
 	String AGGREGATION_FUNCTION_RUNNINGNPV = "running-npv"; //$NON-NLS-1$
+
+	/** design constant: aggregation function countdistinct */
 	String AGGREGATION_FUNCTION_COUNTDISTINCT = "count-distinct"; //$NON-NLS-1$
+
+	/** design constant: aggregation function runningcount */
 	String AGGREGATION_FUNCTION_RUNNINGCOUNT = "running-count"; //$NON-NLS-1$
+
+	/** design constant: aggregation function is top n */
 	String AGGREGATION_FUNCTION_IS_TOP_N = "is-top-n"; //$NON-NLS-1$
+
+	/** design constant: aggregation function is bottom n */
 	String AGGREGATION_FUNCTION_IS_BOTTOM_N = "is-bottom-n"; //$NON-NLS-1$
+
+	/** design constant: aggregation function is top n percent */
 	String AGGREGATION_FUNCTION_IS_TOP_N_PERCENT = "is-top-n-percent"; //$NON-NLS-1$
+
+	/** design constant: aggregation function is bottom n percent */
 	String AGGREGATION_FUNCTION_IS_BOTTOM_N_PERCENT = "is-bottom-n-percent"; //$NON-NLS-1$
+
+	/** design constant: aggregation function percent rank */
 	String AGGREGATION_FUNCTION_PERCENT_RANK = "percent-rank"; //$NON-NLS-1$
+
+	/** design constant: aggregation function percentile */
 	String AGGREGATION_FUNCTION_PERCENTILE = "percentile"; //$NON-NLS-1$
+
+	/** design constant: aggregation function top quartile */
 	String AGGREGATION_FUNCTION_TOP_QUARTILE = "quartile"; //$NON-NLS-1$
+
+	/** design constant: aggregation function percent sum */
 	String AGGREGATION_FUNCTION_PERCENT_SUM = "percent-sum"; //$NON-NLS-1$
+
+	/** design constant: aggregation function rank */
 	String AGGREGATION_FUNCTION_RANK = "rank"; //$NON-NLS-1$
 
+
 	/**
 	 * measure Function -- measure function type.
 	 */
-
+	/** design constant: choice measure function */
 	String CHOICE_MEASURE_FUNCTION = "measureFunction"; //$NON-NLS-1$
+
+	/** design constant: measure function sum */
 	String MEASURE_FUNCTION_SUM = AGGREGATION_FUNCTION_SUM;
+
+	/** design constant: measure function count */
 	String MEASURE_FUNCTION_COUNT = AGGREGATION_FUNCTION_COUNT;
+
+	/** design constant: measure function min */
 	String MEASURE_FUNCTION_MIN = AGGREGATION_FUNCTION_MIN;
+
+	/** design constant: measure function max */
 	String MEASURE_FUNCTION_MAX = AGGREGATION_FUNCTION_MAX;
+
+	/** design constant: measure function average */
 	String MEASURE_FUNCTION_AVERAGE = AGGREGATION_FUNCTION_AVERAGE;
+
+	/** design constant: measure function weightedavg */
 	String MEASURE_FUNCTION_WEIGHTEDAVG = AGGREGATION_FUNCTION_WEIGHTEDAVG;
+
+	/** design constant: measure function stddev */
 	String MEASURE_FUNCTION_STDDEV = AGGREGATION_FUNCTION_STDDEV;
+
+	/** design constant: measure function first */
 	String MEASURE_FUNCTION_FIRST = AGGREGATION_FUNCTION_FIRST;
+
+	/** design constant: measure function last */
 	String MEASURE_FUNCTION_LAST = AGGREGATION_FUNCTION_LAST;
+
+	/** design constant: measure function mode */
 	String MEASURE_FUNCTION_MODE = AGGREGATION_FUNCTION_MODE;
+
+	/** design constant: measure function movingave */
 	String MEASURE_FUNCTION_MOVINGAVE = AGGREGATION_FUNCTION_MOVINGAVE;
+
+	/** design constant: measure function median */
 	String MEASURE_FUNCTION_MEDIAN = AGGREGATION_FUNCTION_MOVINGAVE;
+
+	/** design constant: measure function variance */
 	String MEASURE_FUNCTION_VARIANCE = AGGREGATION_FUNCTION_VARIANCE;
+
+	/** design constant: measure function runningsum */
 	String MEASURE_FUNCTION_RUNNINGSUM = AGGREGATION_FUNCTION_RUNNINGSUM;
+
+	/** design constant: measure function irr */
 	String MEASURE_FUNCTION_IRR = AGGREGATION_FUNCTION_IRR;
+
+	/** design constant: measure function mirr */
 	String MEASURE_FUNCTION_MIRR = AGGREGATION_FUNCTION_IRR;
+
+	/** design constant: measure function npv */
 	String MEASURE_FUNCTION_NPV = AGGREGATION_FUNCTION_NPV;
+
+	/** design constant: measure function runningnpv */
 	String MEASURE_FUNCTION_RUNNINGNPV = AGGREGATION_FUNCTION_RUNNINGNPV;
+
+	/** design constant: measure function countdistinct */
 	String MEASURE_FUNCTION_COUNTDISTINCT = AGGREGATION_FUNCTION_COUNTDISTINCT;
+
+	/** design constant: measure function runningcount */
 	String MEASURE_FUNCTION_RUNNINGCOUNT = AGGREGATION_FUNCTION_RUNNINGCOUNT;
+
 
 	/**
 	 * Level type constants.
 	 */
+	/** design constant: choice level type */
 	String CHOICE_LEVEL_TYPE = "levelType"; //$NON-NLS-1$
+
+	/** design constant: level type dynamic */
 	String LEVEL_TYPE_DYNAMIC = "dynamic"; //$NON-NLS-1$
+
+	/** design constant: level type mirrored */
 	String LEVEL_TYPE_MIRRORED = "mirrored"; //$NON-NLS-1$
+
 
 	/**
 	 * measure Function -- measure function type.
 	 */
-
+	/** design constant: choice access permission */
 	String CHOICE_ACCESS_PERMISSION = "accessPermission"; //$NON-NLS-1$
+
+	/** design constant: access permission allow */
 	String ACCESS_PERMISSION_ALLOW = "allow"; //$NON-NLS-1$
+
+	/** design constant: access permission disallow */
 	String ACCESS_PERMISSION_DISALLOW = "disallow"; //$NON-NLS-1$
+
 
 	/**
 	 * Parameter sort values -- can be value or display text.
 	 */
-
+	/** design constant: choice param sort values */
 	String CHOICE_PARAM_SORT_VALUES = "paramSortValues"; //$NON-NLS-1$
+
+	/** design constant: param sort values value */
 	String PARAM_SORT_VALUES_VALUE = "value"; //$NON-NLS-1$
+
+	/** design constant: param sort values label */
 	String PARAM_SORT_VALUES_LABEL = "label"; //$NON-NLS-1$
+
 
 	/**
 	 * Report layout preference -- layout type for report design.
 	 */
+	/** design constant: choice report layout preference */
 	String CHOICE_REPORT_LAYOUT_PREFERENCE = "reportLayoutPreference"; //$NON-NLS-1$
+
+	/** design constant: report layout preference fixed layout */
 	String REPORT_LAYOUT_PREFERENCE_FIXED_LAYOUT = "fixed layout"; //$NON-NLS-1$
+
+	/** design constant: report layout preference auto layout */
 	String REPORT_LAYOUT_PREFERENCE_AUTO_LAYOUT = "auto layout"; //$NON-NLS-1$
+
 
 	/**
 	 * Date time level type -- type for date-time cube level.
 	 */
+	/** design constant: choice date time level type */
 	String CHOICE_DATE_TIME_LEVEL_TYPE = "dateTimeLevelType"; //$NON-NLS-1$
+
+	/** design constant: date time level type year */
 	String DATE_TIME_LEVEL_TYPE_YEAR = "year"; //$NON-NLS-1$
+
+	/** design constant: date time level type month */
 	String DATE_TIME_LEVEL_TYPE_MONTH = "month"; //$NON-NLS-1$
+
+	/** design constant: date time level type quarter */
 	String DATE_TIME_LEVEL_TYPE_QUARTER = "quarter"; //$NON-NLS-1$
+
+	/** design constant: date time level type week of year */
 	String DATE_TIME_LEVEL_TYPE_WEEK_OF_YEAR = "week-of-year"; //$NON-NLS-1$
+
+	/** design constant: date time level type week of quarter */
 	String DATE_TIME_LEVEL_TYPE_WEEK_OF_QUARTER = "week-of-quarter"; //$NON-NLS-1$
+
+	/** design constant: date time level type week of month */
 	String DATE_TIME_LEVEL_TYPE_WEEK_OF_MONTH = "week-of-month"; //$NON-NLS-1$
+
+	/** design constant: date time level type day of year */
 	String DATE_TIME_LEVEL_TYPE_DAY_OF_YEAR = "day-of-year"; //$NON-NLS-1$
+
+	/** design constant: date time level type day of quarter */
 	String DATE_TIME_LEVEL_TYPE_DAY_OF_QUARTER = "day-of-quarter"; //$NON-NLS-1$
+
+	/** design constant: date time level type day of month */
 	String DATE_TIME_LEVEL_TYPE_DAY_OF_MONTH = "day-of-month"; //$NON-NLS-1$
+
+	/** design constant: date time level type day of week */
 	String DATE_TIME_LEVEL_TYPE_DAY_OF_WEEK = "day-of-week"; //$NON-NLS-1$
+
+	/** design constant: date time level type hour */
 	String DATE_TIME_LEVEL_TYPE_HOUR = "hour"; //$NON-NLS-1$
+
+	/** design constant: date time level type minute */
 	String DATE_TIME_LEVEL_TYPE_MINUTE = "minute"; //$NON-NLS-1$
+
+	/** design constant: date time level type second */
 	String DATE_TIME_LEVEL_TYPE_SECOND = "second"; //$NON-NLS-1$
+
+
 	/**
 	 * @deprecated This is replaced by DATE_TIME_LEVEL_TYPE_WEEK_OF_YEAR and
 	 *             DATE_TIME_LEVEL_TYPE_WEEK_OF_MONTH, and not used anymore.
 	 */
 	@Deprecated
+	/** design constant: date time level type week */
 	String DATE_TIME_LEVEL_TYPE_WEEK = "week"; //$NON-NLS-1$
+
+
 	/**
 	 * @deprecated This is replaced by DATE_TIME_LEVEL_TYPE_DAY_OF_YEAR,
 	 *             DATE_TIME_LEVEL_TYPE_DAY_OF_MONTH and
 	 *             DATE_TIME_LEVEL_TYPE_DAY_OF_WEEK, and not used anymore.
 	 */
 	@Deprecated
+	/** design constant: date time level type day */
 	String DATE_TIME_LEVEL_TYPE_DAY = "day"; //$NON-NLS-1$
+
 
 	/**
 	 * Scalar parameter type.
 	 */
+	/** design constant: choice scalar param type */
 	String CHOICE_SCALAR_PARAM_TYPE = "scalarParamType"; //$NON-NLS-1$
+
+	/** design constant: scalar param type simple */
 	String SCALAR_PARAM_TYPE_SIMPLE = "simple"; //$NON-NLS-1$
+
+	/** design constant: scalar param type multi value */
 	String SCALAR_PARAM_TYPE_MULTI_VALUE = "multi-value"; //$NON-NLS-1$
+
+	/** design constant: scalar param type ad hoc */
 	String SCALAR_PARAM_TYPE_AD_HOC = "ad-hoc"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for direction and orientation
 	 */
+	/** design constant: choice bidi direction */
 	String CHOICE_BIDI_DIRECTION = "bidiDirection"; //$NON-NLS-1$
+
+	/** design constant: bidi direction rtl */
 	String BIDI_DIRECTION_RTL = "rtl"; //$NON-NLS-1$
+
+	/** design constant: bidi direction ltr */
 	String BIDI_DIRECTION_LTR = "ltr"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for scope type.
 	 */
+	/** design constant: choice scope type */
 	String CHOICE_SCOPE_TYPE = "scopeType"; //$NON-NLS-1$
+
+	/** design constant: scope type row */
 	String SCOPE_TYPE_ROW = "row"; //$NON-NLS-1$
+
+	/** design constant: scope type col */
 	String SCOPE_TYPE_COL = "col"; //$NON-NLS-1$
+
+	/** design constant: scope type rowgroup */
 	String SCOPE_TYPE_ROWGROUP = "rowgroup"; //$NON-NLS-1$
+
+	/** design constant: scope type colgroup */
 	String SCOPE_TYPE_COLGROUP = "colgroup"; //$NON-NLS-1$
 
+
 	// dynamic filter
+	/** design constant: choice dynamic filter */
 	String CHOICE_DYNAMIC_FILTER = "dynamicFilterChoice"; //$NON-NLS-1$
+
+	/** design constant: dynamic filter simple */
 	String DYNAMIC_FILTER_SIMPLE = "simple"; //$NON-NLS-1$
+
+	/** design constant: dynamic filter advanced */
 	String DYNAMIC_FILTER_ADVANCED = "advanced"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for workMode.
-	 *
 	 */
+	/** design constant: choice variable type */
 	String CHOICE_VARIABLE_TYPE = "variableType"; //$NON-NLS-1$
+
+	/** design constant: variable type report */
 	String VARIABLE_TYPE_REPORT = "report"; //$NON-NLS-1$
+
+	/** design constant: variable type page */
 	String VARIABLE_TYPE_PAGE = "page"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for nullValueOrderingType.
 	 */
+	/** design constant: choice null value ordering type */
 	String CHOICE_NULL_VALUE_ORDERING_TYPE = "nullValueOrderingType"; //$NON-NLS-1$
+
+	/** design constant: null value ordering type unknown */
 	String NULL_VALUE_ORDERING_TYPE_UNKNOWN = "unknown"; //$NON-NLS-1$
+
+	/** design constant: null value ordering type nullisfirst */
 	String NULL_VALUE_ORDERING_TYPE_NULLISFIRST = "nullIsFirst"; //$NON-NLS-1$
+
+	/** design constant: null value ordering type nullislast */
 	String NULL_VALUE_ORDERING_TYPE_NULLISLAST = "nullIsLast"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for dataVersion.
 	 */
+	/** design constant: choice data version */
 	String CHOICE_DATA_VERSION = "dataVersion"; //$NON-NLS-1$
+
+	/** design constant: data version transient */
 	String DATA_VERSION_TRANSIENT = "transient"; //$NON-NLS-1$
+
+	/** design constant: data version latest */
 	String DATA_VERSION_LATEST = "latest"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for dataSelector type.
 	 */
+	/** design constant: choice data selector type */
 	String CHOICE_DATA_SELECTOR_TYPE = "selectorType"; //$NON-NLS-1$
+
+	/** design constant: data selector type list */
 	String DATA_SELECTOR_TYPE_LIST = "list"; //$NON-NLS-1$
+
+	/** design constant: data selector type dropdown */
 	String DATA_SELECTOR_TYPE_DROPDOWN = "dropdown";//$NON-NLS-1$
+
+	/** design constant: data selector type slider */
 	String DATA_SELECTOR_TYPE_SLIDER = "slider"; //$NON-NLS-1$
+
+	/** design constant: data selector type check box */
 	String DATA_SELECTOR_TYPE_CHECK_BOX = "checkBox";//$NON-NLS-1$
+
+	/** design constant: data selector type radio button */
 	String DATA_SELECTOR_TYPE_RADIO_BUTTON = "radioButton";//$NON-NLS-1$
+
+	/** design constant: data selector type text box */
 	String DATA_SELECTOR_TYPE_TEXT_BOX = "textBox";//$NON-NLS-1$
+
+	/** design constant: data selector type calendar */
 	String DATA_SELECTOR_TYPE_CALENDAR = "calendar";//$NON-NLS-1$
+
+	/** design constant: data selector type current selections */
 	String DATA_SELECTOR_TYPE_CURRENT_SELECTIONS = "currentSelections";//$NON-NLS-1$
+
+	/** design constant: data selector type list group */
 	String DATA_SELECTOR_TYPE_LIST_GROUP = "listGroup";//$NON-NLS-1$
+
+	/** design constant: data selector type checkboxtree group */
 	String DATA_SELECTOR_TYPE_CHECKBOXTREE_GROUP = "checkboxtreeGroup";//$NON-NLS-1$
+
+	/** design constant: data selector type dropdown group */
 	String DATA_SELECTOR_TYPE_DROPDOWN_GROUP = "dropdownGroup";//$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for thumb type.
 	 */
+	/** design constant: choice thumb type */
 	String CHOICE_THUMB_TYPE = "thumbType"; //$NON-NLS-1$
+
+	/** design constant: thumb type single */
 	String THUMB_TYPE_SINGLE = "single"; //$NON-NLS-1$
+
+	/** design constant: thumb type dual */
 	String THUMB_TYPE_DUAL = "dual";//$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for access type.
 	 */
+	/** design constant: choice access type */
 	String CHOICE_ACCESS_TYPE = "accessType"; //$NON-NLS-1$
+
+	/** design constant: access type transient */
 	String ACCESS_TYPE_TRANSIENT = "transient"; //$NON-NLS-1$
+
+	/** design constant: access type specific version */
 	String ACCESS_TYPE_SPECIFIC_VERSION = "specificVersion"; //$NON-NLS-1$
+
+	/** design constant: access type latest */
 	String ACCESS_TYPE_LATEST = "latest"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for overflow.
 	 */
+	/** design constant: choice overflow */
 	String CHOICE_OVERFLOW = "overflow"; //$NON-NLS-1$
+
+	/** design constant: overflow visible */
 	String OVERFLOW_VISIBLE = "visible"; //$NON-NLS-1$
+
+	/** design constant: overflow hidden */
 	String OVERFLOW_HIDDEN = "hidden"; //$NON-NLS-1$
+
+	/** design constant: overflow scroll */
 	String OVERFLOW_SCROLL = "scroll"; //$NON-NLS-1$
+
+	/** design constant: overflow auto */
 	String OVERFLOW_AUTO = "auto"; //$NON-NLS-1$
+
 
 	/**
 	 * @deprecated Use <code>CHOICE_GADGET_CONTENT_TYPE</code> instead.
 	 */
 	@Deprecated
+	/** design constant: choice html gadget content type */
 	String CHOICE_HTML_GADGET_CONTENT_TYPE = "HTMLGadgetContentType"; //$NON-NLS-1$
+
+
 	/**
 	 * @deprecated Use <code>GADGET_CONTENT_TYPE_HTML</code> instead.
 	 */
 	@Deprecated
+	/** design constant: html gadget content type html */
 	String HTML_GADGET_CONTENT_TYPE_HTML = "html"; //$NON-NLS-1$
+
+
 	/**
 	 * @deprecated Use <code>GADGET_CONTENT_TYPE_URL</code> instead.
 	 */
 	@Deprecated
+	/** design constant: html gadget content type url */
 	String HTML_GADGET_CONTENT_TYPE_URL = "url"; //$NON-NLS-1$
 
+	/** design constant: choice gadget content type */
 	String CHOICE_GADGET_CONTENT_TYPE = "GadgetContentType"; //$NON-NLS-1$
+
+	/** design constant: gadget content type html */
 	String GADGET_CONTENT_TYPE_HTML = "html"; //$NON-NLS-1$
+
+	/** design constant: gadget content type url */
 	String GADGET_CONTENT_TYPE_URL = "url"; //$NON-NLS-1$
+
+	/** design constant: gadget content type video */
 	String GADGET_CONTENT_TYPE_VIDEO = "video"; //$NON-NLS-1$
+
+	/** design constant: gadget content type videourl */
 	String GADGET_CONTENT_TYPE_VIDEOURL = "videourl"; //$NON-NLS-1$
+
+	/** design constant: gadget content type text */
 	String GADGET_CONTENT_TYPE_TEXT = "text"; //$NON-NLS-1$
+
+	/** design constant: gadget content type image */
 	String GADGET_CONTENT_TYPE_IMAGE = "image"; //$NON-NLS-1$
 
+	/** design constant: choice window status */
 	String CHOICE_WINDOW_STATUS = "windowStatus"; //$NON-NLS-1$
+
+	/** design constant: window status normal */
 	String WINDOW_STATUS_NORMAL = "normal"; //$NON-NLS-1$
+
+	/** design constant: window status maximized */
 	String WINDOW_STATUS_MAXIMIZED = "maximized"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for reportItemThemeType.
 	 */
+	/** design constant: choice report item theme type */
 	String CHOICE_REPORT_ITEM_THEME_TYPE = "reportItemThemeType"; //$NON-NLS-1$
+
+	/** design constant: report item theme type table */
 	String REPORT_ITEM_THEME_TYPE_TABLE = "Table"; //$NON-NLS-1$
+
+	/** design constant: report item theme type list */
 	String REPORT_ITEM_THEME_TYPE_LIST = "List"; //$NON-NLS-1$
+
+	/** design constant: report item theme type grid */
 	String REPORT_ITEM_THEME_TYPE_GRID = "Grid"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for nullsOrdering.
 	 */
+	/** design constant: choice nulls ordering */
 	String CHOICE_NULLS_ORDERING = "nullsOrdering"; //$NON-NLS-1$
+
+	/** design constant: nulls ordering nulls lowest */
 	String NULLS_ORDERING_NULLS_LOWEST = "nulls lowest"; //$NON-NLS-1$
+
+	/** design constant: nulls ordering nulls highest */
 	String NULLS_ORDERING_NULLS_HIGHEST = "nulls highest"; //$NON-NLS-1$
+
+	/** design constant: nulls ordering exclude nulls */
 	String NULLS_ORDERING_EXCLUDE_NULLS = "exclude nulls"; //$NON-NLS-1$
 
+	/** design constant: choice filter condition type */
 	String CHOICE_FILTER_CONDITION_TYPE = "filterConditionType"; //$NON-NLS-1$
+
+	/** design constant: filter condition type slicer */
 	String FILTER_CONDITION_TYPE_SLICER = "slicer"; //$NON-NLS-1$
+
+	/** design constant: filter condition type simple */
 	String FILTER_CONDITION_TYPE_SIMPLE = "simple"; //$NON-NLS-1$
 
+	/** design constant: choice flyout position */
 	String CHOICE_FLYOUT_POSITION = "flyoutPosition"; //$NON-NLS-1$
+
+	/** design constant: flyout position left */
 	String FLYOUT_POSITION_LEFT = "left"; //$NON-NLS-1$
+
+	/** design constant: flyout position right */
 	String FLYOUT_POSITION_RIGHT = "right"; //$NON-NLS-1$
+
 
 	/**
 	 * Choice constants for reference date type.
 	 */
+	/** design constant: choice reference date type */
 	String CHOICE_REFERENCE_DATE_TYPE = "referenceDateType"; //$NON-NLS-1$
+
+	/** design constant: reference date type today */
 	String REFERENCE_DATE_TYPE_TODAY = "today"; //$NON-NLS-1$
+
+	/** design constant: reference date type fixed date */
 	String REFERENCE_DATE_TYPE_FIXED_DATE = "fixedDate"; //$NON-NLS-1$
+
+	/** design constant: reference date type ending date in dimension */
 	String REFERENCE_DATE_TYPE_ENDING_DATE_IN_DIMENSION = "endingDateInDimension"; //$NON-NLS-1$
+
 }

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/simpleapi/IStyle.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/simpleapi/IStyle.java
@@ -54,7 +54,6 @@ public interface IStyle {
 	 *
 	 * @return the address of the background image as a string
 	 */
-
 	String getBackgroundImage();
 
 	/**
@@ -63,8 +62,23 @@ public interface IStyle {
 	 * @param value the new background image address
 	 * @throws SemanticException if the property is locked
 	 */
-
 	void setBackgroundImage(String value) throws SemanticException;
+
+	/**
+	 * Returns the source type of the background image.
+	 *
+	 * @return the source type of the background image as a string
+	 */
+	String getBackgroundImageType();
+
+	/**
+	 * Sets the source type of the background image. The value is a "url" or
+	 * "embed".
+	 *
+	 * @param value the new background image type
+	 * @throws SemanticException if the property is locked
+	 */
+	void setBackgroundImageType(String value) throws SemanticException;
 
 	/**
 	 * Returns the pattern of the repeat for a background image. The return value is
@@ -1418,7 +1432,7 @@ public interface IStyle {
 	/**
 	 * Sets the value of height property.
 	 *
-	 * @param value the new height value
+	 * @param height the new height value
 	 * @throws SemanticException
 	 */
 	void setHeight(String height) throws SemanticException;
@@ -1433,7 +1447,7 @@ public interface IStyle {
 	/**
 	 * Sets the value of width property.
 	 *
-	 * @param value the new width value
+	 * @param width the new width value
 	 * @throws SemanticException
 	 */
 	void setWidth(String width) throws SemanticException;

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/interfaces/IStyleModel.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/interfaces/IStyleModel.java
@@ -15,83 +15,292 @@
 package org.eclipse.birt.report.model.elements.interfaces;
 
 /**
- * The interface for style element to store the constants.
+ * The interface for style element to store the constants. The constants
+ * represents the ROM property names.
  */
 public interface IStyleModel {
 
 	// Property names: 58
 
+	/**
+	 * Property name: background attachment
+	 */
 	String BACKGROUND_ATTACHMENT_PROP = "backgroundAttachment"; //$NON-NLS-1$
+	/**
+	 * Property name: background color
+	 */
 	String BACKGROUND_COLOR_PROP = "backgroundColor"; //$NON-NLS-1$
+	/**
+	 * Property name: background image
+	 */
 	String BACKGROUND_IMAGE_PROP = "backgroundImage"; //$NON-NLS-1$
+	/**
+	 * Property name: background image source type
+	 */
 	String BACKGROUND_IMAGE_TYPE_PROP = "backgroundImageType"; //$NON-NLS-1$
+	/**
+	 * Property name: background position X
+	 */
 	String BACKGROUND_POSITION_X_PROP = "backgroundPositionX"; //$NON-NLS-1$
+	/**
+	 * Property name: background position Y
+	 */
 	String BACKGROUND_POSITION_Y_PROP = "backgroundPositionY"; //$NON-NLS-1$
+	/**
+	 * Property name: background repeat
+	 */
 	String BACKGROUND_REPEAT_PROP = "backgroundRepeat"; //$NON-NLS-1$
+	/**
+	 * Property name: background size width
+	 */
 	String BACKGROUND_SIZE_WIDTH = "backgroundSizeWidth"; //$NON-NLS-1$
+	/**
+	 * Property name: background size height
+	 */
 	String BACKGROUND_SIZE_HEIGHT = "backgroundSizeHeight"; //$NON-NLS-1$
+	/**
+	 * Property name: border bottom color
+	 */
 	String BORDER_BOTTOM_COLOR_PROP = "borderBottomColor"; //$NON-NLS-1$
+	/**
+	 * Property name: border bottom style
+	 */
 	String BORDER_BOTTOM_STYLE_PROP = "borderBottomStyle"; //$NON-NLS-1$
+	/**
+	 * Property name: border bottom width
+	 */
 	String BORDER_BOTTOM_WIDTH_PROP = "borderBottomWidth"; //$NON-NLS-1$
+	/**
+	 * Property name: border left color
+	 */
 	String BORDER_LEFT_COLOR_PROP = "borderLeftColor"; //$NON-NLS-1$
+	/**
+	 * Property name: border left style
+	 */
 	String BORDER_LEFT_STYLE_PROP = "borderLeftStyle"; //$NON-NLS-1$
+	/**
+	 * Property name: border left width
+	 */
 	String BORDER_LEFT_WIDTH_PROP = "borderLeftWidth"; //$NON-NLS-1$
+	/**
+	 * Property name: border right color
+	 */
 	String BORDER_RIGHT_COLOR_PROP = "borderRightColor"; //$NON-NLS-1$
+	/**
+	 * Property name: border right style
+	 */
 	String BORDER_RIGHT_STYLE_PROP = "borderRightStyle"; //$NON-NLS-1$
+	/**
+	 * Property name: border right width
+	 */
 	String BORDER_RIGHT_WIDTH_PROP = "borderRightWidth"; //$NON-NLS-1$
+	/**
+	 * Property name: border top color
+	 */
 	String BORDER_TOP_COLOR_PROP = "borderTopColor"; //$NON-NLS-1$
+	/**
+	 * Property name: border top style
+	 */
 	String BORDER_TOP_STYLE_PROP = "borderTopStyle"; //$NON-NLS-1$
+	/**
+	 * Property name: border top width
+	 */
 	String BORDER_TOP_WIDTH_PROP = "borderTopWidth"; //$NON-NLS-1$
+
+	/**
+	 * Property name: margin bottom
+	 */
 	String MARGIN_BOTTOM_PROP = "marginBottom"; //$NON-NLS-1$
+	/**
+	 * Property name: margin left
+	 */
 	String MARGIN_LEFT_PROP = "marginLeft"; //$NON-NLS-1$
+	/**
+	 * Property name: margin right
+	 */
 	String MARGIN_RIGHT_PROP = "marginRight"; //$NON-NLS-1$
+	/**
+	 * Property name: margin top
+	 */
 	String MARGIN_TOP_PROP = "marginTop"; //$NON-NLS-1$
+
+	/**
+	 * Property name: padding top
+	 */
 	String PADDING_TOP_PROP = "paddingTop"; //$NON-NLS-1$
+	/**
+	 * Property name: padding left
+	 */
 	String PADDING_LEFT_PROP = "paddingLeft"; //$NON-NLS-1$
+	/**
+	 * Property name: padding bottom
+	 */
 	String PADDING_BOTTOM_PROP = "paddingBottom"; //$NON-NLS-1$
+	/**
+	 * Property name: padding right
+	 */
 	String PADDING_RIGHT_PROP = "paddingRight"; //$NON-NLS-1$
+
+	/**
+	 * Property name: can shrink
+	 */
 	String CAN_SHRINK_PROP = "canShrink"; //$NON-NLS-1$
+	/**
+	 * Property name: color
+	 */
 	String COLOR_PROP = "color"; //$NON-NLS-1$
+
+	/**
+	 * Property name: format date time
+	 */
 	String DATE_TIME_FORMAT_PROP = "dateTimeFormat"; //$NON-NLS-1$
+	/**
+	 * Property name: format date
+	 */
 	String DATE_FORMAT_PROP = "dateFormat"; //$NON-NLS-1$
+	/**
+	 * Property name: format time
+	 */
 	String TIME_FORMAT_PROP = "timeFormat"; //$NON-NLS-1$
+
+	/**
+	 * Property name: font family
+	 */
 	String FONT_FAMILY_PROP = "fontFamily"; //$NON-NLS-1$
+	/**
+	 * Property name: font size
+	 */
 	String FONT_SIZE_PROP = "fontSize"; //$NON-NLS-1$
+	/**
+	 * Property name: font style
+	 */
 	String FONT_STYLE_PROP = "fontStyle"; //$NON-NLS-1$
+	/**
+	 * Property name: font weight
+	 */
 	String FONT_WEIGHT_PROP = "fontWeight"; //$NON-NLS-1$
+	/**
+	 * Property name: font variant
+	 */
 	String FONT_VARIANT_PROP = "fontVariant"; //$NON-NLS-1$
+
+	/**
+	 * Property name: text underline
+	 */
 	String TEXT_UNDERLINE_PROP = "textUnderline"; //$NON-NLS-1$
+	/**
+	 * Property name: text overline
+	 */
 	String TEXT_OVERLINE_PROP = "textOverline"; //$NON-NLS-1$
+	/**
+	 * Property name: text line through
+	 */
 	String TEXT_LINE_THROUGH_PROP = "textLineThrough"; //$NON-NLS-1$
 	// public static final String HIGHLIGHT_TEST_EXPR_PROP =
 	// "highlightTestExpr"; //$NON-NLS-1$
+
+	/**
+	 * Property name: highlight rules
+	 */
 	String HIGHLIGHT_RULES_PROP = "highlightRules"; //$NON-NLS-1$
+	/**
+	 * Property name: map rules
+	 */
 	String MAP_RULES_PROP = "mapRules"; //$NON-NLS-1$
+	/**
+	 * Property name: number format
+	 */
 	String NUMBER_FORMAT_PROP = "numberFormat"; //$NON-NLS-1$
+	/**
+	 * Property name: number align
+	 */
 	String NUMBER_ALIGN_PROP = "numberAlign"; //$NON-NLS-1$
+	/**
+	 * Property name: display
+	 */
 	String DISPLAY_PROP = "display"; //$NON-NLS-1$
+	/**
+	 * Property name: master page
+	 */
 	String MASTER_PAGE_PROP = "masterPage"; //$NON-NLS-1$
+
+	/**
+	 * Property name: page break before
+	 */
 	String PAGE_BREAK_BEFORE_PROP = "pageBreakBefore"; //$NON-NLS-1$
+	/**
+	 * Property name: page break after
+	 */
 	String PAGE_BREAK_AFTER_PROP = "pageBreakAfter"; //$NON-NLS-1$
+	/**
+	 * Property name: page break inside
+	 */
 	String PAGE_BREAK_INSIDE_PROP = "pageBreakInside"; //$NON-NLS-1$
+
+	/**
+	 * Property name: show if blank
+	 */
 	String SHOW_IF_BLANK_PROP = "showIfBlank"; //$NON-NLS-1$
+	/**
+	 * Property name: string format
+	 */
 	String STRING_FORMAT_PROP = "stringFormat"; //$NON-NLS-1$
+	/**
+	 * Property name: text align
+	 */
 	String TEXT_ALIGN_PROP = "textAlign"; //$NON-NLS-1$
+	/**
+	 * Property name: text indent
+	 */
 	String TEXT_INDENT_PROP = "textIndent"; //$NON-NLS-1$
+	/**
+	 * Property name: letter spacing
+	 */
 	String LETTER_SPACING_PROP = "letterSpacing"; //$NON-NLS-1$
+	/**
+	 * Property name: line height
+	 */
 	String LINE_HEIGHT_PROP = "lineHeight"; //$NON-NLS-1$
+	/**
+	 * Property name: orphans
+	 */
 	String ORPHANS_PROP = "orphans"; //$NON-NLS-1$
+	/**
+	 * Property name: text transform
+	 */
 	String TEXT_TRANSFORM_PROP = "textTransform"; //$NON-NLS-1$
+	/**
+	 * Property name: vertical align
+	 */
 	String VERTICAL_ALIGN_PROP = "verticalAlign"; //$NON-NLS-1$
+	/**
+	 * Property name: white space
+	 */
 	String WHITE_SPACE_PROP = "whiteSpace"; //$NON-NLS-1$
+	/**
+	 * Property name: widows
+	 */
 	String WIDOWS_PROP = "widows"; //$NON-NLS-1$
+	/**
+	 * Property name: word spacing
+	 */
 	String WORD_SPACING_PROP = "wordSpacing"; //$NON-NLS-1$
-	/*
+
+	/**
 	 * Bidi text direction property
 	 */
 	String TEXT_DIRECTION_PROP = "bidiTextDirection"; //$NON-NLS-1$
+	/**
+	 * Property name: overfow
+	 */
 	String OVERFLOW_PROP = "overflow"; //$NON-NLS-1$
 
+	/**
+	 * Property name: height
+	 */
 	String HEIGHT_PROP = "height"; //$NON-NLS-1$
+	/**
+	 * Property name: width
+	 */
 	String WIDTH_PROP = "width"; //$NON-NLS-1$
 }

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/simpleapi/Style.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/simpleapi/Style.java
@@ -19,10 +19,21 @@ import org.eclipse.birt.report.model.api.StyleHandle;
 import org.eclipse.birt.report.model.api.activity.SemanticException;
 import org.eclipse.birt.report.model.api.simpleapi.IStyle;
 
+/**
+ * Definition of the model style
+ *
+ * @since 3.3
+ *
+ */
 public class Style implements IStyle {
 
 	private StyleHandle style;
 
+	/**
+	 * Constructor
+	 *
+	 * @param style
+	 */
 	public Style(StyleHandle style) {
 		this.style = style;
 	}
@@ -89,6 +100,40 @@ public class Style implements IStyle {
 		cmdStack.startNonUndoableTrans(null);
 		try {
 			style.setBackgroundImage(value);
+		} catch (SemanticException e) {
+			cmdStack.rollback();
+			throw e;
+		}
+
+		cmdStack.commit();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.birt.report.engine.script.element.IStyleDesign#
+	 * getBackgroundImageType()
+	 */
+
+	@Override
+	public String getBackgroundImageType() {
+		return style.getBackgroundImageType();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.birt.report.engine.script.element.IStyleDesign#
+	 * setBackgroundImageType(java.lang.String)
+	 */
+
+	@Override
+	public void setBackgroundImageType(String value) throws SemanticException {
+		ActivityStack cmdStack = style.getModule().getActivityStack();
+
+		cmdStack.startNonUndoableTrans(null);
+		try {
+			style.setBackgroundImageType(value);
 		} catch (SemanticException e) {
 			cmdStack.rollback();
 			throw e;

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/simpleapi/Style.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/simpleapi/Style.java
@@ -50,13 +50,11 @@ public class Style implements IStyle {
 		return style.getBackgroundAttachment();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/**
+	 * Set the attachment handling of the background
 	 *
-	 * @seeorg.eclipse.birt.report.engine.script.element.IStyleDesign#
-	 * setBackgroundAttachment(java.lang.String)
+	 * @param value
 	 */
-
 	@Override
 	public void setBackgroundAttachment(String value) throws SemanticException {
 		ActivityStack cmdStack = style.getModule().getActivityStack();
@@ -72,27 +70,21 @@ public class Style implements IStyle {
 		cmdStack.commit();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/**
+	 * Get the background image source
 	 *
-	 * @see
-	 * org.eclipse.birt.report.engine.script.element.IStyleDesign#getBackgroundImage
-	 * ()
+	 * @return Return the background image source
 	 */
-
 	@Override
 	public String getBackgroundImage() {
 		return style.getBackgroundImage();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/**
+	 * Set the background image source property
 	 *
-	 * @see
-	 * org.eclipse.birt.report.engine.script.element.IStyleDesign#setBackgroundImage
-	 * (java.lang.String)
+	 * @param value
 	 */
-
 	@Override
 	public void setBackgroundImage(String value) throws SemanticException {
 		ActivityStack cmdStack = style.getModule().getActivityStack();
@@ -108,25 +100,21 @@ public class Style implements IStyle {
 		cmdStack.commit();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/**
+	 * Get the background image type
 	 *
-	 * @see org.eclipse.birt.report.engine.script.element.IStyleDesign#
-	 * getBackgroundImageType()
+	 * @return Return the background image type
 	 */
-
 	@Override
 	public String getBackgroundImageType() {
 		return style.getBackgroundImageType();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/**
+	 * Set the background image type
 	 *
-	 * @see org.eclipse.birt.report.engine.script.element.IStyleDesign#
-	 * setBackgroundImageType(java.lang.String)
+	 * @param value
 	 */
-
 	@Override
 	public void setBackgroundImageType(String value) throws SemanticException {
 		ActivityStack cmdStack = style.getModule().getActivityStack();

--- a/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/script/internal/StyleInstance.java
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core/src/org/eclipse/birt/report/item/crosstab/core/script/internal/StyleInstance.java
@@ -28,6 +28,11 @@ public class StyleInstance implements IScriptStyle {
 
 	private IStyle style;
 
+	/**
+	 * Constructor
+	 *
+	 * @param style
+	 */
 	public StyleInstance(IStyle style) {
 		this.style = style;
 	}
@@ -260,6 +265,22 @@ public class StyleInstance implements IScriptStyle {
 	@Override
 	public void setBackgroundImage(String imageURI) {
 		style.setBackgroundImage(imageURI);
+	}
+
+	/**
+	 * Get the background image source type
+	 */
+	@Override
+	public String getBackgroundImageType() {
+		return style.getBackgroundImage();
+	}
+
+	/**
+	 * Set the background image source type
+	 */
+	@Override
+	public void setBackgroundImageType(String imageSourceType) {
+		style.setBackgroundImage(imageSourceType);
 	}
 
 	/**
@@ -900,6 +921,12 @@ public class StyleInstance implements IScriptStyle {
 		}
 	}
 
+	/**
+	 * Get the property
+	 *
+	 * @param index
+	 * @return Return the property
+	 */
 	public CSSValue getProperty(int index) {
 		return style.getProperty(index);
 	}
@@ -908,6 +935,7 @@ public class StyleInstance implements IScriptStyle {
 	 * Get the text direction. Valid return types are LTR and RTL.
 	 *
 	 * @author bidi_hcg
+	 * @return Return the text direction.
 	 */
 	public String getDirection() {
 		return style.getDirection();
@@ -917,6 +945,7 @@ public class StyleInstance implements IScriptStyle {
 	 * Set the text direction. Valid return types are LTR and RTL.
 	 *
 	 * @author bidi_hcg
+	 * @param dir
 	 */
 	public void setDirection(String dir) {
 		style.setDirection(dir);


### PR DESCRIPTION
 **1. Enhancement of background image handling** 

The change includes the enhancemet that BIRT can handle background images based on the 3 source types
- URL
- Data-URL
- Report embedded images

The new option is given for:
- MasterPage
- Grid
- Table
- Row
- Cell
- TextElements
- all elements wich use backgroundImage

The main changes are given on the "BackgroundImageInfo.java" and "BackgroundImageType.java".
Important is that I enhanced the constructors to but the necessary information to the background-image-object
to have all information to create the background image.

In addition to it I make the property "backgroundImageType" accessable which was original design
but not full implemented to use it at the background image side.

In addition to it I enhanced the designer to display the images.
On emitter side I enhanced the HTML-emitter and the PDF-emitter to show the images.

Test cases of the change - done with the all-in-one-launch:
main test 1: *MasterPages* with all 3 types of background image source
main test 2: *grid with grid-row-cell* background images with all 3 types of background image source
main test 3: different *text elements* with all 3 types of background image source
main test 4: "data table with JavaScript image setting" with all 3 types of background image source

Attached you will find my test reports: [images.zip](https://github.com/eclipse/birt/files/10429573/images.zip)


 **2. Fixing of warning / java documentation**
Many of these classes had lot of warnings based on missing java-doc e.g. the constant-classes
and also the interface-classes. I added the according comments.
I solved also a small part of the warnings based on constant-usage and the render-option-hints on the HTML-emitter.
