### PR TITLE
Save binaries after workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,6 @@ jobs:
           }
 
     # Upload each output as its own artifact (so they appear individually in the UI)
-    - name: Upload birt-charts
-      uses: actions/upload-artifact@v4
-      with:
-        name: birt-charts
-        if-no-files-found: error
-        compression-level: 0
-        path: build/birt-packages/birt-charts/target/birt-charts-*.zip
-
     - name: Upload birt-report-designer linux aarch64
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
* Saves the all-in-one binaries for a quick sanity check of a PR
* Makes sure we do not overflow the available space with old artifacts by removing old artifacts.