### PR TITLE
Add html pagination option to viewer export dialog

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/Messages.properties
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/Messages.properties
@@ -128,6 +128,7 @@ birt.viewer.dialog.export.pdf.fittoauto=Auto
 birt.viewer.dialog.export.pdf.fittoactual=Actual size
 birt.viewer.dialog.export.pdf.fittowidth=Fit to page width
 birt.viewer.dialog.export.pdf.fittowhole=Fit to whole page
+birt.viewer.dialog.export.usehtmlpagination=Preserve report pagination
 birt.viewer.dialog.export.spudsoft.excel.single.sheet=Use single sheet
 
 

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/ajax/ui/dialog/BirtExportReportDialog.js
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/ajax/ui/dialog/BirtExportReportDialog.js
@@ -133,6 +133,8 @@ BirtExportReportDialog.prototype = Object.extend( new AbstractBaseDialog( ),
 				action = action + "&" + Constants.PARAM_PAGERANGE + "=" + pageRange;
 			}			
 
+			action = action + "&__htmlPagination=" + $( 'useHtmlPaginationCheckbox' ).checked;
+
 			// If output format is pdf/ppt/postscript, set some options
 			if( this.__isExcelLayout( format ) )
 			{

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp
@@ -92,6 +92,12 @@
 	<TR>
 		<TD>&nbsp;&nbsp;<%=BirtResources.getHtmlMessage( "birt.viewer.dialog.page.range.description" )%></TD>
 	</TR>
+	<TR>
+		<TD>
+			<INPUT TYPE="checkbox" ID="useHtmlPaginationCheckbox" CHECKED/>
+			<label for="useHtmlPaginationCheckbox"><%=BirtResources.getHtmlMessage( "birt.viewer.dialog.export.usehtmlpagination" )%></label>
+		</TD>
+	</TR>
 	<TR HEIGHT="5px"><TD><HR/></TD></TR>
 	<TR>
 		<TD>


### PR DESCRIPTION
(See issue https://github.com/eclipse-birt/birt/issues/2379)

When exporting a report from the viewer to a different format using an emitter, it can sometimes be desirable to pass the individual pages (as defined by the report / HTML preview) to the emitter, or it can be preferable to pass the report contents as a single page to let the emitter make its own pagination decisions.

The current behavior is determined [here](https://github.com/eclipse-birt/birt/blob/f194fbb91d0a9c80795dc07543106ccf63fded9f/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/impl/RenderTask.java#L389). Briefly: if the emitter specifies `pagination="paper-size-pagination"` in its `plugin.xml`, then there is implemented logic to determine pagination; otherwise the decision is based on the `htmlPagination` render parameter.

If not specified as a URL parameter (e.g. `&__htmlPagination=false`), this parameter currently defaults to true for all emitters **except** the prototype Excel emitter (`format="xls"`), which has a hard-coded exception [here](https://github.com/eclipse-birt/birt/blob/f194fbb91d0a9c80795dc07543106ccf63fded9f/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/service/ReportEngineService.java#L1386).

This PR proposes to add `htmlPagination` as a configurable parameter to the viewer's export dialog. Additionally I would suggest to make the default `false` (unchecked).

<img width="566" height="382" alt="image" src="https://github.com/user-attachments/assets/b1f2feb2-4c0d-4700-9475-87844f0b9bec" />


## Effect



As an example, a report is used with a top-level table which happens to show 5 rows per page in the HTML preview:

<img width="651" height="341" alt="image" src="https://github.com/user-attachments/assets/5e25a353-b73a-4e95-8027-918aeb6a9d33" /> 

\
The following summarizes the effect of setting the `htmlPagination` property on each emitter.

<table border="1" cellspacing="0" cellpadding="6">
  <thead>
    <tr>
      <th>Emitter (Format)</th>
      <th>Pagination</th>
      <th>Effect</th>
    </tr>
  </thead>
  <tbody>
    <tr><td>postscript</td><td rowspan="5">paper-size</td><td rowspan="5">No effect for paper-size pagination.</td></tr>
    <tr><td>odp</td></tr>
    <tr><td>ppt</td></tr>
    <tr><td>pptx</td></tr>
    <tr><td>pdf</td></tr>
    <tr><td>odt</td><td rowspan="5">page-break</td><td rowspan="3">For document emitters, disabling HTML pagination allows the emitter to fill the available space, rather than breaking whenever there happens to be a break in the HTML preview. <br><br><details><summary>Examples</summary><br>Without HTML pagination:
<img width="808" height="588" alt="image" src="https://github.com/user-attachments/assets/24ee4ca2-24e0-4c61-8ef2-395acef662e1" />
With HTML Pagination, pages are either underfilled:
<img width="810" height="570" alt="image" src="https://github.com/user-attachments/assets/cb66eeb7-7090-4b25-b229-1f8459335cc4" />
or spill over, then awkwardly break, depending on the HTML page size:
<img width="1667" height="539" alt="image" src="https://github.com/user-attachments/assets/932e2512-43e3-4c3d-8359-69ab4c7b072e" />
</details></td></tr>
    <tr><td>doc</td></tr>
    <tr><td>docx</td></tr>
    <tr><td>xlsx</td><td rowspan="2">The Spudsoft spreadsheet emitters create a sheet for every page.<br><br>This may be desirable for certain types of reports, but in many use cases this will unnecessarily split tables over many sheets, making spreadsheet analysis impossible. I would argue that if a user wants to export a report to a spreadsheet, this is presumably not what they would expect.<br><br><details><summary>Examples</summary><br>Without HTML pagination, all rows are in one sheet:
<img width="799" height="370" alt="image" src="https://github.com/user-attachments/assets/d8638a5d-2437-4934-9550-e13bc7f6e251" />
With HTML Pagination, each of the 600 pages is in a new sheet with 5 rows each:
<img width="884" height="458" alt="image" src="https://github.com/user-attachments/assets/a4070906-ffc9-4de4-9100-4042127eba87" />
</details></td></tr>
    <tr><td>xls_spudsoft</td></tr>
    <tr><td>ods</td><td rowspan="2">none</td><td rowspan="2">The other spreadsheet emitter <em>do not properly support</em> HTML pagination  - they will output to a single sheet, but repeat column and table group headers as they appeared in the HTML preview, essentially concatenating pages vertically. This again makes any spreadsheet analysis difficult, because the extra header rows pollute the data.<br><br><details><summary>Examples</summary><br>Without HTML pagination:
<img width="627" height="499" alt="image" src="https://github.com/user-attachments/assets/bf22024c-8749-44db-9063-2bd147086790" />
With HTML Pagination, headers are repeated every 5 rows:
<img width="633" height="550" alt="image" src="https://github.com/user-attachments/assets/f3711fdf-cf01-43e3-9b63-85cc674d6a96" />
</details></td></tr>
    <tr><td>xls</td></tr>
  </tbody>
</table>