### PR TITLE
Using the new UserProperty "defaultDpi" we can now ovveride the size …

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
@@ -3221,10 +3221,15 @@ public class HTMLReportEmitter extends ContentEmitterAdapter {
 			String uriString = EmitterUtil.getBackgroundImageUrl(imageStyle, design,
 					this.report.getReportContext() == null ? null : this.report.getReportContext().getAppContext());
 
+			Integer dpi = null;
+			// As we are at the report level, "overriding" (as seen in e.g. CellArea.java)
+			// does not make sense here.
 			backgroundImage = new BackgroundImageInfo(uriString,
 					imageStyle.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl, module,
-					imageStyle.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
-
+					imageStyle.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE), dpi);
+			if (dpi != null) {
+				saveImageDpiOverride(backgroundImage.getImageData(), dpi);
+			}
 			if (backgroundImage.getSourceType().equalsIgnoreCase(CSSConstants.CSS_EMBED_VALUE)) {
 				uri = backgroundImage.getDataUrl();
 			}
@@ -3485,6 +3490,25 @@ public class HTMLReportEmitter extends ContentEmitterAdapter {
 			}
 		}
 	}
+
+	protected void saveImageDpiOverride(byte[] imageData, Integer dpi) {
+		if (dpi != null) {
+			saveImageDpiOverride(imageData, dpi, dpi);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	protected void saveImageDpiOverride(byte[] imageData, int dpiX, int dpiY) {
+		Map<String, Object> appContext = report.getReportContext().getAppContext();
+		Map<byte[], int[]> dpiOverrides = (Map<byte[], int[]>) appContext.get("dpiOverrides");
+		if (dpiOverrides == null) {
+			dpiOverrides = new HashMap<byte[], int[]>();
+			appContext.put("dpiOverrides", dpiOverrides);
+		}
+		dpiOverrides.put(imageData, new int[] { dpiX, dpiY });
+
+	}
+
 }
 
 class IDGenerator {

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
@@ -80,6 +80,8 @@ public class PDFPage extends AbstractPage {
 
 	protected PDFPageDevice pageDevice;
 
+	private Map<byte[], int[]> dpiOverrides;
+
 	/**
 	 * font size must greater than minimum font . if not,illegalArgumentException
 	 * will be thrown.
@@ -167,8 +169,14 @@ public class PDFPage extends AbstractPage {
 				int resolutionX = img.getDpiX();
 				int resolutionY = img.getDpiY();
 				if (0 == resolutionX || 0 == resolutionY) {
-					resolutionX = 96;
-					resolutionY = 96;
+					int[] dpiOverride = dpiOverrides.get(imageData);
+					if (dpiOverride == null) {
+						resolutionX = 96;
+						resolutionY = 96;
+					} else {
+						resolutionX = dpiOverride[0];
+						resolutionY = dpiOverride[1];
+					}
 				}
 				imageWidth = img.getPlainWidth() / resolutionX * 72;
 				imageHeight = img.getPlainHeight() / resolutionY * 72;
@@ -674,5 +682,13 @@ public class PDFPage extends AbstractPage {
 		transcoder.print(g2D, pg, 0);
 		g2D.dispose();
 		return template;
+	}
+
+	/**
+	 * @param dpiOverrides
+	 */
+	public void setDpiOverrides(Map<byte[], int[]> dpiOverrides) {
+		this.dpiOverrides = dpiOverrides;
+
 	}
 }

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFRender.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFRender.java
@@ -77,6 +77,13 @@ public class PDFRender extends PageDeviceRender {
 	protected void newPage(IContainerArea page) {
 		super.newPage(page);
 		currentPage = (PDFPage) pageGraphic;
+		Map appContext = context.getAppContext();
+		Map<byte[], int[]> dpiOverrides = (Map<byte[], int[]>) (appContext.get("dpiOverrides"));
+		if (dpiOverrides == null) {
+			dpiOverrides = new HashMap<byte[], int[]>();
+			appContext.put("dpiOverrides", dpiOverrides);
+		}
+		currentPage.setDpiOverrides(dpiOverrides);
 	}
 
 	@Override

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/EmitterUtil.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/EmitterUtil.java
@@ -156,7 +156,8 @@ public class EmitterUtil {
 
 				if (buffer != null) {
 					if (SvgFile.isSvg(content.getURI())) {
-						buffer = SvgFile.transSvgToArray(new ByteArrayInputStream(buffer));
+						Integer defaultDpi = 96; // FIXME This should be configurable
+						buffer = SvgFile.transSvgToArray(new ByteArrayInputStream(buffer), defaultDpi);
 					}
 					image = Image.getInstance(buffer);
 				}
@@ -166,7 +167,8 @@ public class EmitterUtil {
 				byte[] data = content.getData();
 				ByteArrayInputStream in = new ByteArrayInputStream(data);
 				if (SvgFile.isSvg(mimeType, uri, extension)) {
-					data = SvgFile.transSvgToArray(in);
+					Integer defaultDpi = 96; // FIXME This should be configurable
+					data = SvgFile.transSvgToArray(in, defaultDpi);
 				}
 				in.close();
 				image = Image.getInstance(data);
@@ -174,7 +176,8 @@ public class EmitterUtil {
 
 			case IImageContent.IMAGE_URL:
 				if (SvgFile.isSvg(uri)) {
-					image = Image.getInstance(SvgFile.transSvgToArray(uri));
+					Integer defaultDpi = 96; // FIXME This should be configurable
+					image = Image.getInstance(SvgFile.transSvgToArray(uri, defaultDpi));
 				} else {
 					image = Image.getInstance(new URL(content.getURI()));
 				}
@@ -261,7 +264,8 @@ public class EmitterUtil {
 		byte[] imageData = null;
 		if (SvgFile.isSvg(imageURI)) {
 			try {
-				imageData = SvgFile.transSvgToArray(imageURI);
+				Integer defaultDpi = 96; // FIXME This should be configurable
+				imageData = SvgFile.transSvgToArray(imageURI, defaultDpi);
 			} catch (Exception e) {
 				logger.log(Level.WARNING, e.getMessage());
 			}
@@ -324,6 +328,7 @@ public class EmitterUtil {
 	public static org.eclipse.birt.report.engine.layout.emitter.Image parseImage(IImageContent image, int imageSource,
 			String uri, String mimeType, String extension) throws IOException {
 		org.eclipse.birt.report.engine.layout.emitter.Image imageInfo = null;
+		Integer dpi = 96; // FIXME this should be configurable
 		byte[] data = null;
 		InputStream in = null;
 		try {
@@ -333,7 +338,7 @@ public class EmitterUtil {
 				if (uri != null) {
 					if (SvgFile.isSvg(uri)) {
 						try {
-							data = SvgFile.transSvgToArray(uri);
+							data = SvgFile.transSvgToArray(uri, dpi);
 						} catch (Exception e) {
 							logger.log(Level.WARNING, e.getMessage());
 						}
@@ -348,7 +353,7 @@ public class EmitterUtil {
 				if (SvgFile.isSvg(mimeType, uri, extension) && null != data) {
 					in = new ByteArrayInputStream(data);
 					try {
-						data = SvgFile.transSvgToArray(in);
+						data = SvgFile.transSvgToArray(in, dpi);
 					} catch (Exception e) {
 						logger.log(Level.WARNING, e.getMessage());
 					}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/ImageReader.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/emitter/ImageReader.java
@@ -216,7 +216,8 @@ public class ImageReader {
 			status = OBJECT_LOADED_SUCCESSFULLY;
 		} else if (objectType == TYPE_SVG_OBJECT) {
 			try {
-				buffer = SvgFile.transSvgToArray(in);
+				Integer defaultDpi = 96; // FIXME This should be configurable
+				buffer = SvgFile.transSvgToArray(in, defaultDpi);
 			} catch (Exception e) {
 				buffer = null;
 				status = UNSUPPORTED_OBJECTS;
@@ -240,8 +241,9 @@ public class ImageReader {
 			buffer = data;
 			status = OBJECT_LOADED_SUCCESSFULLY;
 		} else if (objectType == TYPE_SVG_OBJECT) {
+			Integer defaultDpi = 96; // FIXME This should be configurable
 			try (InputStream in = new ByteArrayInputStream(data)) {
-				buffer = SvgFile.transSvgToArray(in);
+				buffer = SvgFile.transSvgToArray(in, defaultDpi);
 			} catch (Exception e) {
 				buffer = null;
 				status = UNSUPPORTED_OBJECTS;

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/CellArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/CellArea.java
@@ -264,9 +264,12 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 			if (exeContext != null) {
 				rl = exeContext.getResourceLocator();
 			}
+
+			Integer dpi = getImageDpiOverride();
+
 			BackgroundImageInfo backgroundImage = new BackgroundImageInfo(getImageUrl(url),
 					style.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl, this.getCurrentModule(),
-					style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
+					style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE), dpi);
 			boxStyle.setBackgroundImage(backgroundImage);
 		}
 		localProperties = new LocalProperties();

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableArea.java
@@ -155,6 +155,7 @@ public class TableArea extends RepeatableArea {
 		return false;
 	}
 
+
 	@Override
 	protected void buildProperties(IContent content, LayoutContext context) {
 		IStyle style = content.getStyle();
@@ -174,9 +175,13 @@ public class TableArea extends RepeatableArea {
 				if (exeContext != null) {
 					rl = exeContext.getResourceLocator();
 				}
+				Integer dpi = getImageDpiOverride();
 				BackgroundImageInfo backgroundImage = new BackgroundImageInfo(getImageUrl(url),
 						style.getProperty(StyleConstants.STYLE_BACKGROUND_REPEAT), 0, 0, 0, 0, rl,
-						this.getCurrentModule(), style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE));
+						this.getCurrentModule(), style.getProperty(StyleConstants.STYLE_BACKGROUND_IMAGE_TYPE), dpi);
+				if (dpi != null) {
+					saveImageDpiOverride(backgroundImage.getImageData(), dpi);
+				}
 				boxStyle.setBackgroundImage(backgroundImage);
 			}
 			localProperties = new LocalProperties();

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/style/BackgroundImageInfo.java
@@ -54,6 +54,7 @@ public class BackgroundImageInfo extends AreaConstants {
 	protected String sourceType;
 	protected String mimeType;
 	protected String fileExtension;
+	protected Integer dpi = null;
 
 	private final static String DATA_PROTOCOL = "data:";
 
@@ -88,7 +89,7 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * @since 4.13
 	 */
 	public BackgroundImageInfo(String url, int repeatedMode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl, Module module, String sourceType) {
+			ResourceLocatorWrapper rl, Module module, String sourceType, Integer dpi) {
 		this.xOffset = xOffset;
 		this.yOffset = yOffset;
 		this.repeatedMode = repeatedMode;
@@ -102,6 +103,7 @@ public class BackgroundImageInfo extends AreaConstants {
 		} else {
 			this.sourceType = BGI_SRC_TYPE_DEFAULT;
 		}
+		this.dpi = dpi;
 		prepareImageByteArray();
 	}
 
@@ -125,6 +127,7 @@ public class BackgroundImageInfo extends AreaConstants {
 		} else {
 			this.sourceType = BGI_SRC_TYPE_DEFAULT;
 		}
+		this.dpi = bgi.dpi;
 	}
 
 	/**
@@ -140,9 +143,9 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * @param module
 	 */
 	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl, Module module) {
+			ResourceLocatorWrapper rl, Module module, Integer dpi) {
 		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, module,
-				BGI_SRC_TYPE_DEFAULT);
+				BGI_SRC_TYPE_DEFAULT, dpi);
 	}
 
 	/**
@@ -159,10 +162,11 @@ public class BackgroundImageInfo extends AreaConstants {
 	 * @param sourceType
 	 */
 	public BackgroundImageInfo(String url, CSSValue mode, int xOffset, int yOffset, int height, int width,
-			ResourceLocatorWrapper rl, Module module, CSSValue sourceType) {
+			ResourceLocatorWrapper rl, Module module, CSSValue sourceType, Integer dpi) {
 		this(url, mode != null ? repeatMap.get(mode) : REPEAT, xOffset, yOffset, height, width, rl, module,
 				sourceType != null ? bgiSourceTypeMap.get(sourceType)
-						: BGI_SRC_TYPE_URL);
+						: BGI_SRC_TYPE_URL,
+				dpi);
 	}
 
 	/**
@@ -320,7 +324,7 @@ public class BackgroundImageInfo extends AreaConstants {
 				this.image = Image.getInstance(this.imageData);
 			} catch (Exception e) {
 				try {
-					this.imageData = SvgFile.transSvgToArray(new ByteArrayInputStream(this.imageData));
+					this.imageData = SvgFile.transSvgToArray(new ByteArrayInputStream(this.imageData), dpi);
 					this.image = Image.getInstance(this.imageData);
 				} catch (Exception te) {
 					this.imageData = null;

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/util/SvgFile.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/util/SvgFile.java
@@ -45,20 +45,24 @@ public class SvgFile {
 		return isSvg;
 	}
 
-	public static byte[] transSvgToArray(String uri) throws Exception {
+	public static byte[] transSvgToArray(String uri, Integer imageDpi) throws Exception {
 		InputStream in = new URL(uri).openStream();
 		try (in) {
-			return transSvgToArray(in);
+			return transSvgToArray(in, imageDpi);
 		}
 	}
 
-	public static byte[] transSvgToArray(InputStream inputStream) throws Exception {
+	public static byte[] transSvgToArray(InputStream inputStream, Integer imageDpi) throws Exception {
 		PNGTranscoder transcoder = new PNGTranscoder();
 		// create the transcoder input
 		TranscoderInput input = new TranscoderInput(inputStream);
 		// create the transcoder output
 		ByteArrayOutputStream ostream = new ByteArrayOutputStream();
 		TranscoderOutput output = new TranscoderOutput(ostream);
+		if (imageDpi != null) {
+			float pixel_to_mm = 25.4f / imageDpi;
+			transcoder.addTranscodingHint(PNGTranscoder.KEY_PIXEL_UNIT_TO_MILLIMETER, pixel_to_mm);
+		}
 		transcoder.transcode(input, output);
 		// flush the stream
 		ostream.flush();


### PR DESCRIPTION
…of the rendered image, at least for the PDF emitter.

First change:
For background images (bitmap and SVG), the report's "imageDpi" setting is used instead of 96 dpi.
So e.g. with a setting of 300 thes background images are rendered smaller but sharper

Second change:
This can be overridden per item with an Integer UserProperty "imageDpi".

Note: I don't know if this is the way to go - it's just one way which allows me to workaround a regression in BIRT:

Earlier BIRT versions (4.2.1 and 4.3.0) "just worked" for *bitmap* images (I don't know why and how: Did they read the DPI metadata from the image or did they take background-image-height and -width into account?).

It would probably be better to use "background-image-height" and "background-image-width" properties for the size calculation.