### PR TITLE
Fix infinite loop in PDF generation with oversized avoid rows (#2319) 

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RowArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RowArea.java
@@ -415,6 +415,11 @@ public class RowArea extends ContainerArea {
 		}
 		updateRow();
 		needResolveBorder = true;
+		// If force is true but we couldn't split anything, return BEFORE_AVOID_WITH_NULL
+		// to signal that the row cannot be placed on the current page, preventing infinite loops
+		if (force) {
+			return SplitResult.BEFORE_AVOID_WITH_NULL;
+		}
 		return SplitResult.SUCCEED_WITH_NULL;
 	}
 


### PR DESCRIPTION
Return BEFORE_AVOID_WITH_NULL when RowArea._split() cannot split due to page-break-inside: avoid, preventing infinite retry loops.

Fixes #2319