### PR TITLE
Use version ranges in the target platform

### DIFF
--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="71">
+<target name="Generated from BIRT" sequenceNumber="72">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="aQute.libg" version="0.0.0"/>
@@ -18,14 +18,14 @@
       <unit id="com.github.weisj.jsvg" version="0.0.0"/>
       <unit id="com.sun.el.javax.el" version="0.0.0"/>
       <unit id="com.zaxxer.sparsebits" version="0.0.0"/>
-      <unit id="jakarta.activation-api" version="1.2.2"/>
-      <unit id="jakarta.activation-api" version="2.1.4"/>
+      <unit id="jakarta.activation-api" version="[1.0.0,2.0.0)"/>
+      <unit id="jakarta.activation-api" version="[2.0.0,3.0.0)"/>
       <unit id="jakarta.annotation-api" version="0.0.0"/>
       <unit id="jakarta.enterprise.cdi-api" version="0.0.0"/>
       <unit id="jakarta.inject.jakarta.inject-api" version="0.0.0"/>
       <unit id="jakarta.interceptor-api" version="0.0.0"/>
       <unit id="jakarta.transaction-api" version="0.0.0"/>
-      <unit id="jakarta.xml.bind-api" version="4.0.4"/>
+      <unit id="jakarta.xml.bind-api" version="[4.0.0,5.0.0)"/>
       <unit id="jakarta.xml.soap-api" version="0.0.0"/>
       <unit id="javax.servlet-api" version="0.0.0"/>
       <unit id="javax.xml.rpc-api" version="0.0.0"/>
@@ -135,8 +135,8 @@
       <unit id="org.eclipse.xsd.edit.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.xsd.feature.group" version="0.0.0"/>
       <unit id="org.mongodb.mongo-java-driver" version="0.0.0"/>
-      <unit id="org.mortbay.jasper.mortbay-apache-el" version="9.0.108"/>
-      <unit id="org.mortbay.jasper.mortbay-apache-jsp" version="9.0.108"/>
+      <unit id="org.mortbay.jasper.mortbay-apache-el" version="[9.0.0,10.0.0)"/>
+      <unit id="org.mortbay.jasper.mortbay-apache-jsp" version="[9.0.0,10.0.0)"/>
       <unit id="org.mozilla.rhino" version="0.0.0"/>
       <unit id="org.objectweb.asm.commons" version="0.0.0"/>
       <unit id="org.osgi.namespace.contract" version="0.0.0"/>


### PR DESCRIPTION
This approach makes the target platform more stable relative to Orbit updates, i.e., no need to regenerate the target platform when a newer version is made available in Orbit.